### PR TITLE
Add collections, entity kinds, graph navigation, and FTS triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ When memory is enabled, two sealed workflows are auto-injected: `memory:compile`
 | `memory_browse` | Find entities by name or kind |
 | `memory_inspect` | Full entity details with propositions and validity |
 | `memory_by_source` | All propositions linked to a source file |
+| `memory_related` | Entity graph navigation — co-occurring entities with connection strength |
 | `memory_search` | Full-text search across proposition content (FTS5) |
 | `memory_status` | Knowledge graph health: total, valid, stale counts |
 

--- a/specs/memory-dir-flag.md
+++ b/specs/memory-dir-flag.md
@@ -1,0 +1,102 @@
+# Spec: `--memory-dir` CLI flag
+
+## Problem
+
+Freelance memory defaults to `.freelance/.state/memory.db` relative to the workflow directory. When Freelance ships as a Claude Code plugin, the workflow directory lives inside `${CLAUDE_PLUGIN_ROOT}` which is replaced on every plugin update — wiping the memory DB.
+
+## Solution
+
+Add `--memory-dir <path>` to the `freelance mcp` command.
+
+```
+freelance mcp --workflows /path/to/workflows --memory-dir /path/to/persistent/dir
+```
+
+## Behavior
+
+When `--memory-dir` is set:
+- Memory DB is stored at `<memory-dir>/memory.db`
+- `memory.enabled` is implicitly `true` (no config.yml opt-in needed)
+- Takes precedence over `config.yml` memory.db path
+
+### Resolution order
+
+```
+--memory-dir flag  >  config.yml memory.db  >  default .freelance/.state/memory.db
+```
+
+### Interaction with config.yml
+
+- `--memory-dir` overrides only the DB path. Other config.yml memory fields (`ignore`, `collections`) still apply if present.
+- If `--memory-dir` is set but no config.yml exists, memory is enabled with default settings (no ignore patterns, single "default" collection).
+
+## Plugin usage
+
+Claude Code plugins expose two path variables:
+- `${CLAUDE_PLUGIN_ROOT}` — bundled assets, replaced on update
+- `${CLAUDE_PLUGIN_DATA}` — persistent storage, survives updates
+
+This enables a plugin `.mcp.json` like:
+
+```json
+{
+  "mcpServers": {
+    "freelance": {
+      "command": "freelance",
+      "args": [
+        "mcp",
+        "--workflows", "${CLAUDE_PLUGIN_ROOT}/workflows",
+        "--memory-dir", "${CLAUDE_PLUGIN_DATA}"
+      ]
+    }
+  }
+}
+```
+
+Result: workflows + docs ship with the plugin and update normally; memory persists across updates at a stable path; teams installing the plugin get memory automatically with zero config.
+
+## Implementation scope
+
+### CLI (`src/index.ts`)
+
+Add `--memory-dir <path>` option to the `mcp` command:
+
+```typescript
+.option("--memory-dir <path>", "Persistent directory for memory database (overrides config.yml)")
+```
+
+In the `mcp` action handler, after `loadMemoryConfig(dirs)`:
+
+```typescript
+if (opts.memoryDir) {
+  const memDir = path.resolve(opts.memoryDir);
+  if (!fs.existsSync(memDir)) {
+    fs.mkdirSync(memDir, { recursive: true });
+  }
+  const dbPath = path.join(memDir, "memory.db");
+  if (memoryConfig) {
+    // Override just the path, keep ignore/collections from config.yml
+    memoryConfig.db = dbPath;
+  } else {
+    // No config.yml — enable memory with defaults
+    memoryConfig = { enabled: true, db: dbPath };
+  }
+}
+```
+
+### Files changed
+
+- `src/index.ts` — one new CLI option + ~10 lines of override logic in the `mcp` action handler
+
+### Files NOT changed
+
+- `src/server.ts` — no changes (already receives `MemoryConfig` from CLI)
+- `src/memory/` — no changes (already accepts any DB path)
+- Config schema — no changes (`config.yml` is unaffected)
+
+## Test plan
+
+- Unit: `--memory-dir` with no config.yml enables memory at specified path
+- Unit: `--memory-dir` with existing config.yml overrides DB path but preserves ignore/collections
+- Unit: `--memory-dir` creates directory if it doesn't exist
+- Integration: full MCP flow with `--memory-dir` flag — register, emit, end, browse

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,14 @@ function loadMemoryConfig(graphsDirs: string[]): MemoryConfig | null {
               ? (path.isAbsolute(mem.db) ? mem.db : path.resolve(ensureStateDir(dir), mem.db))
               : path.join(ensureStateDir(dir), "memory.db");
             const ignore = Array.isArray(mem.ignore) ? mem.ignore as string[] : undefined;
-            return { enabled: true, db: dbPath, ignore };
+            const collections = Array.isArray(mem.collections)
+              ? (mem.collections as Array<Record<string, unknown>>).map((c) => ({
+                  name: String(c.name ?? ""),
+                  description: String(c.description ?? ""),
+                  paths: Array.isArray(c.paths) ? c.paths as string[] : [],
+                })).filter((c) => c.name.length > 0)
+              : undefined;
+            return { enabled: true, db: dbPath, ignore, collections };
           }
         }
       } catch {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -83,8 +83,6 @@ function migrate(db: Database.Database): void {
       db.exec(`ALTER TABLE ${table} ADD COLUMN mtime_ms REAL`);
     }
   }
-
-
 }
 
 export function openDatabase(dbPath: string): Database.Database {

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -35,9 +35,11 @@ CREATE TABLE IF NOT EXISTS propositions (
   content TEXT NOT NULL,
   content_hash TEXT NOT NULL,
   session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  collection TEXT NOT NULL DEFAULT 'default',
   created_at TEXT NOT NULL
 );
-CREATE UNIQUE INDEX IF NOT EXISTS idx_prop_hash ON propositions(content_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prop_hash_coll ON propositions(content_hash, collection);
+CREATE INDEX IF NOT EXISTS idx_prop_collection ON propositions(collection);
 
 CREATE TABLE IF NOT EXISTS about (
   proposition_id TEXT NOT NULL REFERENCES propositions(id) ON DELETE CASCADE,
@@ -59,6 +61,18 @@ CREATE VIRTUAL TABLE IF NOT EXISTS propositions_fts USING fts5(
   content='propositions',
   content_rowid='rowid'
 );
+
+-- Keep FTS in sync with propositions table.
+CREATE TRIGGER IF NOT EXISTS propositions_ai AFTER INSERT ON propositions BEGIN
+  INSERT INTO propositions_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
+CREATE TRIGGER IF NOT EXISTS propositions_ad AFTER DELETE ON propositions BEGIN
+  INSERT INTO propositions_fts(propositions_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+END;
+CREATE TRIGGER IF NOT EXISTS propositions_au AFTER UPDATE ON propositions BEGIN
+  INSERT INTO propositions_fts(propositions_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+  INSERT INTO propositions_fts(rowid, content) VALUES (new.rowid, new.content);
+END;
 `;
 
 function migrate(db: Database.Database): void {
@@ -69,6 +83,8 @@ function migrate(db: Database.Database): void {
       db.exec(`ALTER TABLE ${table} ADD COLUMN mtime_ms REAL`);
     }
   }
+
+
 }
 
 export function openDatabase(dbPath: string): Database.Database {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,4 +1,4 @@
 export { MemoryStore } from "./store.js";
 export { registerMemoryTools } from "./tools.js";
 export { openDatabase } from "./db.js";
-export type { MemoryConfig } from "./types.js";
+export type { MemoryConfig, CollectionConfig } from "./types.js";

--- a/src/memory/recollection.ts
+++ b/src/memory/recollection.ts
@@ -19,6 +19,7 @@ export function buildRecollectionWorkflow(): ValidatedGraph {
       "and emits new propositions to fill the delta."
     )
     .setContext({
+      collection: "",
       query: "",
       recalledEntities: 0,
       recalledPropositions: 0,
@@ -31,11 +32,12 @@ export function buildRecollectionWorkflow(): ValidatedGraph {
       description: "Search memory for existing knowledge related to the query.",
       instructions:
         "Use memory_browse and memory_inspect to find entities and propositions " +
-        "related to the query. Catalog what's already known — these are the propositions " +
+        "related to the query, passing context.collection as the collection parameter. " +
+        "Catalog what's already known — these are the propositions " +
         "from prior compilation sessions. Note the source files listed in provenance " +
         "(source_sessions) — you'll read those next. " +
         "Update context.recalledEntities and context.recalledPropositions with counts.",
-      suggestedTools: ["memory_browse", "memory_inspect"],
+      suggestedTools: ["memory_browse", "memory_inspect", "memory_related"],
       edges: [
         {
           target: "sourcing",
@@ -93,7 +95,8 @@ export function buildRecollectionWorkflow(): ValidatedGraph {
       type: "action",
       description: "Emit new propositions to cover the delta.",
       instructions:
-        "Emit propositions for the gaps identified in the comparison step. " +
+        "Emit propositions for the gaps identified in the comparison step, passing " +
+        "context.collection as the collection parameter to memory_emit. " +
         "Each proposition should be a self-contained claim about 1-2 entities, " +
         "capturing knowledge the sources reveal about the query that wasn't " +
         "previously compiled. Don't re-emit what's already known — focus on the delta. " +

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -338,9 +338,11 @@ export class MemoryStore {
   // --- Entity lookup ---
 
   private findEntity(idOrName: string): EntityRow {
-    const entity = this.db.prepare(
-      "SELECT * FROM entities WHERE id = ? OR name = ? OR LOWER(name) = ? LIMIT 1"
-    ).get(idOrName, idOrName, idOrName.toLowerCase()) as EntityRow | undefined;
+    // Priority: id → exact name → normalized name
+    const entity =
+      (this.db.prepare("SELECT * FROM entities WHERE id = ?").get(idOrName) as EntityRow | undefined) ??
+      (this.db.prepare("SELECT * FROM entities WHERE name = ?").get(idOrName) as EntityRow | undefined) ??
+      (this.db.prepare("SELECT * FROM entities WHERE LOWER(name) = ?").get(idOrName.toLowerCase()) as EntityRow | undefined);
     if (!entity) {
       throw new Error(`Entity not found: ${idOrName}`);
     }
@@ -349,16 +351,26 @@ export class MemoryStore {
 
   // --- Neighbors ---
 
-  private getNeighbors(entityId: string, staleSessionIds: Set<string>): NeighborEntity[] {
-    const staleIds = [...staleSessionIds];
-    const stalePlaceholders = staleIds.length > 0
-      ? staleIds.map(() => "?").join(",")
-      : "'__none__'";
+  private stalePlaceholders(staleSessionIds: Set<string>): { sql: string; params: string[] } {
+    const params = [...staleSessionIds];
+    return { sql: params.length > 0 ? params.map(() => "?").join(",") : "'__none__'", params };
+  }
+
+  private getNeighbors(entityId: string, staleSessionIds: Set<string>, withSample = false): Array<NeighborEntity & { sample?: string | null }> {
+    const stale = this.stalePlaceholders(staleSessionIds);
+    const sampleCol = withSample
+      ? `, (SELECT p2.content FROM propositions p2
+               JOIN about s1 ON p2.id = s1.proposition_id
+               JOIN about s2 ON p2.id = s2.proposition_id
+               WHERE s1.entity_id = ? AND s2.entity_id = e2.id
+               ORDER BY LENGTH(p2.content) DESC LIMIT 1) as sample`
+      : "";
+    const sampleParams = withSample ? [entityId] : [];
 
     return this.db.prepare(
       `SELECT e2.id, e2.name, e2.kind,
               COUNT(DISTINCT a1.proposition_id) as shared_propositions,
-              COUNT(DISTINCT CASE WHEN p.session_id NOT IN (${stalePlaceholders}) THEN a1.proposition_id END) as valid_shared_propositions
+              COUNT(DISTINCT CASE WHEN p.session_id NOT IN (${stale.sql}) THEN a1.proposition_id END) as valid_shared_propositions${sampleCol}
        FROM about a1
        JOIN about a2 ON a1.proposition_id = a2.proposition_id
        JOIN entities e2 ON a2.entity_id = e2.id
@@ -366,7 +378,7 @@ export class MemoryStore {
        WHERE a1.entity_id = ? AND a2.entity_id != a1.entity_id
        GROUP BY e2.id
        ORDER BY valid_shared_propositions DESC`
-    ).all(...staleIds, entityId) as NeighborEntity[];
+    ).all(...stale.params, ...sampleParams, entityId) as Array<NeighborEntity & { sample?: string | null }>;
   }
 
   // --- Query operations ---
@@ -516,7 +528,6 @@ export class MemoryStore {
       `SELECT p.* FROM propositions p JOIN propositions_fts fts ON p.rowid = fts.rowid WHERE propositions_fts MATCH ?${coll.clause} ORDER BY fts.rank LIMIT ?`
     ).all(sanitized, ...coll.params, limit) as PropositionRow[];
 
-
     const propositions = rows.map((p) => {
       const enriched = this.enrichProposition(p);
       const entityRows = this.db.prepare(
@@ -546,30 +557,7 @@ export class MemoryStore {
       "SELECT COUNT(*) as c FROM about WHERE entity_id = ?"
     ).get(entity.id) as { c: number }).c;
 
-    const staleIds = [...staleSessionIds];
-    const stalePlaceholders = staleIds.length > 0
-      ? staleIds.map(() => "?").join(",")
-      : "'__none__'";
-
-    // Single query: neighbors + longest shared proposition as sample
-    const rows = this.db.prepare(
-      `SELECT e2.id, e2.name, e2.kind,
-              COUNT(DISTINCT a1.proposition_id) as shared_propositions,
-              COUNT(DISTINCT CASE WHEN p.session_id NOT IN (${stalePlaceholders}) THEN a1.proposition_id END) as valid_shared_propositions,
-              (SELECT p2.content FROM propositions p2
-               JOIN about s1 ON p2.id = s1.proposition_id
-               JOIN about s2 ON p2.id = s2.proposition_id
-               WHERE s1.entity_id = ? AND s2.entity_id = e2.id
-               ORDER BY LENGTH(p2.content) DESC LIMIT 1) as sample
-       FROM about a1
-       JOIN about a2 ON a1.proposition_id = a2.proposition_id
-       JOIN entities e2 ON a2.entity_id = e2.id
-       JOIN propositions p ON a1.proposition_id = p.id
-       WHERE a1.entity_id = ? AND a2.entity_id != a1.entity_id
-       GROUP BY e2.id
-       ORDER BY valid_shared_propositions DESC`
-    ).all(...staleIds, entity.id, entity.id) as Array<NeighborEntity & { sample: string | null }>;
-
+    const rows = this.getNeighbors(entity.id, staleSessionIds, true);
     const neighbors = rows.map((r) => ({ ...r, sample: r.sample ?? "" }));
 
     return {
@@ -654,10 +642,10 @@ export class MemoryStore {
     if (stale.size === 0) {
       validCount = totalProps;
     } else {
-      const placeholders = [...stale].map(() => "?").join(",");
+      const sp = this.stalePlaceholders(stale);
       const staleCount = (this.db.prepare(
-        `SELECT COUNT(*) as c FROM propositions WHERE session_id IN (${placeholders})${collAnd}`
-      ).get(...stale, ...collParams) as { c: number }).c;
+        `SELECT COUNT(*) as c FROM propositions WHERE session_id IN (${sp.sql})${collAnd}`
+      ).get(...sp.params, ...collParams) as { c: number }).c;
       validCount = totalProps - staleCount;
     }
 
@@ -686,12 +674,12 @@ export class MemoryStore {
         `SELECT COUNT(*) as c FROM about a JOIN propositions p ON a.proposition_id = p.id WHERE a.entity_id = ?${coll.clause}`
       ).get(entityId, ...coll.params) as { c: number }).c;
     }
-    const placeholders = [...staleSessionIds].map(() => "?").join(",");
+    const sp = this.stalePlaceholders(staleSessionIds);
     return (this.db.prepare(
       `SELECT COUNT(*) as c FROM about a
        JOIN propositions p ON a.proposition_id = p.id
-       WHERE a.entity_id = ? AND p.session_id NOT IN (${placeholders})${coll.clause}`
-    ).get(entityId, ...staleSessionIds, ...coll.params) as { c: number }).c;
+       WHERE a.entity_id = ? AND p.session_id NOT IN (${sp.sql})${coll.clause}`
+    ).get(entityId, ...sp.params, ...coll.params) as { c: number }).c;
   }
 
   private enrichProposition(row: PropositionRow): PropositionInfo {

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -27,6 +27,9 @@ import type {
   EndResult,
   RegisterSourceResult,
   SourceSession,
+  CollectionConfig,
+  NeighborEntity,
+  RelatedResult,
 } from "./types.js";
 
 function generateId(): string {
@@ -61,17 +64,35 @@ function mtimeOf(filePath: string): number | null {
   }
 }
 
+const DEFAULT_COLLECTION: CollectionConfig = { name: "default", description: "General project knowledge", paths: [""] };
+
 export class MemoryStore {
   private db: Database.Database;
   private sourceRoot: string;
   private ignore: string[];
+  private collections: Map<string, CollectionConfig>;
   private mtimeCache: Map<string, number | null> = new Map();
   private hashCache: Map<string, string | null> = new Map();
 
-  constructor(dbPath: string, sourceRoot?: string, ignore?: string[]) {
+  constructor(dbPath: string, sourceRoot?: string, ignore?: string[], collections?: CollectionConfig[]) {
     this.db = openDatabase(dbPath);
     this.sourceRoot = sourceRoot ?? process.cwd();
     this.ignore = ignore ?? [];
+    this.collections = new Map(
+      (collections && collections.length > 0 ? collections : [DEFAULT_COLLECTION])
+        .map((c) => [c.name, c])
+    );
+  }
+
+  getCollections(): CollectionConfig[] {
+    return [...this.collections.values()];
+  }
+
+  private resolveCollection(collection: string): void {
+    if (!this.collections.has(collection)) {
+      const available = [...this.collections.keys()].join(", ");
+      throw new Error(`Unknown collection "${collection}". Available: ${available}`);
+    }
   }
 
   close(): void {
@@ -189,7 +210,8 @@ export class MemoryStore {
 
   // --- Proposition emission ---
 
-  emit(propositions: EmitProposition[]): EmitResult {
+  emit(propositions: EmitProposition[], collection: string): EmitResult {
+    this.resolveCollection(collection);
     const sessionId = this.requireActiveSession();
 
     // Validate that at least one source file is registered
@@ -210,7 +232,7 @@ export class MemoryStore {
     };
 
     const insertProp = this.db.prepare(
-      "INSERT INTO propositions (id, content, content_hash, session_id, created_at) VALUES (?, ?, ?, ?, ?)"
+      "INSERT INTO propositions (id, content, content_hash, session_id, collection, created_at) VALUES (?, ?, ?, ?, ?, ?)"
     );
     const insertAbout = this.db.prepare(
       "INSERT OR IGNORE INTO about (proposition_id, entity_id) VALUES (?, ?)"
@@ -232,8 +254,8 @@ export class MemoryStore {
       for (const prop of propositions) {
         const contentHash = hashContent(prop.content);
         const existing = this.db.prepare(
-          "SELECT id FROM propositions WHERE content_hash = ?"
-        ).get(contentHash) as { id: string } | undefined;
+          "SELECT id FROM propositions WHERE content_hash = ? AND collection = ?"
+        ).get(contentHash, collection) as { id: string } | undefined;
 
         const propResult: EmitResult["propositions"][number] = {
           id: "",
@@ -250,7 +272,7 @@ export class MemoryStore {
           result.deduplicated++;
         } else {
           propId = generateId();
-          insertProp.run(propId, prop.content, contentHash, sessionId, now());
+          insertProp.run(propId, prop.content, contentHash, sessionId, collection, now());
           propResult.id = propId;
           result.created++;
         }
@@ -268,7 +290,8 @@ export class MemoryStore {
         }
 
         for (const entityName of prop.entities) {
-          const resolved = this.resolveEntity(entityName);
+          const kind = prop.entityKinds?.[entityName];
+          const resolved = this.resolveEntity(entityName, kind);
           propResult.entities.push(resolved);
           insertAbout.run(propId, resolved.id);
           if (resolved.resolution === "created") {
@@ -288,7 +311,7 @@ export class MemoryStore {
 
   // --- Entity resolution ---
 
-  private resolveEntity(name: string): { id: string; name: string; resolution: "exact" | "normalized" | "created" } {
+  private resolveEntity(name: string, kind?: string): { id: string; name: string; resolution: "exact" | "normalized" | "created" } {
     const exact = this.db.prepare(
       "SELECT id, name FROM entities WHERE name = ?"
     ).get(name) as EntityRow | undefined;
@@ -306,26 +329,79 @@ export class MemoryStore {
 
     const id = generateId();
     this.db.prepare(
-      "INSERT INTO entities (id, name, kind, created_at) VALUES (?, ?, NULL, ?)"
-    ).run(id, name, now());
+      "INSERT INTO entities (id, name, kind, created_at) VALUES (?, ?, ?, ?)"
+    ).run(id, name, kind ?? null, now());
 
     return { id, name, resolution: "created" };
   }
 
+  // --- Entity lookup ---
+
+  private findEntity(idOrName: string): EntityRow {
+    const entity = this.db.prepare(
+      "SELECT * FROM entities WHERE id = ? OR name = ? OR LOWER(name) = ? LIMIT 1"
+    ).get(idOrName, idOrName, idOrName.toLowerCase()) as EntityRow | undefined;
+    if (!entity) {
+      throw new Error(`Entity not found: ${idOrName}`);
+    }
+    return entity;
+  }
+
+  // --- Neighbors ---
+
+  private getNeighbors(entityId: string, staleSessionIds: Set<string>): NeighborEntity[] {
+    const staleIds = [...staleSessionIds];
+    const stalePlaceholders = staleIds.length > 0
+      ? staleIds.map(() => "?").join(",")
+      : "'__none__'";
+
+    return this.db.prepare(
+      `SELECT e2.id, e2.name, e2.kind,
+              COUNT(DISTINCT a1.proposition_id) as shared_propositions,
+              COUNT(DISTINCT CASE WHEN p.session_id NOT IN (${stalePlaceholders}) THEN a1.proposition_id END) as valid_shared_propositions
+       FROM about a1
+       JOIN about a2 ON a1.proposition_id = a2.proposition_id
+       JOIN entities e2 ON a2.entity_id = e2.id
+       JOIN propositions p ON a1.proposition_id = p.id
+       WHERE a1.entity_id = ? AND a2.entity_id != a1.entity_id
+       GROUP BY e2.id
+       ORDER BY valid_shared_propositions DESC`
+    ).all(...staleIds, entityId) as NeighborEntity[];
+  }
+
   // --- Query operations ---
+
+  /** Build optional collection filter clause + params for WHERE appendage. */
+  private collectionFilter(collection: string | undefined): { clause: string; params: unknown[] } {
+    if (!collection) return { clause: "", params: [] };
+    return { clause: " AND p.collection = ?", params: [collection] };
+  }
 
   private clearProvenanceCache(): void {
     this.mtimeCache.clear();
     this.hashCache.clear();
   }
 
-  browse(options?: { name?: string; kind?: string; limit?: number; offset?: number }): BrowseResult {
+  browse(options?: { name?: string; kind?: string; limit?: number; offset?: number; collection?: string }): BrowseResult {
     this.clearProvenanceCache();
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
+    const collection = options?.collection;
 
-    let where = "1=1";
+    if (collection) this.resolveCollection(collection);
+
+    let where: string;
     const params: unknown[] = [];
+    let joinClause: string;
+
+    if (collection) {
+      joinClause = "JOIN about a ON e.id = a.entity_id JOIN propositions p ON a.proposition_id = p.id";
+      where = "p.collection = ?";
+      params.push(collection);
+    } else {
+      joinClause = "LEFT JOIN about a ON e.id = a.entity_id";
+      where = "1=1";
+    }
 
     if (options?.name) {
       where += " AND LOWER(e.name) LIKE ?";
@@ -336,14 +412,15 @@ export class MemoryStore {
       params.push(options.kind);
     }
 
-    const countRow = this.db.prepare(
-      `SELECT COUNT(*) as total FROM entities e WHERE ${where}`
-    ).get(...params) as { total: number };
+    const countSql = collection
+      ? `SELECT COUNT(DISTINCT e.id) as total FROM entities e JOIN about a ON e.id = a.entity_id JOIN propositions p ON a.proposition_id = p.id WHERE ${where}`
+      : `SELECT COUNT(*) as total FROM entities e WHERE ${where}`;
+    const total = (this.db.prepare(countSql).get(...params) as { total: number }).total;
 
     const rows = this.db.prepare(
-      `SELECT e.*, COUNT(a.proposition_id) as proposition_count
+      `SELECT e.*, COUNT(${collection ? "DISTINCT " : ""}a.proposition_id) as proposition_count
        FROM entities e
-       LEFT JOIN about a ON e.id = a.entity_id
+       ${joinClause}
        WHERE ${where}
        GROUP BY e.id
        ORDER BY e.created_at DESC
@@ -353,7 +430,7 @@ export class MemoryStore {
     const staleSessionIds = this.getStaleSessionIds();
 
     const entities: EntityInfo[] = rows.map((row) => {
-      const validCount = this.countValidForEntity(row.id, staleSessionIds);
+      const validCount = this.countValidForEntity(row.id, staleSessionIds, collection);
       return {
         id: row.id,
         name: row.name,
@@ -363,29 +440,18 @@ export class MemoryStore {
       };
     });
 
-    return { entities, total: countRow.total };
+    return { entities, total };
   }
 
-  inspect(entityIdOrName: string): InspectResult {
+  inspect(entityIdOrName: string, collection?: string): InspectResult {
+    if (collection) this.resolveCollection(collection);
     this.clearProvenanceCache();
+    const entity = this.findEntity(entityIdOrName);
 
-    let entity = this.db.prepare("SELECT * FROM entities WHERE id = ?").get(entityIdOrName) as EntityRow | undefined;
-    if (!entity) {
-      entity = this.db.prepare("SELECT * FROM entities WHERE name = ?").get(entityIdOrName) as EntityRow | undefined;
-    }
-    if (!entity) {
-      entity = this.db.prepare("SELECT * FROM entities WHERE LOWER(name) = ?").get(entityIdOrName.toLowerCase()) as EntityRow | undefined;
-    }
-    if (!entity) {
-      throw new Error(`Entity not found: ${entityIdOrName}`);
-    }
-
+    const coll = this.collectionFilter(collection);
     const propRows = this.db.prepare(
-      `SELECT p.* FROM propositions p
-       JOIN about a ON p.id = a.proposition_id
-       WHERE a.entity_id = ?
-       ORDER BY p.created_at DESC`
-    ).all(entity.id) as PropositionRow[];
+      `SELECT p.* FROM propositions p JOIN about a ON p.id = a.proposition_id WHERE a.entity_id = ?${coll.clause} ORDER BY p.created_at DESC`
+    ).all(entity.id, ...coll.params) as PropositionRow[];
 
     const propositions = propRows.map((p) => this.enrichProposition(p));
 
@@ -398,6 +464,8 @@ export class MemoryStore {
     });
 
     const validCount = propositions.filter((p) => p.valid).length;
+    const staleSessionIds = this.getStaleSessionIds();
+    const neighbors = this.getNeighbors(entity.id, staleSessionIds);
 
     return {
       entity: {
@@ -408,23 +476,23 @@ export class MemoryStore {
         valid_proposition_count: validCount,
       },
       propositions,
+      neighbors,
       source_sessions: sourceSessions,
     };
   }
 
-  bySource(filePath: string): BySourceResult {
+  bySource(filePath: string, collection?: string): BySourceResult {
+    if (collection) this.resolveCollection(collection);
     this.clearProvenanceCache();
 
     const storedPath = path.isAbsolute(filePath)
       ? path.relative(this.sourceRoot, filePath)
       : filePath;
 
+    const coll = this.collectionFilter(collection);
     const propRows = this.db.prepare(
-      `SELECT DISTINCT p.* FROM propositions p
-       JOIN session_files sf ON p.session_id = sf.session_id
-       WHERE sf.file_path = ?
-       ORDER BY p.created_at DESC`
-    ).all(storedPath) as PropositionRow[];
+      `SELECT DISTINCT p.* FROM propositions p JOIN session_files sf ON p.session_id = sf.session_id WHERE sf.file_path = ?${coll.clause} ORDER BY p.created_at DESC`
+    ).all(storedPath, ...coll.params) as PropositionRow[];
 
     return {
       file_path: storedPath,
@@ -432,7 +500,9 @@ export class MemoryStore {
     };
   }
 
-  search(query: string, options?: { limit?: number }): SearchResult {
+  search(query: string, options?: { limit?: number; collection?: string }): SearchResult {
+    const collection = options?.collection;
+    if (collection) this.resolveCollection(collection);
     this.clearProvenanceCache();
     const limit = options?.limit ?? 20;
 
@@ -441,13 +511,11 @@ export class MemoryStore {
     // Preserve explicitly quoted phrases and prefix wildcards.
     const sanitized = query.replace(/(?<!["])\b(\w+)-(\w+)\b(?!["])/g, "$1 $2");
 
+    const coll = this.collectionFilter(collection);
     const rows = this.db.prepare(
-      `SELECT p.* FROM propositions p
-       JOIN propositions_fts fts ON p.rowid = fts.rowid
-       WHERE propositions_fts MATCH ?
-       ORDER BY fts.rank
-       LIMIT ?`
-    ).all(sanitized, limit) as PropositionRow[];
+      `SELECT p.* FROM propositions p JOIN propositions_fts fts ON p.rowid = fts.rowid WHERE propositions_fts MATCH ?${coll.clause} ORDER BY fts.rank LIMIT ?`
+    ).all(sanitized, ...coll.params, limit) as PropositionRow[];
+
 
     const propositions = rows.map((p) => {
       const enriched = this.enrichProposition(p);
@@ -462,9 +530,58 @@ export class MemoryStore {
     return { query, propositions };
   }
 
-  status(): StatusResult {
+  status(collection?: string): StatusResult {
+    if (collection) this.resolveCollection(collection);
     this.clearProvenanceCache();
-    return this.computeStatus();
+    return this.computeStatus(collection);
+  }
+
+  related(entityIdOrName: string): RelatedResult {
+    this.clearProvenanceCache();
+    const entity = this.findEntity(entityIdOrName);
+
+    const staleSessionIds = this.getStaleSessionIds();
+    const validCount = this.countValidForEntity(entity.id, staleSessionIds);
+    const totalCount = (this.db.prepare(
+      "SELECT COUNT(*) as c FROM about WHERE entity_id = ?"
+    ).get(entity.id) as { c: number }).c;
+
+    const staleIds = [...staleSessionIds];
+    const stalePlaceholders = staleIds.length > 0
+      ? staleIds.map(() => "?").join(",")
+      : "'__none__'";
+
+    // Single query: neighbors + longest shared proposition as sample
+    const rows = this.db.prepare(
+      `SELECT e2.id, e2.name, e2.kind,
+              COUNT(DISTINCT a1.proposition_id) as shared_propositions,
+              COUNT(DISTINCT CASE WHEN p.session_id NOT IN (${stalePlaceholders}) THEN a1.proposition_id END) as valid_shared_propositions,
+              (SELECT p2.content FROM propositions p2
+               JOIN about s1 ON p2.id = s1.proposition_id
+               JOIN about s2 ON p2.id = s2.proposition_id
+               WHERE s1.entity_id = ? AND s2.entity_id = e2.id
+               ORDER BY LENGTH(p2.content) DESC LIMIT 1) as sample
+       FROM about a1
+       JOIN about a2 ON a1.proposition_id = a2.proposition_id
+       JOIN entities e2 ON a2.entity_id = e2.id
+       JOIN propositions p ON a1.proposition_id = p.id
+       WHERE a1.entity_id = ? AND a2.entity_id != a1.entity_id
+       GROUP BY e2.id
+       ORDER BY valid_shared_propositions DESC`
+    ).all(...staleIds, entity.id, entity.id) as Array<NeighborEntity & { sample: string | null }>;
+
+    const neighbors = rows.map((r) => ({ ...r, sample: r.sample ?? "" }));
+
+    return {
+      entity: {
+        id: entity.id,
+        name: entity.name,
+        kind: entity.kind,
+        proposition_count: totalCount,
+        valid_proposition_count: validCount,
+      },
+      neighbors,
+    };
   }
 
   // --- Provenance validation ---
@@ -519,8 +636,14 @@ export class MemoryStore {
     return stale;
   }
 
-  private computeStatus(): StatusResult {
-    const totalProps = (this.db.prepare("SELECT COUNT(*) as c FROM propositions").get() as { c: number }).c;
+  private computeStatus(collection?: string): StatusResult {
+    const collWhere = collection ? " WHERE collection = ?" : "";
+    const collAnd = collection ? " AND collection = ?" : "";
+    const collParams: unknown[] = collection ? [collection] : [];
+
+    const totalProps = (this.db.prepare(
+      `SELECT COUNT(*) as c FROM propositions${collWhere}`
+    ).get(...collParams) as { c: number }).c;
     const totalEntities = (this.db.prepare("SELECT COUNT(*) as c FROM entities").get() as { c: number }).c;
     const totalSessions = (this.db.prepare("SELECT COUNT(*) as c FROM sessions").get() as { c: number }).c;
     const activeSession = this.getActiveSession();
@@ -533,8 +656,8 @@ export class MemoryStore {
     } else {
       const placeholders = [...stale].map(() => "?").join(",");
       const staleCount = (this.db.prepare(
-        `SELECT COUNT(*) as c FROM propositions WHERE session_id IN (${placeholders})`
-      ).get(...stale) as { c: number }).c;
+        `SELECT COUNT(*) as c FROM propositions WHERE session_id IN (${placeholders})${collAnd}`
+      ).get(...stale, ...collParams) as { c: number }).c;
       validCount = totalProps - staleCount;
     }
 
@@ -548,18 +671,27 @@ export class MemoryStore {
     };
   }
 
-  private countValidForEntity(entityId: string, staleSessionIds: Set<string>): number {
-    if (staleSessionIds.size === 0) {
+  private countValidForEntity(entityId: string, staleSessionIds: Set<string>, collection?: string): number {
+    // Fast path: no stale sessions and no collection filter — skip JOIN
+    if (staleSessionIds.size === 0 && !collection) {
       return (this.db.prepare(
         "SELECT COUNT(*) as c FROM about WHERE entity_id = ?"
       ).get(entityId) as { c: number }).c;
+    }
+
+    const coll = this.collectionFilter(collection);
+
+    if (staleSessionIds.size === 0) {
+      return (this.db.prepare(
+        `SELECT COUNT(*) as c FROM about a JOIN propositions p ON a.proposition_id = p.id WHERE a.entity_id = ?${coll.clause}`
+      ).get(entityId, ...coll.params) as { c: number }).c;
     }
     const placeholders = [...staleSessionIds].map(() => "?").join(",");
     return (this.db.prepare(
       `SELECT COUNT(*) as c FROM about a
        JOIN propositions p ON a.proposition_id = p.id
-       WHERE a.entity_id = ? AND p.session_id NOT IN (${placeholders})`
-    ).get(entityId, ...staleSessionIds) as { c: number }).c;
+       WHERE a.entity_id = ? AND p.session_id NOT IN (${placeholders})${coll.clause}`
+    ).get(entityId, ...staleSessionIds, ...coll.params) as { c: number }).c;
   }
 
   private enrichProposition(row: PropositionRow): PropositionInfo {
@@ -588,6 +720,7 @@ export class MemoryStore {
       session_id: row.session_id,
       created_at: row.created_at,
       valid,
+      collection: row.collection,
       source_files: sourceFiles,
     };
   }

--- a/src/memory/tools.ts
+++ b/src/memory/tools.ts
@@ -1,7 +1,7 @@
 /**
  * MCP tool registration for Freelance Memory.
  *
- * 7 tools: 3 write (register_source, emit, end), 4 read (browse, inspect, by_source, status).
+ * 9 tools: 3 write (register_source, emit, end), 6 read (browse, inspect, by_source, search, related, status).
  */
 
 import { z } from "zod";
@@ -15,6 +15,14 @@ function handleError(e: unknown) {
 }
 
 export function registerMemoryTools(server: McpServer, store: MemoryStore): void {
+  const collections = store.getCollections();
+  const collectionEnum = z.enum(
+    collections.map((c) => c.name) as [string, ...string[]]
+  );
+  const collectionsNote = `Available collections: ${
+    collections.map((c) => `"${c.name}" (${c.paths.join(", ")}) — ${c.description}`).join("; ")
+  }.`;
+
   // --- Write ---
 
   server.tool(
@@ -34,17 +42,19 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
 
   server.tool(
     "memory_emit",
-    "Write propositions to memory. Each proposition is a self-contained claim about 1-2 entities, written in natural prose. Deduplicates by content hash. Requires an active session with at least one registered source file.",
+    `Write propositions to memory. Each proposition is a self-contained claim about 1-2 entities, written in natural prose. Deduplicates by content hash within a collection. Requires an active session with at least one registered source file. ${collectionsNote}`,
     {
+      collection: collectionEnum.describe("Target collection for these propositions"),
       propositions: z.array(z.object({
         content: z.string().min(1).describe("The proposition — a self-contained claim in natural prose"),
         entities: z.array(z.string().min(1)).min(1).max(2).describe("Entity names this proposition is about (1-2)"),
         sources: z.array(z.string().min(1)).min(1).describe("Source file paths this proposition was derived from (relative to source root). Each path must be registered in the active session."),
+        entityKinds: z.record(z.string(), z.string()).optional().describe("Map of entity name to kind (e.g. function, class, type, interface, enum). Sets kind on entity creation."),
       })).min(1),
     },
-    ({ propositions }) => {
+    ({ collection, propositions }) => {
       try {
-        return jsonResponse(store.emit(propositions));
+        return jsonResponse(store.emit(propositions, collection));
       } catch (e) {
         return handleError(e);
       }
@@ -68,16 +78,17 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
 
   server.tool(
     "memory_browse",
-    "Find entities by name, kind, or partial match. Returns entities with valid proposition counts.",
+    `Find entities by name, kind, or partial match. Returns entities with valid proposition counts. Stale entities can be refreshed by re-registering their source files via memory_register_source. ${collectionsNote}`,
     {
+      collection: collectionEnum.optional().describe("Collection to filter by (omit for all)"),
       name: z.string().optional().describe("Partial name match (case-insensitive)"),
       kind: z.string().optional().describe("Filter by entity kind"),
       limit: z.number().int().min(1).max(200).default(50).optional(),
       offset: z.number().int().min(0).default(0).optional(),
     },
-    ({ name, kind, limit, offset }) => {
+    ({ collection, name, kind, limit, offset }) => {
       try {
-        return jsonResponse(store.browse({ name, kind, limit, offset }));
+        return jsonResponse(store.browse({ collection, name, kind, limit, offset }));
       } catch (e) {
         return handleError(e);
       }
@@ -86,13 +97,14 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
 
   server.tool(
     "memory_inspect",
-    "Full entity details — valid propositions and source sessions.",
+    `Full entity details — valid propositions, neighbors, and source sessions. Stale propositions can be refreshed by re-registering their source files via memory_register_source. ${collectionsNote}`,
     {
+      collection: collectionEnum.optional().describe("Collection to filter by (omit for all)"),
       entity: z.string().min(1).describe("Entity ID or name"),
     },
-    ({ entity }) => {
+    ({ collection, entity }) => {
       try {
-        return jsonResponse(store.inspect(entity));
+        return jsonResponse(store.inspect(entity, collection));
       } catch (e) {
         return handleError(e);
       }
@@ -101,13 +113,14 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
 
   server.tool(
     "memory_by_source",
-    "All propositions from sessions that included a file. Shows valid and stale.",
+    `All propositions from sessions that included a file. Shows valid and stale. ${collectionsNote}`,
     {
+      collection: collectionEnum.optional().describe("Collection to filter by (omit for all)"),
       file_path: z.string().min(1).describe("File path (relative to source root or absolute)"),
     },
-    ({ file_path }) => {
+    ({ collection, file_path }) => {
       try {
-        return jsonResponse(store.bySource(file_path));
+        return jsonResponse(store.bySource(file_path, collection));
       } catch (e) {
         return handleError(e);
       }
@@ -116,14 +129,30 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
 
   server.tool(
     "memory_search",
-    "Full-text search across proposition content. Returns matching propositions with their entities and validity status. Use FTS5 query syntax: plain words for OR, double-quoted phrases for exact match, prefix* for prefix search. If your search returns no results but you later discover the answer through other means, consider starting the memory:compile workflow to capture what you learned — a search miss is a signal that memory has a gap worth filling.",
+    `Full-text search across proposition content. Returns matching propositions with their entities and validity status. Use FTS5 query syntax: plain words for OR, double-quoted phrases for exact match, prefix* for prefix search. If your search returns no results but you later discover the answer through other means, consider starting the memory:compile workflow to capture what you learned — a search miss is a signal that memory has a gap worth filling. ${collectionsNote}`,
     {
+      collection: collectionEnum.optional().describe("Collection to filter by (omit for all)"),
       query: z.string().min(1).describe("FTS5 search query (e.g. 'subgraph context', '\"return values\"', 'wait*')"),
       limit: z.number().int().min(1).max(100).default(20).optional(),
     },
-    ({ query, limit }) => {
+    ({ collection, query, limit }) => {
       try {
-        return jsonResponse(store.search(query, { limit }));
+        return jsonResponse(store.search(query, { limit, collection }));
+      } catch (e) {
+        return handleError(e);
+      }
+    }
+  );
+
+  server.tool(
+    "memory_related",
+    "Show entities related to a given entity via shared propositions. Returns co-occurring entities ranked by connection strength, each with a sample proposition showing the relationship. Use during recall to navigate the knowledge graph without inspecting entities one at a time.",
+    {
+      entity: z.string().min(1).describe("Entity ID or name"),
+    },
+    ({ entity }) => {
+      try {
+        return jsonResponse(store.related(entity));
       } catch (e) {
         return handleError(e);
       }
@@ -132,11 +161,13 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
 
   server.tool(
     "memory_status",
-    "Total propositions, valid count, stale count, entity count.",
-    {},
-    () => {
+    `Total propositions, valid count, stale count, entity count. Optionally scoped to a collection. ${collectionsNote}`,
+    {
+      collection: collectionEnum.optional().describe("Collection to get status for (omit for aggregate)"),
+    },
+    ({ collection }) => {
       try {
-        return jsonResponse(store.status());
+        return jsonResponse(store.status(collection));
       } catch (e) {
         return handleError(e);
       }

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -23,6 +23,7 @@ export interface PropositionRow {
   content: string;
   content_hash: string;
   session_id: string;
+  collection: string;
   created_at: string;
 }
 
@@ -32,6 +33,7 @@ export interface EmitProposition {
   content: string;
   entities: string[];
   sources: string[];
+  entityKinds?: Record<string, string>;
 }
 
 export interface EmitResult {
@@ -66,13 +68,28 @@ export interface PropositionInfo {
   session_id: string;
   created_at: string;
   valid: boolean;
+  collection: string;
   source_files: Array<{ path: string; hash: string; current_match: boolean }>;
+}
+
+export interface NeighborEntity {
+  id: string;
+  name: string;
+  kind: string | null;
+  shared_propositions: number;
+  valid_shared_propositions: number;
 }
 
 export interface InspectResult {
   entity: EntityInfo;
   propositions: PropositionInfo[];
+  neighbors: NeighborEntity[];
   source_sessions: SourceSession[];
+}
+
+export interface RelatedResult {
+  entity: EntityInfo;
+  neighbors: Array<NeighborEntity & { sample: string }>;
 }
 
 export interface BrowseResult {
@@ -115,8 +132,15 @@ export interface RegisterSourceResult {
   status: "registered" | "updated" | "skipped";
 }
 
+export interface CollectionConfig {
+  name: string;
+  description: string;
+  paths: string[];
+}
+
 export interface MemoryConfig {
   enabled: boolean;
   db: string;
   ignore?: string[];
+  collections?: CollectionConfig[];
 }

--- a/src/memory/workflow.ts
+++ b/src/memory/workflow.ts
@@ -17,6 +17,7 @@ export function buildCompileKnowledgeWorkflow(): ValidatedGraph {
       "Use this workflow to build persistent knowledge about the codebase."
     )
     .setContext({
+      collection: "",
       query: "",
       filesRead: 0,
       propositionsEmitted: 0,
@@ -45,7 +46,8 @@ export function buildCompileKnowledgeWorkflow(): ValidatedGraph {
       description: "Emit propositions about what you learned from the source files.",
       instructions:
         "Reason about what you read. Write self-contained propositions in natural prose, " +
-        "each about 1-2 entities. Use memory_emit to write them to Memory. " +
+        "each about 1-2 entities. Use memory_emit to write them to Memory, passing " +
+        "context.collection as the collection parameter. " +
         "Update context.propositionsEmitted with the total emitted this session.",
       suggestedTools: ["memory_emit"],
       edges: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -419,7 +419,7 @@ export function createServer(
   // --- Memory ---
   let memoryStore: MemoryStore | undefined;
   if (options?.memory?.enabled && options.memory.db) {
-    memoryStore = new MemoryStore(options.memory.db, options.sourceRoot, options.memory.ignore);
+    memoryStore = new MemoryStore(options.memory.db, options.sourceRoot, options.memory.ignore, options.memory.collections);
     registerMemoryTools(server, memoryStore);
 
     // Inject sealed memory workflows

--- a/test/memory-tools.test.ts
+++ b/test/memory-tools.test.ts
@@ -58,7 +58,7 @@ describe("Memory MCP tools", () => {
     await cleanup();
   });
 
-  it("registers 8 memory tools (no memory_begin)", async () => {
+  it("registers 9 memory tools (no memory_begin)", async () => {
     const tools = await client.listTools();
     const memTools = tools.tools.filter((t) => t.name.startsWith("memory_"));
     const names = memTools.map((t) => t.name).sort();
@@ -69,6 +69,7 @@ describe("Memory MCP tools", () => {
       "memory_end",
       "memory_inspect",
       "memory_register_source",
+      "memory_related",
       "memory_search",
       "memory_status",
     ]);
@@ -88,6 +89,7 @@ describe("Memory MCP tools", () => {
     const emitResult = await client.callTool({
       name: "memory_emit",
       arguments: {
+        collection: "default",
         propositions: [
           { content: "Auth validates JWT tokens using RS256.", entities: ["Auth"], sources: ["auth.ts"] },
           { content: "Auth returns 401 for expired tokens.", entities: ["Auth"], sources: ["auth.ts"] },
@@ -135,7 +137,7 @@ describe("Memory MCP tools", () => {
   it("emit rejected without registered source", async () => {
     const emitResult = await client.callTool({
       name: "memory_emit",
-      arguments: { propositions: [{ content: "test", entities: ["Foo"], sources: ["a.ts"] }] },
+      arguments: { collection: "default", propositions: [{ content: "test", entities: ["Foo"], sources: ["a.ts"] }] },
     });
     expect(emitResult.isError).toBeTruthy();
     const err = parseContent(emitResult) as { error: string };

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -19,6 +19,8 @@ function writeFile(dir: string, name: string, content: string): string {
   return filePath;
 }
 
+const C = "default";
+
 describe("MemoryStore", () => {
   let tmpDir: string;
   let store: MemoryStore;
@@ -49,7 +51,7 @@ describe("MemoryStore", () => {
     it("end closes session and returns stats", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
-      store.emit([{ content: "Foo exists.", entities: ["Foo"], sources: ["a.ts"] }]);
+      store.emit([{ content: "Foo exists.", entities: ["Foo"], sources: ["a.ts"] }], C);
 
       const end = store.end();
       expect(end.session_id).toBeTruthy();
@@ -66,7 +68,7 @@ describe("MemoryStore", () => {
     });
 
     it("rejects emit without registered source", () => {
-      expect(() => store.emit([{ content: "test", entities: ["Foo"], sources: ["a.ts"] }]))
+      expect(() => store.emit([{ content: "test", entities: ["Foo"], sources: ["a.ts"] }], C))
         .toThrow("Register a source file first");
     });
 
@@ -86,7 +88,7 @@ describe("MemoryStore", () => {
     it("new session after end + registerSource", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
-      store.emit([{ content: "Foo.", entities: ["Foo"], sources: ["a.ts"] }]);
+      store.emit([{ content: "Foo.", entities: ["Foo"], sources: ["a.ts"] }], C);
       const session1 = store.status().active_session;
       store.end();
 
@@ -193,7 +195,7 @@ describe("MemoryStore", () => {
       // Register a real source and emit
       writeFile(tmpDir, "auth.ts", "class Auth {}");
       ignoredStore.registerSource("auth.ts");
-      ignoredStore.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      ignoredStore.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       ignoredStore.end();
 
       // Register an ignored file — shouldn't affect anything
@@ -208,14 +210,14 @@ describe("MemoryStore", () => {
 
   describe("proposition emission", () => {
     it("requires at least one registered source", () => {
-      expect(() => store.emit([{ content: "Foo exists.", entities: ["Foo"], sources: ["a.ts"] }]))
+      expect(() => store.emit([{ content: "Foo exists.", entities: ["Foo"], sources: ["a.ts"] }], C))
         .toThrow("Register a source file first");
     });
 
     it("rejects emit with unregistered source path", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
-      expect(() => store.emit([{ content: "Foo.", entities: ["Foo"], sources: ["unknown.ts"] }]))
+      expect(() => store.emit([{ content: "Foo.", entities: ["Foo"], sources: ["unknown.ts"] }], C))
         .toThrow('Source "unknown.ts" is not registered');
     });
 
@@ -226,7 +228,7 @@ describe("MemoryStore", () => {
       const result = store.emit([
         { content: "Auth validates JWT tokens.", entities: ["Auth"], sources: ["auth.ts"] },
         { content: "Auth returns 401 for expired tokens.", entities: ["Auth"], sources: ["auth.ts"] },
-      ]);
+      ], C);
 
       expect(result.created).toBe(2);
       expect(result.deduplicated).toBe(0);
@@ -241,8 +243,8 @@ describe("MemoryStore", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");
       store.registerSource("auth.ts");
 
-      const r1 = store.emit([{ content: "Foo does bar.", entities: ["Foo"], sources: ["auth.ts"] }]);
-      const r2 = store.emit([{ content: "Foo does bar.", entities: ["Foo"], sources: ["auth.ts"] }]);
+      const r1 = store.emit([{ content: "Foo does bar.", entities: ["Foo"], sources: ["auth.ts"] }], C);
+      const r2 = store.emit([{ content: "Foo does bar.", entities: ["Foo"], sources: ["auth.ts"] }], C);
 
       expect(r1.created).toBe(1);
       expect(r2.created).toBe(0);
@@ -255,7 +257,7 @@ describe("MemoryStore", () => {
 
       const result = store.emit([
         { content: "Auth depends on Database.", entities: ["Auth", "Database"], sources: ["auth.ts"] },
-      ]);
+      ], C);
 
       expect(result.entities_created).toBe(2);
       expect(result.propositions[0].entities).toHaveLength(2);
@@ -266,8 +268,8 @@ describe("MemoryStore", () => {
     it("resolves by normalized name", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
-      store.emit([{ content: "Foo exists.", entities: ["AuthService"], sources: ["a.ts"] }]);
-      const r2 = store.emit([{ content: "Bar exists.", entities: ["authservice"], sources: ["a.ts"] }]);
+      store.emit([{ content: "Foo exists.", entities: ["AuthService"], sources: ["a.ts"] }], C);
+      const r2 = store.emit([{ content: "Bar exists.", entities: ["authservice"], sources: ["a.ts"] }], C);
 
       expect(r2.propositions[0].entities[0].resolution).toBe("normalized");
       expect(r2.entities_resolved).toBe(1);
@@ -282,7 +284,7 @@ describe("MemoryStore", () => {
       store.emit([
         { content: "Auth validates.", entities: ["Auth"], sources: ["a.ts"] },
         { content: "DB stores.", entities: ["Database"], sources: ["a.ts"] },
-      ]);
+      ], C);
       store.end();
 
       const result = store.browse();
@@ -297,7 +299,7 @@ describe("MemoryStore", () => {
       store.emit([
         { content: "Auth validates.", entities: ["Auth"], sources: ["a.ts"] },
         { content: "DB stores.", entities: ["Database"], sources: ["a.ts"] },
-      ]);
+      ], C);
       store.end();
 
       const result = store.browse({ name: "auth" });
@@ -309,7 +311,7 @@ describe("MemoryStore", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
       for (let i = 0; i < 5; i++) {
-        store.emit([{ content: `Entity ${i} exists.`, entities: [`Entity${i}`], sources: ["a.ts"] }]);
+        store.emit([{ content: `Entity ${i} exists.`, entities: [`Entity${i}`], sources: ["a.ts"] }], C);
       }
       store.end();
 
@@ -326,7 +328,7 @@ describe("MemoryStore", () => {
       store.emit([
         { content: "Auth validates JWT tokens.", entities: ["Auth"], sources: ["auth.ts"] },
         { content: "Auth returns 401 for expired tokens.", entities: ["Auth"], sources: ["auth.ts"] },
-      ]);
+      ], C);
       store.end();
 
       const result = store.inspect("Auth");
@@ -343,7 +345,7 @@ describe("MemoryStore", () => {
     it("resolves by name", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
-      store.emit([{ content: "Foo exists.", entities: ["MyService"], sources: ["a.ts"] }]);
+      store.emit([{ content: "Foo exists.", entities: ["MyService"], sources: ["a.ts"] }], C);
       store.end();
 
       const result = store.inspect("MyService");
@@ -359,11 +361,11 @@ describe("MemoryStore", () => {
       writeFile(tmpDir, "spec.md", "# Auth Spec");
 
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       store.registerSource("spec.md");
-      store.emit([{ content: "Auth should support refresh.", entities: ["Auth"], sources: ["spec.md"] }]);
+      store.emit([{ content: "Auth should support refresh.", entities: ["Auth"], sources: ["spec.md"] }], C);
       store.end();
 
       const result = store.inspect("Auth");
@@ -378,13 +380,26 @@ describe("MemoryStore", () => {
     it("finds propositions from sessions that included a file", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth validates.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth validates.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       const result = store.bySource("auth.ts");
       expect(result.file_path).toBe("auth.ts");
       expect(result.propositions).toHaveLength(1);
       expect(result.propositions[0].content).toBe("Auth validates.");
+    });
+  });
+
+  describe("search", () => {
+    it("finds propositions immediately after emit (same connection)", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([{ content: "Auth validates JWT tokens.", entities: ["Auth"], sources: ["a.ts"] }], C);
+      store.end();
+
+      const result = store.search("JWT");
+      expect(result.propositions).toHaveLength(1);
+      expect(result.propositions[0].content).toContain("JWT");
     });
   });
 
@@ -395,7 +410,7 @@ describe("MemoryStore", () => {
       store.emit([
         { content: "Foo exists.", entities: ["Foo"], sources: ["a.ts"] },
         { content: "Bar exists.", entities: ["Bar"], sources: ["a.ts"] },
-      ]);
+      ], C);
       store.end();
 
       const result = store.status();
@@ -412,7 +427,7 @@ describe("MemoryStore", () => {
     it("propositions valid when files unchanged", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       const result = store.inspect("Auth");
@@ -422,7 +437,7 @@ describe("MemoryStore", () => {
     it("propositions stale when files changed", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       writeFile(tmpDir, "auth.ts", "class Auth { validate() {} }");
@@ -435,7 +450,7 @@ describe("MemoryStore", () => {
     it("propositions stale when files deleted", () => {
       const filePath = writeFile(tmpDir, "auth.ts", "class Auth {}");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       fs.unlinkSync(filePath);
@@ -447,7 +462,7 @@ describe("MemoryStore", () => {
     it("status reflects valid/stale counts", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       let status = store.status();
@@ -466,11 +481,11 @@ describe("MemoryStore", () => {
       writeFile(tmpDir, "db.ts", "class DB {}");
 
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth validates.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth validates.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       store.registerSource("db.ts");
-      store.emit([{ content: "DB stores.", entities: ["Database"], sources: ["db.ts"] }]);
+      store.emit([{ content: "DB stores.", entities: ["Database"], sources: ["db.ts"] }], C);
       store.end();
 
       writeFile(tmpDir, "auth.ts", "class Auth { changed }");
@@ -486,12 +501,12 @@ describe("MemoryStore", () => {
     it("multiple sessions referencing same file — only matching hash is valid", () => {
       writeFile(tmpDir, "auth.ts", "version 1");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth v1.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth v1.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       writeFile(tmpDir, "auth.ts", "version 2");
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth v2.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth v2.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       const result = store.inspect("Auth");
@@ -513,7 +528,7 @@ describe("MemoryStore", () => {
 
       store.registerSource("a.ts");
       store.registerSource("b.ts");
-      store.emit([{ content: "Uses both.", entities: ["Multi"], sources: ["a.ts", "b.ts"] }]);
+      store.emit([{ content: "Uses both.", entities: ["Multi"], sources: ["a.ts", "b.ts"] }], C);
       store.end();
 
       expect(store.inspect("Multi").propositions[0].valid).toBe(true);
@@ -529,11 +544,11 @@ describe("MemoryStore", () => {
       writeFile(tmpDir, "db.ts", "class DB {}");
 
       store.registerSource("auth.ts");
-      store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["auth.ts"] }]);
+      store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["auth.ts"] }], C);
       store.end();
 
       store.registerSource("db.ts");
-      store.emit([{ content: "DB stores users.", entities: ["Database"], sources: ["db.ts"] }]);
+      store.emit([{ content: "DB stores users.", entities: ["Database"], sources: ["db.ts"] }], C);
       store.end();
 
       const status = store.status();
@@ -545,12 +560,12 @@ describe("MemoryStore", () => {
     it("deduplication works across sessions", () => {
       writeFile(tmpDir, "a.ts", "x");
       store.registerSource("a.ts");
-      store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["a.ts"] }]);
+      store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["a.ts"] }], C);
       store.end();
 
       writeFile(tmpDir, "b.ts", "y");
       store.registerSource("b.ts");
-      const r = store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["b.ts"] }]);
+      const r = store.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["b.ts"] }], C);
       expect(r.deduplicated).toBe(1);
       expect(r.created).toBe(0);
       store.end();
@@ -575,7 +590,7 @@ describe("MemoryStore", () => {
       store2.registerSource("b.ts");
 
       // store can emit (both sources are registered)
-      store.emit([{ content: "Uses both.", entities: ["Multi"], sources: ["a.ts", "b.ts"] }]);
+      store.emit([{ content: "Uses both.", entities: ["Multi"], sources: ["a.ts", "b.ts"] }], C);
       store.end();
 
       // store2 sees the results
@@ -583,6 +598,298 @@ describe("MemoryStore", () => {
       expect(result.entities).toHaveLength(1);
 
       store2.close();
+    });
+  });
+
+  describe("entityKinds", () => {
+    it("sets kind on entity creation", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([{
+        content: "Auth validates tokens.",
+        entities: ["Auth"],
+        sources: ["a.ts"],
+        entityKinds: { Auth: "class" },
+      }], C);
+      store.end();
+
+      const result = store.browse({ name: "Auth" });
+      expect(result.entities[0].kind).toBe("class");
+    });
+
+    it("kind is null when entityKinds not provided", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([{ content: "Foo exists.", entities: ["Foo"], sources: ["a.ts"] }], C);
+      store.end();
+
+      const result = store.browse({ name: "Foo" });
+      expect(result.entities[0].kind).toBeNull();
+    });
+
+    it("existing entity keeps its kind on re-resolution", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([{
+        content: "Auth validates.",
+        entities: ["Auth"],
+        sources: ["a.ts"],
+        entityKinds: { Auth: "class" },
+      }], C);
+      // Re-resolve same entity without kind — should keep original
+      store.emit([{
+        content: "Auth also logs.",
+        entities: ["Auth"],
+        sources: ["a.ts"],
+      }], C);
+      store.end();
+
+      const result = store.browse({ name: "Auth" });
+      expect(result.entities[0].kind).toBe("class");
+    });
+  });
+
+  describe("neighbors", () => {
+    it("inspect returns co-occurring entities with valid counts", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([
+        { content: "Auth depends on Database.", entities: ["Auth", "Database"], sources: ["a.ts"] },
+        { content: "Auth uses Cache for tokens.", entities: ["Auth", "Cache"], sources: ["a.ts"] },
+      ], C);
+      store.end();
+
+      const result = store.inspect("Auth");
+      expect(result.neighbors).toHaveLength(2);
+      const names = result.neighbors.map((n) => n.name).sort();
+      expect(names).toEqual(["Cache", "Database"]);
+      expect(result.neighbors[0].shared_propositions).toBe(1);
+      expect(result.neighbors[0].valid_shared_propositions).toBe(1);
+    });
+
+    it("no neighbors for isolated entity", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([{ content: "Standalone exists.", entities: ["Standalone"], sources: ["a.ts"] }], C);
+      store.end();
+
+      const result = store.inspect("Standalone");
+      expect(result.neighbors).toHaveLength(0);
+    });
+
+    it("valid count drops when source goes stale", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([
+        { content: "Auth depends on Database.", entities: ["Auth", "Database"], sources: ["a.ts"] },
+      ], C);
+      store.end();
+
+      writeFile(tmpDir, "b.ts", "y");
+      store.registerSource("b.ts");
+      store.emit([
+        { content: "Auth also uses Database for caching.", entities: ["Auth", "Database"], sources: ["b.ts"] },
+      ], C);
+      store.end();
+
+      let result = store.inspect("Auth");
+      const db = result.neighbors.find((n) => n.name === "Database")!;
+      expect(db.shared_propositions).toBe(2);
+      expect(db.valid_shared_propositions).toBe(2);
+
+      writeFile(tmpDir, "a.ts", "changed");
+      result = store.inspect("Auth");
+      const db2 = result.neighbors.find((n) => n.name === "Database")!;
+      expect(db2.shared_propositions).toBe(2);
+      expect(db2.valid_shared_propositions).toBe(1);
+    });
+  });
+
+  describe("related", () => {
+    it("returns neighbors with sample propositions", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([
+        { content: "Auth depends on Database for user lookups.", entities: ["Auth", "Database"], sources: ["a.ts"] },
+        { content: "Auth uses Cache to store sessions.", entities: ["Auth", "Cache"], sources: ["a.ts"] },
+        { content: "Auth also queries Database for roles.", entities: ["Auth", "Database"], sources: ["a.ts"] },
+      ], C);
+      store.end();
+
+      const result = store.related("Auth");
+      expect(result.entity.name).toBe("Auth");
+      expect(result.neighbors).toHaveLength(2);
+
+      const db = result.neighbors.find((n) => n.name === "Database");
+      expect(db!.shared_propositions).toBe(2);
+      expect(db!.sample).toBeTruthy();
+
+      const cache = result.neighbors.find((n) => n.name === "Cache");
+      expect(cache!.shared_propositions).toBe(1);
+    });
+
+    it("throws for unknown entity", () => {
+      expect(() => store.related("nonexistent")).toThrow("Entity not found");
+    });
+  });
+
+  describe("collections", () => {
+    it("rejects unknown collection on emit", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      expect(() => store.emit([{ content: "Foo.", entities: ["Foo"], sources: ["a.ts"] }], "unknown"))
+        .toThrow('Unknown collection "unknown"');
+    });
+
+    it("same proposition in two collections creates two rows", () => {
+      const colStore = new MemoryStore(
+        path.join(tmpDir, "col.db"), tmpDir, [],
+        [
+          { name: "spec", description: "Specs", paths: [""] },
+          { name: "domain", description: "Domain", paths: [""] },
+        ]
+      );
+
+      writeFile(tmpDir, "a.ts", "x");
+      colStore.registerSource("a.ts");
+      colStore.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["a.ts"] }], "spec");
+      colStore.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["a.ts"] }], "domain");
+      colStore.end();
+
+      const status = colStore.status();
+      expect(status.total_propositions).toBe(2);
+      colStore.close();
+    });
+
+    it("deduplicates within the same collection", () => {
+      const colStore = new MemoryStore(
+        path.join(tmpDir, "col2.db"), tmpDir, [],
+        [{ name: "spec", description: "Specs", paths: [""] }]
+      );
+
+      writeFile(tmpDir, "a.ts", "x");
+      colStore.registerSource("a.ts");
+      const r1 = colStore.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["a.ts"] }], "spec");
+      const r2 = colStore.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["a.ts"] }], "spec");
+      expect(r1.created).toBe(1);
+      expect(r2.deduplicated).toBe(1);
+      colStore.end();
+      colStore.close();
+    });
+
+    it("browse with collection filter scopes results", () => {
+      const colStore = new MemoryStore(
+        path.join(tmpDir, "col3.db"), tmpDir, [],
+        [
+          { name: "spec", description: "Specs", paths: [""] },
+          { name: "domain", description: "Domain", paths: [""] },
+        ]
+      );
+
+      writeFile(tmpDir, "a.ts", "x");
+      colStore.registerSource("a.ts");
+      colStore.emit([{ content: "Auth validates.", entities: ["Auth"], sources: ["a.ts"] }], "spec");
+      colStore.emit([{ content: "DB stores.", entities: ["Database"], sources: ["a.ts"] }], "domain");
+      colStore.end();
+
+      const specResult = colStore.browse({ collection: "spec" });
+      expect(specResult.entities).toHaveLength(1);
+      expect(specResult.entities[0].name).toBe("Auth");
+
+      const allResult = colStore.browse();
+      expect(allResult.entities).toHaveLength(2);
+
+      colStore.close();
+    });
+
+    it("inspect with collection filter shows only that collection's propositions", () => {
+      const colStore = new MemoryStore(
+        path.join(tmpDir, "col4.db"), tmpDir, [],
+        [
+          { name: "spec", description: "Specs", paths: [""] },
+          { name: "domain", description: "Domain", paths: [""] },
+        ]
+      );
+
+      writeFile(tmpDir, "a.ts", "x");
+      colStore.registerSource("a.ts");
+      colStore.emit([{ content: "Auth spec claim.", entities: ["Auth"], sources: ["a.ts"] }], "spec");
+      colStore.emit([{ content: "Auth domain claim.", entities: ["Auth"], sources: ["a.ts"] }], "domain");
+      colStore.end();
+
+      const specResult = colStore.inspect("Auth", "spec");
+      expect(specResult.propositions).toHaveLength(1);
+      expect(specResult.propositions[0].content).toBe("Auth spec claim.");
+      expect(specResult.propositions[0].collection).toBe("spec");
+
+      const allResult = colStore.inspect("Auth");
+      expect(allResult.propositions).toHaveLength(2);
+
+      colStore.close();
+    });
+
+    it("search with collection filter scopes results", () => {
+      const colStore = new MemoryStore(
+        path.join(tmpDir, "col5.db"), tmpDir, [],
+        [
+          { name: "spec", description: "Specs", paths: [""] },
+          { name: "domain", description: "Domain", paths: [""] },
+        ]
+      );
+
+      writeFile(tmpDir, "a.ts", "x");
+      colStore.registerSource("a.ts");
+      colStore.emit([{ content: "Auth validates tokens.", entities: ["Auth"], sources: ["a.ts"] }], "spec");
+      colStore.emit([{ content: "Auth handles requests.", entities: ["Auth"], sources: ["a.ts"] }], "domain");
+      colStore.end();
+
+      const specResult = colStore.search("Auth", { collection: "spec" });
+      expect(specResult.propositions).toHaveLength(1);
+      expect(specResult.propositions[0].collection).toBe("spec");
+
+      const allResult = colStore.search("Auth");
+      expect(allResult.propositions).toHaveLength(2);
+
+      colStore.close();
+    });
+
+    it("status scoped to collection", () => {
+      const colStore = new MemoryStore(
+        path.join(tmpDir, "col6.db"), tmpDir, [],
+        [
+          { name: "spec", description: "Specs", paths: [""] },
+          { name: "domain", description: "Domain", paths: [""] },
+        ]
+      );
+
+      writeFile(tmpDir, "a.ts", "x");
+      colStore.registerSource("a.ts");
+      colStore.emit([{ content: "Spec prop.", entities: ["Spec"], sources: ["a.ts"] }], "spec");
+      colStore.emit([{ content: "Domain prop 1.", entities: ["Dom"], sources: ["a.ts"] }], "domain");
+      colStore.emit([{ content: "Domain prop 2.", entities: ["Dom"], sources: ["a.ts"] }], "domain");
+      colStore.end();
+
+      expect(colStore.status("spec").total_propositions).toBe(1);
+      expect(colStore.status("domain").total_propositions).toBe(2);
+      expect(colStore.status().total_propositions).toBe(3);
+
+      colStore.close();
+    });
+
+    it("default collection synthesized when none configured", () => {
+      const collections = store.getCollections();
+      expect(collections).toHaveLength(1);
+      expect(collections[0].name).toBe("default");
+    });
+
+    it("propositions include collection label in results", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.registerSource("a.ts");
+      store.emit([{ content: "Auth exists.", entities: ["Auth"], sources: ["a.ts"] }], C);
+      store.end();
+
+      const result = store.inspect("Auth");
+      expect(result.propositions[0].collection).toBe("default");
     });
   });
 });


### PR DESCRIPTION
## Summary

Consolidates three feature branches (`pr/entitykinds-and-nudges`, `memory/entity-graph-navigation`, `feat/memory-collections`) into a single cohesive change with design refinements from deliberation:

- **Collections**: named partitions for propositions. Required on `emit`, optional filter on all read methods (`browse`, `inspect`, `search`, `by_source`, `status`). Results include `collection` label so agents see knowledge provenance without pre-filtering.
- **Entity kinds**: optional `entityKinds` map on emit sets kind at entity creation time.
- **Entity graph navigation**: `findEntity` helper, `getNeighbors` with staleness-aware counts, `memory_related` tool, neighbors in `inspect` results.
- **FTS triggers**: keep search index in sync on insert/update/delete so search works immediately after emit (no server restart needed).
- **Summaries**: cut from entity-graph-navigation branch (deferred).

Also includes `specs/memory-dir-flag.md` — spec for a `--memory-dir` CLI flag to support persistent memory in plugin deployments.

Supersedes branches: `pr/entitykinds-and-nudges`, `memory/entity-graph-navigation`, `feat/memory-collections`

## Test plan

- [x] `npm run build` passes
- [x] 595 tests pass (15 new: collections, neighbors, related, entityKinds, FTS same-session search)
- [x] Dogfooded with live MCP server: compile workflow, emit to collections, staleness detection, search, related, browse across collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)