### PR TITLE
Restrict memory write tools to active memory workflow traversals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freelance-mcp",
-  "version": "1.1.3",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freelance-mcp",
-      "version": "1.1.3",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/graphlib": "^4.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -438,30 +438,21 @@ addWorkflowsOpt(configCmd
 program
   .command("memory-register <file>")
   .description("Register a file as a provenance source (used by Claude Code hooks)")
-  .option("--db <path>", "Path to memory database")
-  .option("--source-root <path>", "Source root for relative path storage")
-  .action(async (file, opts) => {
+  .action(async (file) => {
     const { MemoryStore } = await import("./memory/index.js");
     const { COMPILE_KNOWLEDGE_ID } = await import("./memory/workflow.js");
     const { RECOLLECTION_ID } = await import("./memory/recollection.js");
 
-    // Resolve memory config once — this is a hot path (fires on every Read)
-    let dbPath = opts.db as string | undefined;
-    let ignore: string[] | undefined;
-    let dirs: string[] | undefined;
-    if (!dbPath) {
-      dirs = resolveGraphsDirs();
-      const memConfig = resolveMemoryConfig(dirs, {});
-      if (!memConfig) {
-        // Memory disabled — silently exit.
-        process.exit(0);
-      }
-      dbPath = memConfig.db;
-      ignore = memConfig.ignore;
+    // Resolve config — this is a hot path (fires on every Read)
+    const dirs = resolveGraphsDirs();
+    const memConfig = resolveMemoryConfig(dirs, {});
+    if (!memConfig) {
+      // Memory disabled — silently exit.
+      process.exit(0);
     }
 
     // Gate: only register files when a memory traversal is active
-    const stateDbPath = resolveStateDb(dirs ?? resolveGraphsDirs());
+    const stateDbPath = resolveStateDb(dirs);
     try {
       const { openStateDatabase } = await import("./state/index.js");
       const stateDb = openStateDatabase(stateDbPath);
@@ -479,9 +470,9 @@ program
       process.exit(0);
     }
 
-    const sourceRoot = opts.sourceRoot ?? process.cwd();
+    const sourceRoot = process.cwd();
     try {
-      const store = new MemoryStore(dbPath, sourceRoot, ignore);
+      const store = new MemoryStore(memConfig.db, sourceRoot, memConfig.ignore);
       const result = store.registerSource(file);
       store.close();
       if (!program.opts().quiet) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,12 +442,15 @@ program
   .option("--source-root <path>", "Source root for relative path storage")
   .action(async (file, opts) => {
     const { MemoryStore } = await import("./memory/index.js");
+    const { COMPILE_KNOWLEDGE_ID } = await import("./memory/workflow.js");
+    const { RECOLLECTION_ID } = await import("./memory/recollection.js");
 
     // Resolve memory config once — this is a hot path (fires on every Read)
     let dbPath = opts.db as string | undefined;
     let ignore: string[] | undefined;
-    const dirs = resolveGraphsDirs();
+    let dirs: string[] | undefined;
     if (!dbPath) {
+      dirs = resolveGraphsDirs();
       const memConfig = resolveMemoryConfig(dirs, {});
       if (!memConfig) {
         // Memory disabled — silently exit.
@@ -458,13 +461,14 @@ program
     }
 
     // Gate: only register files when a memory traversal is active
-    const stateDbPath = resolveStateDb(dirs);
+    const stateDbPath = resolveStateDb(dirs ?? resolveGraphsDirs());
     try {
       const { openStateDatabase } = await import("./state/index.js");
       const stateDb = openStateDatabase(stateDbPath);
+      const placeholders = [COMPILE_KNOWLEDGE_ID, RECOLLECTION_ID].map(() => "?").join(", ");
       const row = stateDb.prepare(
-        "SELECT 1 FROM traversals WHERE graph_id IN ('memory:compile', 'memory:recall') LIMIT 1"
-      ).get();
+        `SELECT 1 FROM traversals WHERE graph_id IN (${placeholders}) LIMIT 1`
+      ).get(COMPILE_KNOWLEDGE_ID, RECOLLECTION_ID);
       stateDb.close();
       if (!row) {
         // No active memory traversal — silently exit.

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,8 +446,8 @@ program
     // Resolve memory config once — this is a hot path (fires on every Read)
     let dbPath = opts.db as string | undefined;
     let ignore: string[] | undefined;
+    const dirs = resolveGraphsDirs();
     if (!dbPath) {
-      const dirs = resolveGraphsDirs();
       const memConfig = resolveMemoryConfig(dirs, {});
       if (!memConfig) {
         // Memory disabled — silently exit.
@@ -455,6 +455,24 @@ program
       }
       dbPath = memConfig.db;
       ignore = memConfig.ignore;
+    }
+
+    // Gate: only register files when a memory traversal is active
+    const stateDbPath = resolveStateDb(dirs);
+    try {
+      const { openStateDatabase } = await import("./state/index.js");
+      const stateDb = openStateDatabase(stateDbPath);
+      const row = stateDb.prepare(
+        "SELECT 1 FROM traversals WHERE graph_id IN ('memory:compile', 'memory:recall') LIMIT 1"
+      ).get();
+      stateDb.close();
+      if (!row) {
+        // No active memory traversal — silently exit.
+        process.exit(0);
+      }
+    } catch {
+      // State DB unavailable — silently exit.
+      process.exit(0);
     }
 
     const sourceRoot = opts.sourceRoot ?? process.cwd();

--- a/src/memory/tools.ts
+++ b/src/memory/tools.ts
@@ -14,8 +14,21 @@ function handleError(e: unknown) {
   return errorResponse(message);
 }
 
-export function registerMemoryTools(server: McpServer, store: MemoryStore): void {
-  // --- Write ---
+export function registerMemoryTools(
+  server: McpServer,
+  store: MemoryStore,
+  hasActiveMemoryTraversal?: () => boolean,
+): void {
+  const TRAVERSAL_REQUIRED =
+    "Memory write tools require an active memory workflow traversal. Start a memory:compile or memory:recall traversal first.";
+
+  function requireMemoryTraversal(): string | undefined {
+    if (hasActiveMemoryTraversal && !hasActiveMemoryTraversal()) {
+      return TRAVERSAL_REQUIRED;
+    }
+  }
+
+  // --- Write (gated by active memory traversal) ---
 
   server.tool(
     "memory_register_source",
@@ -28,6 +41,8 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
     },
     ({ file_path }) => {
       try {
+        const blocked = requireMemoryTraversal();
+        if (blocked) return errorResponse(blocked);
         const paths = Array.isArray(file_path) ? file_path : [file_path];
         const results = paths.map(p => store.registerSource(p));
         return jsonResponse(results.length === 1 ? results[0] : results);
@@ -51,6 +66,8 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
     },
     ({ collection, propositions }) => {
       try {
+        const blocked = requireMemoryTraversal();
+        if (blocked) return errorResponse(blocked);
         return jsonResponse(store.emit(propositions, collection));
       } catch (e) {
         return handleError(e);
@@ -64,6 +81,8 @@ export function registerMemoryTools(server: McpServer, store: MemoryStore): void
     {},
     () => {
       try {
+        const blocked = requireMemoryTraversal();
+        if (blocked) return errorResponse(blocked);
         return jsonResponse(store.end());
       } catch (e) {
         return handleError(e);

--- a/src/server.ts
+++ b/src/server.ts
@@ -433,7 +433,9 @@ export function createServer(
   // --- Memory ---
   if (options?.memory?.enabled !== false && options?.memory?.db) {
     memoryStore = new MemoryStore(options.memory.db, options.sourceRoot, options.memory.ignore, options.memory.collections);
-    registerMemoryTools(server, memoryStore);
+    const hasActiveMemoryTraversal = () =>
+      manager.hasActiveTraversalForGraph(COMPILE_KNOWLEDGE_ID, RECOLLECTION_ID);
+    registerMemoryTools(server, memoryStore, hasActiveMemoryTraversal);
 
     // Inject sealed memory workflows
     let injected = false;

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -201,6 +201,16 @@ export class TraversalStore {
     );
   }
 
+  /** Check whether any active traversal belongs to one of the given graph IDs. */
+  hasActiveTraversalForGraph(...graphIds: string[]): boolean {
+    if (graphIds.length === 0) return false;
+    const placeholders = graphIds.map(() => "?").join(", ");
+    const row = this.db.prepare(
+      `SELECT 1 FROM traversals WHERE graph_id IN (${placeholders}) LIMIT 1`
+    ).get(...graphIds);
+    return row !== undefined;
+  }
+
   // --- Engine load/save ---
 
   private loadEngine(traversalId: string): GraphEngine {

--- a/test/cli-memory-register.test.ts
+++ b/test/cli-memory-register.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the memory-register CLI command's traversal gate.
+ *
+ * The CLI command opens the state DB and checks for active memory traversals
+ * using a raw SQL query. These tests verify that query logic works correctly
+ * against real SQLite state — the same DB schema and constants used by the CLI.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openStateDatabase } from "../src/state/index.js";
+import { COMPILE_KNOWLEDGE_ID } from "../src/memory/workflow.js";
+import { RECOLLECTION_ID } from "../src/memory/recollection.js";
+
+/**
+ * Mirrors the query used in `src/index.ts` memory-register command.
+ * Tests that the SQL + constants correctly detect active memory traversals.
+ */
+function hasActiveMemoryTraversal(stateDbPath: string): boolean {
+  const stateDb = openStateDatabase(stateDbPath);
+  const graphIds = [COMPILE_KNOWLEDGE_ID, RECOLLECTION_ID];
+  const placeholders = graphIds.map(() => "?").join(", ");
+  const row = stateDb.prepare(
+    `SELECT 1 FROM traversals WHERE graph_id IN (${placeholders}) LIMIT 1`
+  ).get(...graphIds);
+  stateDb.close();
+  return row !== undefined;
+}
+
+describe("memory-register traversal gate (SQL query)", () => {
+  let tmpDir: string;
+  let stateDbPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mem-reg-gate-"));
+    stateDbPath = path.join(tmpDir, "state.db");
+    // Create the state DB with schema
+    const db = openStateDatabase(stateDbPath);
+    db.close();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false when no traversals exist", () => {
+    expect(hasActiveMemoryTraversal(stateDbPath)).toBe(false);
+  });
+
+  it("returns true with active memory:compile traversal", () => {
+    const db = openStateDatabase(stateDbPath);
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO traversals (id, stack, graph_id, current_node, stack_depth, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run("tr_test0001", "[]", COMPILE_KNOWLEDGE_ID, "exploring", 1, now, now);
+    db.close();
+
+    expect(hasActiveMemoryTraversal(stateDbPath)).toBe(true);
+  });
+
+  it("returns true with active memory:recall traversal", () => {
+    const db = openStateDatabase(stateDbPath);
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO traversals (id, stack, graph_id, current_node, stack_depth, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run("tr_test0002", "[]", RECOLLECTION_ID, "recalling", 1, now, now);
+    db.close();
+
+    expect(hasActiveMemoryTraversal(stateDbPath)).toBe(true);
+  });
+
+  it("returns false with only non-memory traversals active", () => {
+    const db = openStateDatabase(stateDbPath);
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO traversals (id, stack, graph_id, current_node, stack_depth, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+    ).run("tr_test0003", "[]", "some-other-workflow", "step1", 1, now, now);
+    db.close();
+
+    expect(hasActiveMemoryTraversal(stateDbPath)).toBe(false);
+  });
+
+  it("uses correct constant values for graph IDs", () => {
+    expect(COMPILE_KNOWLEDGE_ID).toBe("memory:compile");
+    expect(RECOLLECTION_ID).toBe("memory:recall");
+  });
+});

--- a/test/memory-tools.test.ts
+++ b/test/memory-tools.test.ts
@@ -75,7 +75,60 @@ describe("Memory MCP tools", () => {
     ]);
   });
 
-  it("full compilation flow via MCP tools", async () => {
+  it("write tools blocked without active memory traversal", async () => {
+    // memory_register_source should be blocked
+    const regResult = await client.callTool({
+      name: "memory_register_source",
+      arguments: { file_path: "auth.ts" },
+    });
+    expect(regResult.isError).toBeTruthy();
+    const regErr = parseContent(regResult) as { error: string };
+    expect(regErr.error).toContain("active memory workflow traversal");
+
+    // memory_emit should be blocked
+    const emitResult = await client.callTool({
+      name: "memory_emit",
+      arguments: {
+        collection: "default",
+        propositions: [{ content: "test", entities: ["Foo"], sources: ["a.ts"] }],
+      },
+    });
+    expect(emitResult.isError).toBeTruthy();
+    const emitErr = parseContent(emitResult) as { error: string };
+    expect(emitErr.error).toContain("active memory workflow traversal");
+
+    // memory_end should be blocked
+    const endResult = await client.callTool({ name: "memory_end", arguments: {} });
+    expect(endResult.isError).toBeTruthy();
+    const endErr = parseContent(endResult) as { error: string };
+    expect(endErr.error).toContain("active memory workflow traversal");
+  });
+
+  it("read tools available without active memory traversal", async () => {
+    // Browse should work without a traversal
+    const browseResult = await client.callTool({ name: "memory_browse", arguments: {} });
+    expect(browseResult.isError).toBeFalsy();
+
+    // Status should work without a traversal
+    const statusResult = await client.callTool({ name: "memory_status", arguments: {} });
+    expect(statusResult.isError).toBeFalsy();
+
+    // Search should work without a traversal
+    const searchResult = await client.callTool({
+      name: "memory_search",
+      arguments: { query: "test" },
+    });
+    expect(searchResult.isError).toBeFalsy();
+  });
+
+  it("full compilation flow via MCP tools (with active traversal)", async () => {
+    // Start a memory:compile traversal first
+    const startResult = await client.callTool({
+      name: "freelance_start",
+      arguments: { graphId: "memory:compile" },
+    });
+    expect(startResult.isError).toBeFalsy();
+
     // Register source — session created lazily
     const regResult = await client.callTool({
       name: "memory_register_source",
@@ -134,7 +187,13 @@ describe("Memory MCP tools", () => {
     expect(status.valid_propositions).toBe(2);
   });
 
-  it("emit rejected without registered source", async () => {
+  it("emit rejected without registered source (within active traversal)", async () => {
+    // Start memory traversal
+    await client.callTool({
+      name: "freelance_start",
+      arguments: { graphId: "memory:compile" },
+    });
+
     const emitResult = await client.callTool({
       name: "memory_emit",
       arguments: { collection: "default", propositions: [{ content: "test", entities: ["Foo"], sources: ["a.ts"] }] },

--- a/test/traversal-store.test.ts
+++ b/test/traversal-store.test.ts
@@ -177,4 +177,34 @@ describe("TraversalStore — stateless SQLite", () => {
       store = new TraversalStore(openStateDatabase(path.join(tmpDir, "state.db")), graphs);
     });
   });
+
+  describe("hasActiveTraversalForGraph", () => {
+    it("returns false when no traversals exist", () => {
+      expect(store.hasActiveTraversalForGraph("valid-simple")).toBe(false);
+    });
+
+    it("returns true when a matching traversal exists", () => {
+      store.createTraversal("valid-simple");
+      expect(store.hasActiveTraversalForGraph("valid-simple")).toBe(true);
+      expect(store.hasActiveTraversalForGraph("valid-branching")).toBe(false);
+    });
+
+    it("accepts multiple graph IDs", () => {
+      store.createTraversal("valid-branching");
+      expect(store.hasActiveTraversalForGraph("valid-simple", "valid-branching")).toBe(true);
+      expect(store.hasActiveTraversalForGraph("nonexistent", "also-nonexistent")).toBe(false);
+    });
+
+    it("returns false after traversal is reset", () => {
+      const t = store.createTraversal("valid-simple");
+      expect(store.hasActiveTraversalForGraph("valid-simple")).toBe(true);
+      store.resetTraversal(t.traversalId);
+      expect(store.hasActiveTraversalForGraph("valid-simple")).toBe(false);
+    });
+
+    it("returns false for empty graphIds", () => {
+      store.createTraversal("valid-simple");
+      expect(store.hasActiveTraversalForGraph()).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
memory_register_source, memory_emit, and memory_end now require an active
memory:compile or memory:recall traversal. Read tools remain unrestricted.
Also gates the memory-register CLI hook behind the same traversal check.

https://claude.ai/code/session_017vBSEcUUN91A4VdtvU3LSm