### PR TITLE
fix(watcher): scope watch tree to avoid Windows WAL-churn CPU pin

### DIFF
--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { CollectingLoadResult } from "./loader.js";
 import { loadGraphsCollecting } from "./loader.js";
 import type { ValidatedGraph } from "./types.js";
@@ -19,10 +20,25 @@ interface WatcherOptions {
 }
 
 /**
+ * Immediate-child subdirectories of each graphsDir that hold high-churn
+ * runtime data (SQLite WAL frames, per-traversal JSON files). Excluded from
+ * the watch tree: on Windows, recursive ReadDirectoryChangesW can pin a CPU
+ * core when WAL writes flood the internal event buffer. Scoped to direct
+ * children only — a nested `memory/` inside a user-authored domain folder
+ * is unusual and not special-cased.
+ */
+const RUNTIME_SUBDIRS: ReadonlySet<string> = new Set(["memory", "traversals"]);
+
+/**
  * Watch directory(ies) for graph file changes and reload on modification.
  *
- * Uses fs.watch with debounce. On any change to *.workflow.yaml files,
- * re-reads all directories, validates, and calls onUpdate.
+ * Each graphsDir is watched non-recursively for top-level changes, and each
+ * existing immediate subdirectory (except RUNTIME_SUBDIRS) is watched
+ * recursively so nested `*.workflow.yaml` files still hot-reload. New
+ * top-level subdirs created after startup are armed with a recursive
+ * watcher when their creation event lands on the top-level watcher — files
+ * created inside a brand-new subdir before that arm completes are not
+ * guaranteed to trigger a reload; restart the server to pick them up.
  *
  * Note: fs.watch behavior varies by platform. On Linux (inotify) it is
  * reliable. On macOS (FSEvents) it may fire duplicate or miss events.
@@ -49,18 +65,61 @@ export function watchGraphs(options: WatcherOptions): () => void {
     }
   }
 
-  const watchers = dirs.map((dir) =>
-    fs.watch(dir, { recursive: true }, (_eventType, filename) => {
-      if (!filename) return;
-      if ((filename === "config.yml" || filename === "config.local.yml") && onConfigChange) {
-        if (configDebounce) clearTimeout(configDebounce);
-        configDebounce = setTimeout(() => onConfigChange(dir), debounceMs);
-      } else if (filename.endsWith(".workflow.yaml")) {
-        if (graphDebounce) clearTimeout(graphDebounce);
-        graphDebounce = setTimeout(reload, debounceMs);
-      }
-    }),
-  );
+  function scheduleReload() {
+    if (graphDebounce) clearTimeout(graphDebounce);
+    graphDebounce = setTimeout(reload, debounceMs);
+  }
+
+  const watchers: fs.FSWatcher[] = [];
+  const watchedSubdirs = new Set<string>();
+
+  function armSubdirWatcher(subdirPath: string) {
+    if (watchedSubdirs.has(subdirPath)) return;
+    watchedSubdirs.add(subdirPath);
+    watchers.push(
+      fs.watch(subdirPath, { recursive: true }, (_eventType, filename) => {
+        if (filename?.endsWith(".workflow.yaml")) scheduleReload();
+      }),
+    );
+  }
+
+  function handleTopLevel(dir: string, filename: string | null) {
+    if (!filename) return;
+    if ((filename === "config.yml" || filename === "config.local.yml") && onConfigChange) {
+      if (configDebounce) clearTimeout(configDebounce);
+      configDebounce = setTimeout(() => onConfigChange(dir), debounceMs);
+      return;
+    }
+    if (filename.endsWith(".workflow.yaml")) {
+      scheduleReload();
+      return;
+    }
+    if (RUNTIME_SUBDIRS.has(filename)) return;
+    const full = path.join(dir, filename);
+    if (watchedSubdirs.has(full)) return;
+    try {
+      if (!fs.statSync(full).isDirectory()) return;
+    } catch {
+      return;
+    }
+    armSubdirWatcher(full);
+  }
+
+  for (const dir of dirs) {
+    watchers.push(fs.watch(dir, (_eventType, filename) => handleTopLevel(dir, filename)));
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (RUNTIME_SUBDIRS.has(entry.name)) continue;
+      armSubdirWatcher(path.join(dir, entry.name));
+    }
+  }
 
   return () => {
     if (graphDebounce) clearTimeout(graphDebounce);

--- a/test/watcher.test.ts
+++ b/test/watcher.test.ts
@@ -133,6 +133,78 @@ describe("Graph watcher", () => {
     expect(updateCount).toBeLessThanOrEqual(2);
   });
 
+  it("reloads on changes to nested *.workflow.yaml files in existing subdirs", async () => {
+    const dir = tmpGraphDir();
+    const subdir = path.join(dir, "domain-a");
+    fs.mkdirSync(subdir);
+    const nested = path.join(subdir, "nested.workflow.yaml");
+    fs.copyFileSync(path.join(FIXTURES_DIR, "valid-simple.workflow.yaml"), nested);
+
+    let updateCount = 0;
+    const stop = watchGraphs({
+      graphsDir: dir,
+      onUpdate: () => {
+        updateCount++;
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+    cleanups.push(stop);
+
+    fs.writeFileSync(nested, fs.readFileSync(nested, "utf-8"));
+    await waitFor(() => updateCount > 0);
+    expect(updateCount).toBeGreaterThan(0);
+  });
+
+  it("does not reload on writes inside memory/ or traversals/ subdirs", async () => {
+    const dir = tmpGraphDir();
+    fs.mkdirSync(path.join(dir, "memory"));
+    fs.mkdirSync(path.join(dir, "traversals"));
+
+    let updateCount = 0;
+    const stop = watchGraphs({
+      graphsDir: dir,
+      onUpdate: () => {
+        updateCount++;
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+    cleanups.push(stop);
+
+    for (let i = 0; i < 20; i++) {
+      fs.writeFileSync(path.join(dir, "memory", `wal-${i}.bin`), "x".repeat(100));
+      fs.writeFileSync(path.join(dir, "traversals", `t-${i}.json`), "{}");
+    }
+    await new Promise((r) => setTimeout(r, 300));
+    expect(updateCount).toBe(0);
+  });
+
+  it("arms a recursive watcher on a new top-level subdir created after startup", async () => {
+    const dir = tmpGraphDir();
+    let updateCount = 0;
+    const stop = watchGraphs({
+      graphsDir: dir,
+      onUpdate: () => {
+        updateCount++;
+      },
+      onError: () => {},
+      debounceMs: 50,
+    });
+    cleanups.push(stop);
+
+    const newDomain = path.join(dir, "new-domain");
+    fs.mkdirSync(newDomain);
+    // Give the top-level watcher time to fire + stat + arm recursive watcher.
+    await new Promise((r) => setTimeout(r, 150));
+    fs.copyFileSync(
+      path.join(FIXTURES_DIR, "valid-simple.workflow.yaml"),
+      path.join(newDomain, "added.workflow.yaml"),
+    );
+    await waitFor(() => updateCount > 0);
+    expect(updateCount).toBeGreaterThan(0);
+  });
+
   it("stop function prevents further callbacks", async () => {
     const dir = tmpGraphDir();
     let updateCount = 0;


### PR DESCRIPTION
Investigation on Windows (process tree Claude Code → npx → cmd.exe shim → node worker) showed freelance-mcp workers pinning a full CPU core. Instrumentation traced it to fs.watch with recursive:true on .freelance/ firing per-frame as SQLite writes the memory.db-wal sidecar, and on Windows ReadDirectoryChangesW's internal event buffer can overflow on bursty churn, driving a tight libuv notify loop. Linux/macOS are unaffected but still do redundant work.

Fix: watch each graphsDir non-recursively for top-level events, then arm a recursive watcher per existing immediate subdir — skipping the known high-churn runtime subtrees (memory/, traversals/) via the new RUNTIME_SUBDIRS set. New top-level subdirs created after startup get a recursive watcher when their creation event lands on the top-level watcher; files created inside a brand-new subdir before that arm completes are not guaranteed to trigger a reload (restart to pick them up — rare and survivable).

RUNTIME_SUBDIRS is a constant, filtered only against direct children of each graphsDir — a nested memory/ inside a user domain folder is unusual and deliberately not special-cased.

Tests cover: nested .workflow.yaml in subdirs still reloads, writes into memory/ and traversals/ do not reload, and new top-level subdirs armed after startup reload nested files.