### PR TITLE
fix(server): close orphan-process gap in parent-disconnect watchdog

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,50 @@ export interface ServerOptions {
   hookTimeoutMs?: number;
 }
 
+/**
+ * Watch for the startup-time parent process going away and invoke `onExit`
+ * when it does. Returns the interval handle (for clearInterval in shutdown),
+ * or undefined if there's nothing meaningful to watch.
+ *
+ * Two detectors run on every tick, cheapest first:
+ *
+ *   1. **ppid drift.** When the original parent dies, the kernel reparents
+ *      us to init or a subreaper, so `process.ppid` changes atomically. This
+ *      is stronger than the existence probe: it's immune to PID recycling
+ *      and it catches the case where we're reparented to PID 1 (which never
+ *      dies, so `kill(1, 0)` always succeeds).
+ *
+ *   2. **Existence probe.** `kill(ppid, 0)` is the documented Node idiom for
+ *      "is this process alive" — throws ESRCH when the target is gone.
+ *      Kept as belt-and-braces for exotic schedulers where drift might lag.
+ *
+ * Skipped entirely when `initialPpid <= 1`: either we were already orphaned
+ * at startup or the launcher intentionally detached us, in which case there
+ * is no parent to watch.
+ */
+export function startParentHeartbeat(
+  initialPpid: number,
+  onExit: (reason: "parent-exited" | "parent-reparented") => void,
+  intervalMs = 2000,
+): NodeJS.Timeout | undefined {
+  if (initialPpid <= 1) return undefined;
+  const timer = setInterval(() => {
+    if (process.ppid !== initialPpid) {
+      onExit("parent-reparented");
+      return;
+    }
+    try {
+      process.kill(initialPpid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+        onExit("parent-exited");
+      }
+    }
+  }, intervalMs);
+  timer.unref();
+  return timer;
+}
+
 export function createServer(
   graphs: Map<string, ValidatedGraph>,
   options?: ServerOptions,
@@ -196,24 +240,10 @@ export async function startServer(
   // orphaned hook shells): the kernel keeps the pipe open until *every*
   // write-end fd is closed, so stdin never hits EOF. Poll the original
   // parent instead. Snapshot ppid now — once orphaned the kernel reparents
-  // us to init (PID 1), and PID 1 never dies. `kill(pid, 0)` is a
-  // permission/existence probe that throws ESRCH when the target is gone.
-  // Skip the heartbeat if we're already orphaned at startup (ppid=1), which
-  // means either there's no real parent to watch or the daemon was launched
-  // detached on purpose.
-  const initialPpid = process.ppid;
-  if (initialPpid > 1) {
-    parentHeartbeat = setInterval(() => {
-      try {
-        process.kill(initialPpid, 0);
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === "ESRCH") {
-          shutdown("parent-exited");
-        }
-      }
-    }, 5000);
-    parentHeartbeat.unref();
-  }
+  // us to init (PID 1) or a subreaper, so a later read of process.ppid
+  // points at the wrong target. Skip the heartbeat if we're already
+  // orphaned at startup (ppid=1): there's no real parent to watch.
+  parentHeartbeat = startParentHeartbeat(process.ppid, (reason) => shutdown(reason));
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,8 +33,8 @@ export interface ServerOptions {
 
 /**
  * Watch for the startup-time parent process going away and invoke `onExit`
- * when it does. Returns the interval handle (for clearInterval in shutdown),
- * or undefined if there's nothing meaningful to watch.
+ * when it does. Returns a `stop` function for cleanup; calling stop is
+ * always safe (no-op when there was nothing to watch).
  *
  * Two detectors run on every tick, cheapest first:
  *
@@ -48,23 +48,24 @@ export interface ServerOptions {
  *      "is this process alive" — throws ESRCH when the target is gone.
  *      Kept as belt-and-braces for exotic schedulers where drift might lag.
  *
- * Skipped entirely when `initialPpid <= 1`: either we were already orphaned
- * at startup or the launcher intentionally detached us, in which case there
- * is no parent to watch.
+ * No-op when `ppid <= 1`: either we were already orphaned at startup or the
+ * launcher intentionally detached us, in which case there is no parent to
+ * watch.
  */
-export function startParentHeartbeat(
-  initialPpid: number,
-  onExit: (reason: "parent-exited" | "parent-reparented") => void,
-  intervalMs = 2000,
-): NodeJS.Timeout | undefined {
-  if (initialPpid <= 1) return undefined;
+export function startParentHeartbeat(opts: {
+  ppid: number;
+  onExit: (reason: "parent-exited" | "parent-reparented") => void;
+  intervalMs?: number;
+}): () => void {
+  const { ppid, onExit, intervalMs = 2000 } = opts;
+  if (ppid <= 1) return () => {};
   const timer = setInterval(() => {
-    if (process.ppid !== initialPpid) {
+    if (process.ppid !== ppid) {
       onExit("parent-reparented");
       return;
     }
     try {
-      process.kill(initialPpid, 0);
+      process.kill(ppid, 0);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ESRCH") {
         onExit("parent-exited");
@@ -72,7 +73,7 @@ export function startParentHeartbeat(
     }
   }, intervalMs);
   timer.unref();
-  return timer;
+  return () => clearInterval(timer);
 }
 
 export function createServer(
@@ -173,11 +174,11 @@ export async function startServer(
   process.stderr.write(`freelance-mcp ${VERSION} started pid=${process.pid}\n`);
 
   let shuttingDown = false;
-  let parentHeartbeat: NodeJS.Timeout | undefined;
+  let stopHeartbeat: () => void = () => {};
   const shutdown = (reason: string, exitCode = 0) => {
     if (shuttingDown) return;
     shuttingDown = true;
-    if (parentHeartbeat) clearInterval(parentHeartbeat);
+    stopHeartbeat();
     process.stderr.write(`freelance-mcp shutdown pid=${process.pid} reason=${reason}\n`);
     void (async () => {
       try {
@@ -235,23 +236,15 @@ export async function startServer(
     }
   });
 
-  // Parent-PID heartbeat. Pipe-close signals are unreliable when a chain of
-  // stdio-inheriting descendants outlives the parent (npx middleman,
-  // orphaned hook shells): the kernel keeps the pipe open until *every*
-  // write-end fd is closed, so stdin never hits EOF. Poll the original
-  // parent instead. Snapshot ppid now — once orphaned the kernel reparents
-  // us to init (PID 1) or a subreaper, so a later read of process.ppid
-  // points at the wrong target. Skip the heartbeat if we're already
-  // orphaned at startup (ppid=1): there's no real parent to watch.
-  parentHeartbeat = startParentHeartbeat(process.ppid, (reason) => shutdown(reason));
+  // Snapshot ppid before connect — kernel reparents an orphaned process to
+  // init/subreaper, so reading later gives the wrong target.
+  stopHeartbeat = startParentHeartbeat({ ppid: process.ppid, onExit: shutdown });
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
-  // Safety net for the ordering fix above: if stdin drained and ended
-  // synchronously inside connect(), our `end` listener already fired and
-  // shutdown is in flight — this is a no-op. If for any reason the event
-  // was missed, this catches it before we return control to the event loop.
+  // If stdin drained and ended synchronously inside connect(), our `end`
+  // listener already fired and shutdown is in flight — this is a no-op.
   if (process.stdin.readableEnded) {
     shutdown("stdin-ended-early");
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,8 +119,6 @@ export async function startServer(
   options?: ServerOptions,
 ): Promise<void> {
   const { server, stopWatcher, runtime } = createServer(graphs, options);
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
 
   // Lifecycle breadcrumbs on stderr. By MCP stdio convention, stderr is
   // forwarded to the client's MCP log and not shown to the user. A matching
@@ -131,9 +129,11 @@ export async function startServer(
   process.stderr.write(`freelance-mcp ${VERSION} started pid=${process.pid}\n`);
 
   let shuttingDown = false;
+  let parentHeartbeat: NodeJS.Timeout | undefined;
   const shutdown = (reason: string, exitCode = 0) => {
     if (shuttingDown) return;
     shuttingDown = true;
+    if (parentHeartbeat) clearInterval(parentHeartbeat);
     process.stderr.write(`freelance-mcp shutdown pid=${process.pid} reason=${reason}\n`);
     void (async () => {
       try {
@@ -173,6 +173,11 @@ export async function startServer(
   //
   //   - `end`/`close`: clean EOF (parent closed its write end)
   //   - `error` with EBADF/EPIPE: fd revoked (macOS terminal close)
+  //
+  // Register BEFORE server.connect() — connect() is what puts stdin into
+  // flowing mode via the SDK's `data` listener, and `end` fires exactly
+  // once. If EOF lands while connect() is awaiting, a listener attached
+  // after would miss it permanently.
   process.stdin.on("end", () => shutdown("stdin-end"));
   process.stdin.on("close", () => shutdown("stdin-close"));
   process.stdin.on("error", (err: NodeJS.ErrnoException) => {
@@ -185,4 +190,39 @@ export async function startServer(
       shutdown(`stdout-${err.code.toLowerCase()}`);
     }
   });
+
+  // Parent-PID heartbeat. Pipe-close signals are unreliable when a chain of
+  // stdio-inheriting descendants outlives the parent (npx middleman,
+  // orphaned hook shells): the kernel keeps the pipe open until *every*
+  // write-end fd is closed, so stdin never hits EOF. Poll the original
+  // parent instead. Snapshot ppid now — once orphaned the kernel reparents
+  // us to init (PID 1), and PID 1 never dies. `kill(pid, 0)` is a
+  // permission/existence probe that throws ESRCH when the target is gone.
+  // Skip the heartbeat if we're already orphaned at startup (ppid=1), which
+  // means either there's no real parent to watch or the daemon was launched
+  // detached on purpose.
+  const initialPpid = process.ppid;
+  if (initialPpid > 1) {
+    parentHeartbeat = setInterval(() => {
+      try {
+        process.kill(initialPpid, 0);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+          shutdown("parent-exited");
+        }
+      }
+    }, 5000);
+    parentHeartbeat.unref();
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Safety net for the ordering fix above: if stdin drained and ended
+  // synchronously inside connect(), our `end` listener already fired and
+  // shutdown is in flight — this is a no-op. If for any reason the event
+  // was missed, this catches it before we return control to the event loop.
+  if (process.stdin.readableEnded) {
+    shutdown("stdin-ended-early");
+  }
 }

--- a/test/parent-heartbeat.test.ts
+++ b/test/parent-heartbeat.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startParentHeartbeat } from "../src/server.js";
+
+const tick = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe("startParentHeartbeat", () => {
+  const timers: NodeJS.Timeout[] = [];
+
+  afterEach(() => {
+    while (timers.length) {
+      const t = timers.pop();
+      if (t) clearInterval(t);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns undefined when initialPpid <= 1 (nothing to watch)", () => {
+    expect(startParentHeartbeat(0, () => {})).toBeUndefined();
+    expect(startParentHeartbeat(1, () => {})).toBeUndefined();
+  });
+
+  it("does not fire when the original parent is alive and ppid is stable", async () => {
+    const onExit = vi.fn();
+    const timer = startParentHeartbeat(process.ppid, onExit, 10);
+    if (timer) timers.push(timer);
+    await tick(60);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("fires 'parent-exited' when the existence probe throws ESRCH", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err: NodeJS.ErrnoException = new Error("no such process");
+      err.code = "ESRCH";
+      throw err;
+    });
+    const onExit = vi.fn();
+    const timer = startParentHeartbeat(process.ppid, onExit, 10);
+    if (timer) timers.push(timer);
+    await tick(60);
+    expect(onExit).toHaveBeenCalledWith("parent-exited");
+  });
+
+  it("ignores non-ESRCH kill errors (e.g. EPERM)", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      const err: NodeJS.ErrnoException = new Error("operation not permitted");
+      err.code = "EPERM";
+      throw err;
+    });
+    const onExit = vi.fn();
+    const timer = startParentHeartbeat(process.ppid, onExit, 10);
+    if (timer) timers.push(timer);
+    await tick(60);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("fires 'parent-reparented' when process.ppid drifts from the snapshot", async () => {
+    const ppidDesc = Object.getOwnPropertyDescriptor(process, "ppid");
+    Object.defineProperty(process, "ppid", {
+      get: () => 1,
+      configurable: true,
+    });
+    try {
+      const onExit = vi.fn();
+      const timer = startParentHeartbeat(99999, onExit, 10);
+      if (timer) timers.push(timer);
+      await tick(60);
+      expect(onExit).toHaveBeenCalledWith("parent-reparented");
+    } finally {
+      if (ppidDesc) Object.defineProperty(process, "ppid", ppidDesc);
+    }
+  });
+
+  it("prefers drift detection over the kill probe (no kill call on drift)", async () => {
+    const killSpy = vi.spyOn(process, "kill");
+    const ppidDesc = Object.getOwnPropertyDescriptor(process, "ppid");
+    Object.defineProperty(process, "ppid", {
+      get: () => 1,
+      configurable: true,
+    });
+    try {
+      const onExit = vi.fn();
+      const timer = startParentHeartbeat(99999, onExit, 10);
+      if (timer) timers.push(timer);
+      await tick(60);
+      expect(onExit).toHaveBeenCalledWith("parent-reparented");
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      if (ppidDesc) Object.defineProperty(process, "ppid", ppidDesc);
+    }
+  });
+});

--- a/test/parent-heartbeat.test.ts
+++ b/test/parent-heartbeat.test.ts
@@ -4,25 +4,27 @@ import { startParentHeartbeat } from "../src/server.js";
 const tick = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 describe("startParentHeartbeat", () => {
-  const timers: NodeJS.Timeout[] = [];
+  let stop: (() => void) | undefined;
 
   afterEach(() => {
-    while (timers.length) {
-      const t = timers.pop();
-      if (t) clearInterval(t);
-    }
+    if (stop) stop();
+    stop = undefined;
     vi.restoreAllMocks();
   });
 
-  it("returns undefined when initialPpid <= 1 (nothing to watch)", () => {
-    expect(startParentHeartbeat(0, () => {})).toBeUndefined();
-    expect(startParentHeartbeat(1, () => {})).toBeUndefined();
+  it("does nothing when ppid <= 1 (nothing to watch)", async () => {
+    const onExit = vi.fn();
+    const stop1 = startParentHeartbeat({ ppid: 0, onExit, intervalMs: 10 });
+    const stop2 = startParentHeartbeat({ ppid: 1, onExit, intervalMs: 10 });
+    await tick(60);
+    stop1();
+    stop2();
+    expect(onExit).not.toHaveBeenCalled();
   });
 
   it("does not fire when the original parent is alive and ppid is stable", async () => {
     const onExit = vi.fn();
-    const timer = startParentHeartbeat(process.ppid, onExit, 10);
-    if (timer) timers.push(timer);
+    stop = startParentHeartbeat({ ppid: process.ppid, onExit, intervalMs: 10 });
     await tick(60);
     expect(onExit).not.toHaveBeenCalled();
   });
@@ -34,8 +36,7 @@ describe("startParentHeartbeat", () => {
       throw err;
     });
     const onExit = vi.fn();
-    const timer = startParentHeartbeat(process.ppid, onExit, 10);
-    if (timer) timers.push(timer);
+    stop = startParentHeartbeat({ ppid: process.ppid, onExit, intervalMs: 10 });
     await tick(60);
     expect(onExit).toHaveBeenCalledWith("parent-exited");
   });
@@ -47,22 +48,17 @@ describe("startParentHeartbeat", () => {
       throw err;
     });
     const onExit = vi.fn();
-    const timer = startParentHeartbeat(process.ppid, onExit, 10);
-    if (timer) timers.push(timer);
+    stop = startParentHeartbeat({ ppid: process.ppid, onExit, intervalMs: 10 });
     await tick(60);
     expect(onExit).not.toHaveBeenCalled();
   });
 
   it("fires 'parent-reparented' when process.ppid drifts from the snapshot", async () => {
     const ppidDesc = Object.getOwnPropertyDescriptor(process, "ppid");
-    Object.defineProperty(process, "ppid", {
-      get: () => 1,
-      configurable: true,
-    });
+    Object.defineProperty(process, "ppid", { get: () => 1, configurable: true });
     try {
       const onExit = vi.fn();
-      const timer = startParentHeartbeat(99999, onExit, 10);
-      if (timer) timers.push(timer);
+      stop = startParentHeartbeat({ ppid: 99999, onExit, intervalMs: 10 });
       await tick(60);
       expect(onExit).toHaveBeenCalledWith("parent-reparented");
     } finally {
@@ -73,14 +69,10 @@ describe("startParentHeartbeat", () => {
   it("prefers drift detection over the kill probe (no kill call on drift)", async () => {
     const killSpy = vi.spyOn(process, "kill");
     const ppidDesc = Object.getOwnPropertyDescriptor(process, "ppid");
-    Object.defineProperty(process, "ppid", {
-      get: () => 1,
-      configurable: true,
-    });
+    Object.defineProperty(process, "ppid", { get: () => 1, configurable: true });
     try {
       const onExit = vi.fn();
-      const timer = startParentHeartbeat(99999, onExit, 10);
-      if (timer) timers.push(timer);
+      stop = startParentHeartbeat({ ppid: 99999, onExit, intervalMs: 10 });
       await tick(60);
       expect(onExit).toHaveBeenCalledWith("parent-reparented");
       expect(killSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Pipe-close signals (stdin end/close/error, stdout EPIPE) miss two
real-world orphan paths: an npx/shell chain holding the write-end fd
open after the true parent exits, and a race where EOF lands while
server.connect() is awaiting and the end listener has not attached
yet.

Add a 5s parent-PID heartbeat (kill(ppid, 0); ESRCH triggers shutdown)
that catches the held-pipe case regardless of stdin state. Snapshot
ppid at startup since orphaned processes reparent to PID 1. Register
stdin listeners before server.connect() and check readableEnded after,
so an EOF during connect() cannot slip past. The heartbeat is unref-ed
so it does not keep the event loop alive on its own.