### PR TITLE
fix(loader): inject sealed memory workflows before cross-graph validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Graph-based workflow enforcement for AI coding agents.
 - `npm test` — run all tests
 - `npm run dev` — run in development mode
 
+After a non-trivial batch of code changes (multiple files or a cohesive multi-step edit), run `/simplify` before reporting the task complete. Skip for single-line fixes, test-only tweaks, or pure config/docs edits.
+
 ## Code navigation
 
 Prefer AST-aware tools over plain text search when exploring or refactoring TypeScript:

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -188,10 +188,7 @@ program
       { memoryDir: opts.memoryDir, memory: opts.memory },
       config,
     );
-    // Sealed memory workflows have to be present in the graph map
-    // *before* cross-graph validation, otherwise a user workflow that
-    // references memory:recall as a subgraph target fails load with
-    // "unknown graph" and the error is cached in loadErrors.
+    // Sealed graphs must reach the loader before cross-graph validation.
     const sealedGraphs = memoryConfig ? getSealedGraphs() : undefined;
     const { graphs, errors: loadErrors } = loadGraphsGraceful(dirs, { sealedGraphs });
     const sourceRoot = resolveSourceRoot(dirs, opts.sourceRoot);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { Command, Option } from "commander";
 import { loadConfigFromDirs } from "../config.js";
 import { loadGraphsGraceful, resolveGraphsDirs, resolveSourceRoot } from "../graph-resolution.js";
+import { getSealedGraphs } from "../memory/sealed.js";
 import { extractSection } from "../section-resolver.js";
 import { startServer } from "../server.js";
 import { VERSION } from "../version.js";
@@ -181,7 +182,18 @@ program
   .option("--no-memory", "Disable memory (overrides memory.enabled=true in config)")
   .action(async (opts) => {
     const dirs = resolveGraphsDirs(opts.workflows);
-    const { graphs, errors: loadErrors } = loadGraphsGraceful(dirs);
+    const config = loadConfigFromDirs(dirs);
+    const memoryConfig = resolveMemoryConfig(
+      dirs,
+      { memoryDir: opts.memoryDir, memory: opts.memory },
+      config,
+    );
+    // Sealed memory workflows have to be present in the graph map
+    // *before* cross-graph validation, otherwise a user workflow that
+    // references memory:recall as a subgraph target fails load with
+    // "unknown graph" and the error is cached in loadErrors.
+    const sealedGraphs = memoryConfig ? getSealedGraphs() : undefined;
+    const { graphs, errors: loadErrors } = loadGraphsGraceful(dirs, { sealedGraphs });
     const sourceRoot = resolveSourceRoot(dirs, opts.sourceRoot);
     const sectionResolver = (filePath: string, section: string) =>
       extractSection(filePath, section);
@@ -190,12 +202,6 @@ program
         `Freelance: ${loadErrors.length} graph(s) failed validation — call freelance_validate for details`,
       );
     }
-    const config = loadConfigFromDirs(dirs);
-    const memoryConfig = resolveMemoryConfig(
-      dirs,
-      { memoryDir: opts.memoryDir, memory: opts.memory },
-      config,
-    );
     if (memoryConfig) {
       info(`Freelance: memory enabled (${memoryConfig.db})`);
     }

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { findGraphFiles, loadSingleGraph, validateCrossGraphRefs } from "../loader.js";
+import { SEALED_GRAPH_IDS } from "../memory/sealed.js";
 import { extractSection } from "../section-resolver.js";
 import type { SourceOptions } from "../sources.js";
 import { getDetailedDrift, validateGraphSources } from "../sources.js";
@@ -96,10 +97,12 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
     }
   }
 
-  // Phase 2: if all individual files passed, run cross-graph validation (subgraph refs)
+  // Phase 2: if all individual files passed, run cross-graph validation (subgraph refs).
+  // Sealed memory workflows aren't on disk but exist at runtime when memory is
+  // enabled — treat them as valid subgraph targets so references don't fail here.
   if (result.errors.length === 0) {
     try {
-      validateCrossGraphRefs(parsed);
+      validateCrossGraphRefs(parsed, { extraAvailableIds: SEALED_GRAPH_IDS });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       result.errors.push({ file: resolvedDir, message: msg });

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -97,9 +97,8 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
     }
   }
 
-  // Phase 2: if all individual files passed, run cross-graph validation (subgraph refs).
-  // Sealed memory workflows aren't on disk but exist at runtime when memory is
-  // enabled — treat them as valid subgraph targets so references don't fail here.
+  // Phase 2: cross-graph validation. Sealed memory workflows exist at
+  // runtime but not on disk — accept them as valid subgraph targets.
   if (result.errors.length === 0) {
     try {
       validateCrossGraphRefs(parsed, { extraAvailableIds: SEALED_GRAPH_IDS });

--- a/src/graph-resolution.ts
+++ b/src/graph-resolution.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { loadConfigFromDirs } from "./config.js";
 import type { LoadGraphsOptions } from "./loader.js";
 import { loadGraphsCollecting } from "./loader.js";
+import { mergeSealedGraphs } from "./memory/sealed.js";
 import type { ValidatedGraph } from "./types.js";
 
 /**
@@ -97,9 +98,7 @@ export function loadGraphsGraceful(
 
   if (dirs.length === 0) {
     const graphs = new Map<string, ValidatedGraph>();
-    if (options?.sealedGraphs) {
-      for (const [id, graph] of options.sealedGraphs) graphs.set(id, graph);
-    }
+    if (options?.sealedGraphs) mergeSealedGraphs(graphs, options.sealedGraphs);
     return { graphs, errors: [] };
   }
 

--- a/src/graph-resolution.ts
+++ b/src/graph-resolution.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { loadConfigFromDirs } from "./config.js";
+import type { LoadGraphsOptions } from "./loader.js";
 import { loadGraphsCollecting } from "./loader.js";
 import type { ValidatedGraph } from "./types.js";
 
@@ -88,12 +89,19 @@ interface GracefulLoadResult {
  * Always returns both graphs and structured errors. Suitable for long-running
  * servers that should start even without valid graphs (the watcher can pick them up later).
  */
-export function loadGraphsGraceful(graphsDirs?: string | string[] | null): GracefulLoadResult {
+export function loadGraphsGraceful(
+  graphsDirs?: string | string[] | null,
+  options?: LoadGraphsOptions,
+): GracefulLoadResult {
   const dirs = resolveGraphsDirs(graphsDirs);
 
   if (dirs.length === 0) {
-    return { graphs: new Map(), errors: [] };
+    const graphs = new Map<string, ValidatedGraph>();
+    if (options?.sealedGraphs) {
+      for (const [id, graph] of options.sealedGraphs) graphs.set(id, graph);
+    }
+    return { graphs, errors: [] };
   }
 
-  return loadGraphsCollecting(dirs);
+  return loadGraphsCollecting(dirs, options);
 }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -12,6 +12,7 @@ import yaml from "js-yaml";
 import { buildAndValidateGraph } from "./graph-construction.js";
 import { validateExpressions, validateReturnSchemas } from "./graph-validation.js";
 import { resolveGraphHooks } from "./hook-resolution.js";
+import { mergeSealedGraphs } from "./memory/sealed.js";
 
 // @dagrejs/graphlib is a CJS bundle with `cjs-module-lexer` named-export
 // hints. Node's native ESM loader reads those hints and lets us import
@@ -98,25 +99,9 @@ export function findGraphFiles(dir: string): string[] {
   return results;
 }
 
-/**
- * Options for bulk loaders. `sealedGraphs` are built-in workflows (e.g. the
- * memory:* pair) merged into the result map — user-authored entries win —
- * BEFORE cross-graph validation runs, so workflows can safely reference
- * sealed ids as subgraph targets without the validator seeing a partial
- * graph set.
- */
 export interface LoadGraphsOptions {
+  /** Built-ins merged before cross-graph validation. User entries win. */
   sealedGraphs?: Map<string, ValidatedGraph>;
-}
-
-function mergeSealed(
-  target: Map<string, ValidatedGraph>,
-  sealed: Map<string, ValidatedGraph> | undefined,
-): void {
-  if (!sealed) return;
-  for (const [id, graph] of sealed) {
-    if (!target.has(id)) target.set(id, graph);
-  }
 }
 
 /**
@@ -162,10 +147,7 @@ export function loadGraphs(
     );
   }
 
-  // Sealed graphs must be present before cross-graph validation so
-  // user workflows that subgraph into memory:recall / memory:compile
-  // don't trip "unknown graph" errors.
-  mergeSealed(results, options?.sealedGraphs);
+  if (options?.sealedGraphs) mergeSealedGraphs(results, options.sealedGraphs);
 
   // Cross-graph validation: subgraph references and circular detection
   validateCrossGraphRefs(results);
@@ -194,7 +176,7 @@ export function loadGraphsCollecting(
   const existingDirs = resolvedDirs.filter((d) => fs.existsSync(d));
 
   if (existingDirs.length === 0) {
-    mergeSealed(graphs, options?.sealedGraphs);
+    if (options?.sealedGraphs) mergeSealedGraphs(graphs, options.sealedGraphs);
     return { graphs, errors };
   }
 
@@ -213,7 +195,7 @@ export function loadGraphsCollecting(
     }
   }
 
-  mergeSealed(graphs, options?.sealedGraphs);
+  if (options?.sealedGraphs) mergeSealedGraphs(graphs, options.sealedGraphs);
 
   // Cross-graph validation (only if we have graphs)
   if (graphs.size > 0) {
@@ -296,7 +278,7 @@ export function loadGraphsLayered(
     process.stderr.write(`Warnings:\n${warnings.join("\n")}\n`);
   }
 
-  mergeSealed(results, options?.sealedGraphs);
+  if (options?.sealedGraphs) mergeSealedGraphs(results, options.sealedGraphs);
 
   // Cross-graph validation: subgraph references and circular detection
   validateCrossGraphRefs(results);
@@ -305,13 +287,7 @@ export function loadGraphsLayered(
 }
 
 export interface ValidateCrossGraphRefsOptions {
-  /**
-   * Additional graph IDs to treat as valid subgraph targets without needing
-   * a full ValidatedGraph. Useful when the caller knows a workflow will be
-   * injected at runtime (e.g. sealed memory:* graphs) but doesn't want to
-   * include it in the "validated user graphs" list. Since these entries
-   * have no definition, the DFS treats them as leaves for cycle detection.
-   */
+  /** IDs accepted as valid subgraph targets without a materialized graph. Treated as leaves by cycle detection. */
   extraAvailableIds?: ReadonlySet<string>;
 }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -99,11 +99,35 @@ export function findGraphFiles(dir: string): string[] {
 }
 
 /**
+ * Options for bulk loaders. `sealedGraphs` are built-in workflows (e.g. the
+ * memory:* pair) merged into the result map — user-authored entries win —
+ * BEFORE cross-graph validation runs, so workflows can safely reference
+ * sealed ids as subgraph targets without the validator seeing a partial
+ * graph set.
+ */
+export interface LoadGraphsOptions {
+  sealedGraphs?: Map<string, ValidatedGraph>;
+}
+
+function mergeSealed(
+  target: Map<string, ValidatedGraph>,
+  sealed: Map<string, ValidatedGraph> | undefined,
+): void {
+  if (!sealed) return;
+  for (const [id, graph] of sealed) {
+    if (!target.has(id)) target.set(id, graph);
+  }
+}
+
+/**
  * Load and validate all *.workflow.yaml files from a directory (recursively).
  * Returns a Map of graphId → ValidatedGraph.
  * Throws on any validation failure with descriptive errors.
  */
-export function loadGraphs(directory: string): Map<string, ValidatedGraph> {
+export function loadGraphs(
+  directory: string,
+  options?: LoadGraphsOptions,
+): Map<string, ValidatedGraph> {
   const resolvedDir = path.resolve(directory);
 
   if (!fs.existsSync(resolvedDir)) {
@@ -138,6 +162,11 @@ export function loadGraphs(directory: string): Map<string, ValidatedGraph> {
     );
   }
 
+  // Sealed graphs must be present before cross-graph validation so
+  // user workflows that subgraph into memory:recall / memory:compile
+  // don't trip "unknown graph" errors.
+  mergeSealed(results, options?.sealedGraphs);
+
   // Cross-graph validation: subgraph references and circular detection
   validateCrossGraphRefs(results);
 
@@ -154,7 +183,10 @@ export interface CollectingLoadResult {
  * throwing or writing to stderr. Always returns both graphs and errors.
  * Suitable for contexts where partial success should be surfaced.
  */
-export function loadGraphsCollecting(directories: string[]): CollectingLoadResult {
+export function loadGraphsCollecting(
+  directories: string[],
+  options?: LoadGraphsOptions,
+): CollectingLoadResult {
   const graphs = new Map<string, ValidatedGraph>();
   const errors: Array<{ file: string; message: string }> = [];
 
@@ -162,6 +194,7 @@ export function loadGraphsCollecting(directories: string[]): CollectingLoadResul
   const existingDirs = resolvedDirs.filter((d) => fs.existsSync(d));
 
   if (existingDirs.length === 0) {
+    mergeSealed(graphs, options?.sealedGraphs);
     return { graphs, errors };
   }
 
@@ -179,6 +212,8 @@ export function loadGraphsCollecting(directories: string[]): CollectingLoadResul
       }
     }
   }
+
+  mergeSealed(graphs, options?.sealedGraphs);
 
   // Cross-graph validation (only if we have graphs)
   if (graphs.size > 0) {
@@ -199,7 +234,10 @@ export function loadGraphsCollecting(directories: string[]): CollectingLoadResul
  * Non-existent or empty directories are skipped with warnings.
  * Returns a Map of graphId → ValidatedGraph.
  */
-export function loadGraphsLayered(directories: string[]): Map<string, ValidatedGraph> {
+export function loadGraphsLayered(
+  directories: string[],
+  options?: LoadGraphsOptions,
+): Map<string, ValidatedGraph> {
   const results = new Map<string, ValidatedGraph>();
   const warnings: string[] = [];
 
@@ -258,10 +296,23 @@ export function loadGraphsLayered(directories: string[]): Map<string, ValidatedG
     process.stderr.write(`Warnings:\n${warnings.join("\n")}\n`);
   }
 
+  mergeSealed(results, options?.sealedGraphs);
+
   // Cross-graph validation: subgraph references and circular detection
   validateCrossGraphRefs(results);
 
   return results;
+}
+
+export interface ValidateCrossGraphRefsOptions {
+  /**
+   * Additional graph IDs to treat as valid subgraph targets without needing
+   * a full ValidatedGraph. Useful when the caller knows a workflow will be
+   * injected at runtime (e.g. sealed memory:* graphs) but doesn't want to
+   * include it in the "validated user graphs" list. Since these entries
+   * have no definition, the DFS treats them as leaves for cycle detection.
+   */
+  extraAvailableIds?: ReadonlySet<string>;
 }
 
 /**
@@ -269,7 +320,12 @@ export function loadGraphsLayered(directories: string[]): Map<string, ValidatedG
  * 1. Verify all subgraph.graphId references exist in the loaded graph set.
  * 2. Detect circular subgraph references via DFS.
  */
-export function validateCrossGraphRefs(graphs: Map<string, ValidatedGraph>): void {
+export function validateCrossGraphRefs(
+  graphs: Map<string, ValidatedGraph>,
+  options?: ValidateCrossGraphRefsOptions,
+): void {
+  const extra = options?.extraAvailableIds;
+
   // Build adjacency list for subgraph references
   const subgraphEdges = new Map<string, Set<string>>();
 
@@ -281,7 +337,7 @@ export function validateCrossGraphRefs(graphs: Map<string, ValidatedGraph>): voi
         const targetId = node.subgraph.graphId;
 
         // Verify referenced graph exists
-        if (!graphs.has(targetId)) {
+        if (!graphs.has(targetId) && !extra?.has(targetId)) {
           throw new Error(
             `Graph "${graphId}", node "${nodeId}": subgraph references unknown graph "${targetId}"`,
           );

--- a/src/memory/sealed.ts
+++ b/src/memory/sealed.ts
@@ -1,0 +1,44 @@
+/**
+ * Sealed workflows registry. Single source of truth for the workflow graphs
+ * that ship built-in with memory — `memory:compile` and `memory:recall`.
+ *
+ * Centralized so the loader, the MCP server, and the CLI `validate` command
+ * all see the same set of sealed graph ids. Cross-graph validation needs
+ * these to resolve subgraph references from user-authored workflows before
+ * the server has had a chance to inject them into the runtime graphs map.
+ */
+
+import type { ValidatedGraph } from "../types.js";
+import { buildRecollectionWorkflow, RECOLLECTION_ID } from "./recollection.js";
+import { buildCompileKnowledgeWorkflow, COMPILE_KNOWLEDGE_ID } from "./workflow.js";
+
+export { COMPILE_KNOWLEDGE_ID, RECOLLECTION_ID };
+
+/** IDs of all sealed workflows. Cheap to compute — no graph construction. */
+export const SEALED_GRAPH_IDS: ReadonlySet<string> = new Set([
+  COMPILE_KNOWLEDGE_ID,
+  RECOLLECTION_ID,
+]);
+
+/** Build a fresh Map of sealed workflow id → ValidatedGraph. */
+export function getSealedGraphs(): Map<string, ValidatedGraph> {
+  const sealed = new Map<string, ValidatedGraph>();
+  sealed.set(COMPILE_KNOWLEDGE_ID, buildCompileKnowledgeWorkflow());
+  sealed.set(RECOLLECTION_ID, buildRecollectionWorkflow());
+  return sealed;
+}
+
+/**
+ * Merge sealed graphs into a target map. User-authored entries take
+ * precedence — a sealed id only lands if nothing has claimed it yet.
+ * Mutates `target` in place and returns it for convenience.
+ */
+export function mergeSealedGraphs(
+  target: Map<string, ValidatedGraph>,
+  sealed: Map<string, ValidatedGraph>,
+): Map<string, ValidatedGraph> {
+  for (const [id, graph] of sealed) {
+    if (!target.has(id)) target.set(id, graph);
+  }
+  return target;
+}

--- a/src/memory/sealed.ts
+++ b/src/memory/sealed.ts
@@ -1,11 +1,8 @@
 /**
- * Sealed workflows registry. Single source of truth for the workflow graphs
- * that ship built-in with memory — `memory:compile` and `memory:recall`.
- *
- * Centralized so the loader, the MCP server, and the CLI `validate` command
- * all see the same set of sealed graph ids. Cross-graph validation needs
- * these to resolve subgraph references from user-authored workflows before
- * the server has had a chance to inject them into the runtime graphs map.
+ * Built-in memory workflows (`memory:compile`, `memory:recall`) and the
+ * helpers used to merge them into a graphs map. The loader needs these
+ * visible during cross-graph validation or user workflows that subgraph
+ * into memory:* fail as "unknown graph" before runtime injection.
  */
 
 import type { ValidatedGraph } from "../types.js";
@@ -14,13 +11,11 @@ import { buildCompileKnowledgeWorkflow, COMPILE_KNOWLEDGE_ID } from "./workflow.
 
 export { COMPILE_KNOWLEDGE_ID, RECOLLECTION_ID };
 
-/** IDs of all sealed workflows. Cheap to compute — no graph construction. */
 export const SEALED_GRAPH_IDS: ReadonlySet<string> = new Set([
   COMPILE_KNOWLEDGE_ID,
   RECOLLECTION_ID,
 ]);
 
-/** Build a fresh Map of sealed workflow id → ValidatedGraph. */
 export function getSealedGraphs(): Map<string, ValidatedGraph> {
   const sealed = new Map<string, ValidatedGraph>();
   sealed.set(COMPILE_KNOWLEDGE_ID, buildCompileKnowledgeWorkflow());
@@ -28,11 +23,7 @@ export function getSealedGraphs(): Map<string, ValidatedGraph> {
   return sealed;
 }
 
-/**
- * Merge sealed graphs into a target map. User-authored entries take
- * precedence — a sealed id only lands if nothing has claimed it yet.
- * Mutates `target` in place and returns it for convenience.
- */
+/** Merge sealed graphs into `target`. User-authored ids win. Mutates `target`. */
 export function mergeSealedGraphs(
   target: Map<string, ValidatedGraph>,
   sealed: Map<string, ValidatedGraph>,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,7 @@ import type { Runtime } from "./compose.js";
 import { composeRuntime } from "./compose.js";
 import type { MemoryConfig } from "./memory/index.js";
 import { registerMemoryTools } from "./memory/index.js";
-import { buildRecollectionWorkflow, RECOLLECTION_ID } from "./memory/recollection.js";
-import { buildCompileKnowledgeWorkflow, COMPILE_KNOWLEDGE_ID } from "./memory/workflow.js";
+import { getSealedGraphs, mergeSealedGraphs } from "./memory/sealed.js";
 import type { SectionResolver } from "./sources.js";
 import { registerFreelanceTools } from "./tools/index.js";
 import type { ValidatedGraph } from "./types.js";
@@ -99,27 +98,18 @@ export function createServer(
   // read through the getter below so they always see the current value.
   let currentLoadErrors: Array<{ file: string; message: string }> = options?.loadErrors ?? [];
 
-  // Inject sealed memory workflows into a fresh graph map. Must run at
-  // startup AND on every watcher reload — the watcher replaces the
-  // graphs map with on-disk-only loads, which would wipe the sealed
-  // graphs. User-authored workflows with the sealed ids take precedence
-  // (the `has` check preserves overrides from .workflow.yaml files).
-  const injectSealedGraphs = (target: Map<string, ValidatedGraph>): void => {
-    if (!memoryStore) return;
-    if (!target.has(COMPILE_KNOWLEDGE_ID)) {
-      target.set(COMPILE_KNOWLEDGE_ID, buildCompileKnowledgeWorkflow());
-    }
-    if (!target.has(RECOLLECTION_ID)) {
-      target.set(RECOLLECTION_ID, buildRecollectionWorkflow());
-    }
-  };
+  // Sealed memory workflows. User-authored workflows with the sealed ids
+  // take precedence (mergeSealedGraphs skips ids already claimed). Built
+  // once here and threaded to the loader/watcher so cross-graph validation
+  // sees sealed ids BEFORE flagging them as unknown subgraph targets.
+  const sealedGraphs = memoryStore ? getSealedGraphs() : undefined;
 
   let stopWatcher: (() => void) | undefined;
   if (options?.graphsDirs?.length) {
     stopWatcher = watchGraphs({
       graphsDir: options.graphsDirs,
+      sealedGraphs,
       onUpdate: (newGraphs) => {
-        injectSealedGraphs(newGraphs);
         manager.updateGraphs(newGraphs);
       },
       onError: (err) => {
@@ -146,7 +136,7 @@ export function createServer(
   });
 
   // --- Memory ---
-  if (memoryStore) {
+  if (memoryStore && sealedGraphs) {
     // Gate memory writes on "must be inside SOME active traversal",
     // not "must be inside memory:compile or memory:recall specifically".
     // The gate exists to prevent accidental writes outside a structured
@@ -156,9 +146,11 @@ export function createServer(
     const hasActiveMemoryTraversal = () => manager.listTraversals().length > 0;
     registerMemoryTools(server, memoryStore, hasActiveMemoryTraversal);
 
-    // Initial injection at startup. The watcher's onUpdate also calls
-    // injectSealedGraphs, so sealed workflows survive file reloads.
-    injectSealedGraphs(graphs);
+    // Belt-and-braces: the caller is expected to have merged sealed
+    // graphs before calling createServer (so cross-graph validation sees
+    // them). Re-merge here to cover programmatic callers that passed a
+    // bare graphs map. Idempotent — user-authored ids win.
+    mergeSealedGraphs(graphs, sealedGraphs);
     manager.updateGraphs(graphs);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -98,10 +98,8 @@ export function createServer(
   // read through the getter below so they always see the current value.
   let currentLoadErrors: Array<{ file: string; message: string }> = options?.loadErrors ?? [];
 
-  // Sealed memory workflows. User-authored workflows with the sealed ids
-  // take precedence (mergeSealedGraphs skips ids already claimed). Built
-  // once here and threaded to the loader/watcher so cross-graph validation
-  // sees sealed ids BEFORE flagging them as unknown subgraph targets.
+  // Built once, reused by watcher reloads so sealed graphs survive
+  // on-disk-only loads without a rebuild per reload.
   const sealedGraphs = memoryStore ? getSealedGraphs() : undefined;
 
   let stopWatcher: (() => void) | undefined;
@@ -146,10 +144,8 @@ export function createServer(
     const hasActiveMemoryTraversal = () => manager.listTraversals().length > 0;
     registerMemoryTools(server, memoryStore, hasActiveMemoryTraversal);
 
-    // Belt-and-braces: the caller is expected to have merged sealed
-    // graphs before calling createServer (so cross-graph validation sees
-    // them). Re-merge here to cover programmatic callers that passed a
-    // bare graphs map. Idempotent — user-authored ids win.
+    // Programmatic callers may pass a bare graphs map; idempotent merge
+    // ensures runtime always has the sealed workflows available.
     mergeSealedGraphs(graphs, sealedGraphs);
     manager.updateGraphs(graphs);
   }

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -3,6 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { findGraphFiles, loadSingleGraph, validateCrossGraphRefs } from "../loader.js";
 import { errorResponse, handleError, jsonResponse } from "../mcp-helpers.js";
+import { SEALED_GRAPH_IDS } from "../memory/sealed.js";
 import type { ValidatedGraph } from "../types.js";
 import type { FreelanceToolDeps } from "./deps.js";
 
@@ -48,10 +49,13 @@ export function registerValidateTool(server: McpServer, deps: FreelanceToolDeps)
           }
         }
 
-        // Cross-graph validation (only if individual files passed)
+        // Cross-graph validation (only if individual files passed).
+        // Sealed memory workflows are runtime-injected — treat their ids as
+        // valid subgraph targets so user references to memory:recall /
+        // memory:compile don't trip "unknown graph" at validate time.
         if (errors.length === 0 && parsed.size > 0) {
           try {
-            validateCrossGraphRefs(parsed);
+            validateCrossGraphRefs(parsed, { extraAvailableIds: SEALED_GRAPH_IDS });
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             errors.push({ file: "(cross-graph)", message: msg });

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -49,10 +49,8 @@ export function registerValidateTool(server: McpServer, deps: FreelanceToolDeps)
           }
         }
 
-        // Cross-graph validation (only if individual files passed).
-        // Sealed memory workflows are runtime-injected — treat their ids as
-        // valid subgraph targets so user references to memory:recall /
-        // memory:compile don't trip "unknown graph" at validate time.
+        // Cross-graph validation. Sealed memory workflows are runtime-
+        // injected — accept their ids as valid subgraph targets.
         if (errors.length === 0 && parsed.size > 0) {
           try {
             validateCrossGraphRefs(parsed, { extraAvailableIds: SEALED_GRAPH_IDS });

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -17,6 +17,12 @@ interface WatcherOptions {
   onConfigChange?: (dir: string) => void;
   /** Debounce interval in ms (default: 200) */
   debounceMs?: number;
+  /**
+   * Built-in workflows to merge into every reload before cross-graph
+   * validation runs. Prevents "unknown graph" errors when user workflows
+   * reference sealed ids (e.g. memory:recall) on hot-reload.
+   */
+  sealedGraphs?: Map<string, ValidatedGraph>;
 }
 
 /**
@@ -56,7 +62,15 @@ const RUNTIME_SUBDIRS: ReadonlySet<string> = new Set(["memory", "traversals"]);
  * Returns a cleanup function that stops watching.
  */
 export function watchGraphs(options: WatcherOptions): () => void {
-  const { graphsDir, onUpdate, onError, onLoadErrors, onConfigChange, debounceMs = 200 } = options;
+  const {
+    graphsDir,
+    onUpdate,
+    onError,
+    onLoadErrors,
+    onConfigChange,
+    debounceMs = 200,
+    sealedGraphs,
+  } = options;
   const dirs = Array.isArray(graphsDir) ? graphsDir : [graphsDir];
 
   let graphDebounce: ReturnType<typeof setTimeout> | null = null;
@@ -64,7 +78,7 @@ export function watchGraphs(options: WatcherOptions): () => void {
 
   function reload() {
     try {
-      const { graphs, errors } = loadGraphsCollecting(dirs);
+      const { graphs, errors } = loadGraphsCollecting(dirs, { sealedGraphs });
       onUpdate(graphs);
       if (onLoadErrors) {
         onLoadErrors(errors);

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -17,11 +17,7 @@ interface WatcherOptions {
   onConfigChange?: (dir: string) => void;
   /** Debounce interval in ms (default: 200) */
   debounceMs?: number;
-  /**
-   * Built-in workflows to merge into every reload before cross-graph
-   * validation runs. Prevents "unknown graph" errors when user workflows
-   * reference sealed ids (e.g. memory:recall) on hot-reload.
-   */
+  /** Built-ins merged into every reload before cross-graph validation. */
   sealedGraphs?: Map<string, ValidatedGraph>;
 }
 

--- a/test/cli-index.test.ts
+++ b/test/cli-index.test.ts
@@ -62,6 +62,15 @@ vi.mock("../src/loader.js", () => ({
   loadGraphsLayered: vi.fn(() => new Map([["test", {}]])),
   loadGraphsCollecting: vi.fn(() => ({ graphs: new Map([["test", {}]]), errors: [] })),
 }));
+// Sealed graphs aren't relevant to these wiring tests — stub the builder so
+// the mcp command can resolve it without pulling in the real GraphBuilder.
+vi.mock("../src/memory/sealed.js", () => ({
+  getSealedGraphs: vi.fn(() => new Map()),
+  mergeSealedGraphs: vi.fn((target: Map<string, unknown>) => target),
+  SEALED_GRAPH_IDS: new Set<string>(),
+  COMPILE_KNOWLEDGE_ID: "memory:compile",
+  RECOLLECTION_ID: "memory:recall",
+}));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let exitSpy: any;

--- a/test/cli-index.test.ts
+++ b/test/cli-index.test.ts
@@ -62,8 +62,7 @@ vi.mock("../src/loader.js", () => ({
   loadGraphsLayered: vi.fn(() => new Map([["test", {}]])),
   loadGraphsCollecting: vi.fn(() => ({ graphs: new Map([["test", {}]]), errors: [] })),
 }));
-// Sealed graphs aren't relevant to these wiring tests — stub the builder so
-// the mcp command can resolve it without pulling in the real GraphBuilder.
+// Stub sealed graph builder — irrelevant to these wiring tests and pulls in GraphBuilder.
 vi.mock("../src/memory/sealed.js", () => ({
   getSealedGraphs: vi.fn(() => new Map()),
   mergeSealedGraphs: vi.fn((target: Map<string, unknown>) => target),

--- a/test/cli-validate.test.ts
+++ b/test/cli-validate.test.ts
@@ -145,10 +145,6 @@ describe("CLI validate", () => {
   });
 
   it("accepts subgraph references to sealed memory:* workflows", () => {
-    // Regression: cross-graph validation used to fire before sealed
-    // memory workflows were injected, so a user workflow that subgraphs
-    // into memory:recall would fail validate even though the id exists
-    // at runtime.
     const dir = tmpDir();
     copyFixtures(dir, "parent-with-sealed-subgraph.workflow.yaml");
     validate(dir);

--- a/test/cli-validate.test.ts
+++ b/test/cli-validate.test.ts
@@ -144,6 +144,17 @@ describe("CLI validate", () => {
     expect(exitSpy).toHaveBeenCalledWith(3);
   });
 
+  it("accepts subgraph references to sealed memory:* workflows", () => {
+    // Regression: cross-graph validation used to fire before sealed
+    // memory workflows were injected, so a user workflow that subgraphs
+    // into memory:recall would fail validate even though the id exists
+    // at runtime.
+    const dir = tmpDir();
+    copyFixtures(dir, "parent-with-sealed-subgraph.workflow.yaml");
+    validate(dir);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
   it("treats directory with non-graph files as empty", () => {
     const dir = tmpDir();
     fs.writeFileSync(path.join(dir, "readme.txt"), "not a graph");

--- a/test/fixtures/parent-with-sealed-subgraph.workflow.yaml
+++ b/test/fixtures/parent-with-sealed-subgraph.workflow.yaml
@@ -1,0 +1,35 @@
+id: parent-with-sealed
+version: "1.0.0"
+name: "Parent With Sealed Subgraph"
+description: "A workflow that subgraphs into a sealed memory:* workflow"
+startNode: start
+context:
+  recalled: false
+
+nodes:
+  start:
+    type: action
+    description: "Begin parent workflow"
+    instructions: "Do work, then delegate to memory:recall."
+    edges:
+      - target: recall
+        label: work-done
+
+  recall:
+    type: gate
+    description: "Delegate to sealed recall workflow"
+    instructions: "Invoke memory:recall as a subgraph."
+    subgraph:
+      graphId: memory:recall
+      contextMap: {}
+    validations:
+      - expr: "true"
+        message: "Always pass — the subgraph's own returns gate the step."
+    edges:
+      - target: finalize
+        label: recalled
+
+  finalize:
+    type: terminal
+    description: "Workflow complete"
+    instructions: "Summarize results."

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -8,7 +8,9 @@ import {
   loadGraphsCollecting,
   loadGraphsLayered,
   resolveContextDefaults,
+  validateCrossGraphRefs,
 } from "../src/loader.js";
+import { getSealedGraphs, SEALED_GRAPH_IDS } from "../src/memory/sealed.js";
 
 const FIXTURES_DIR = path.resolve(import.meta.dirname, "fixtures");
 
@@ -451,5 +453,97 @@ describe("loadGraphsCollecting", () => {
     const { graphs, errors } = loadGraphsCollecting(["/nonexistent/path"]);
     expect(graphs.size).toBe(0);
     expect(errors).toHaveLength(0);
+  });
+});
+
+describe("cross-graph validation with sealed graphs", () => {
+  it("loadGraphsCollecting: subgraph ref to memory:recall resolves when sealedGraphs supplied", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sealed-load-test-"));
+    fs.copyFileSync(
+      path.join(FIXTURES_DIR, "parent-with-sealed-subgraph.workflow.yaml"),
+      path.join(tmpDir, "parent-with-sealed-subgraph.workflow.yaml"),
+    );
+    try {
+      // Without sealedGraphs — the reference to memory:recall dangles.
+      const bare = loadGraphsCollecting([tmpDir]);
+      expect(bare.errors.some((e) => /memory:recall/.test(e.message))).toBe(true);
+
+      // With sealedGraphs — validation passes and sealed are present in result.
+      const { graphs, errors } = loadGraphsCollecting([tmpDir], {
+        sealedGraphs: getSealedGraphs(),
+      });
+      expect(errors).toHaveLength(0);
+      expect(graphs.has("parent-with-sealed")).toBe(true);
+      expect(graphs.has("memory:recall")).toBe(true);
+      expect(graphs.has("memory:compile")).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loadGraphs: throws without sealedGraphs, passes with them", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sealed-load-test-"));
+    fs.copyFileSync(
+      path.join(FIXTURES_DIR, "parent-with-sealed-subgraph.workflow.yaml"),
+      path.join(tmpDir, "parent-with-sealed-subgraph.workflow.yaml"),
+    );
+    try {
+      expect(() => loadGraphs(tmpDir)).toThrow(/memory:recall/);
+      const graphs = loadGraphs(tmpDir, { sealedGraphs: getSealedGraphs() });
+      expect(graphs.has("parent-with-sealed")).toBe(true);
+      expect(graphs.has("memory:recall")).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("user-authored graph with sealed id wins over sealed default", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sealed-override-test-"));
+    // User authors their own memory:recall workflow — mergeSealed must skip
+    // the sealed builder output in favor of the user's file.
+    const userYaml = `id: "memory:recall"
+version: "9.9.9"
+name: "User Recall Override"
+description: "User override"
+startNode: start
+context: {}
+nodes:
+  start:
+    type: terminal
+    description: "user-authored terminal"
+`;
+    fs.writeFileSync(path.join(tmpDir, "user-recall.workflow.yaml"), userYaml);
+    try {
+      const { graphs, errors } = loadGraphsCollecting([tmpDir], {
+        sealedGraphs: getSealedGraphs(),
+      });
+      expect(errors).toHaveLength(0);
+      const recall = graphs.get("memory:recall");
+      expect(recall).toBeDefined();
+      expect(recall?.definition.version).toBe("9.9.9");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("validateCrossGraphRefs: extraAvailableIds accepts sealed ids without merging them", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sealed-ids-test-"));
+    fs.copyFileSync(
+      path.join(FIXTURES_DIR, "parent-with-sealed-subgraph.workflow.yaml"),
+      path.join(tmpDir, "parent-with-sealed-subgraph.workflow.yaml"),
+    );
+    try {
+      // Load the user file alone (no sealed merge). Cross-graph validation
+      // would normally fail, but extraAvailableIds unblocks it.
+      const { graphs } = loadGraphsCollecting([tmpDir]);
+      // Remove the error-producing validation from the result map — take
+      // a fresh single-graph map and call validateCrossGraphRefs directly.
+      const map = new Map(graphs);
+      expect(() =>
+        validateCrossGraphRefs(map, { extraAvailableIds: SEALED_GRAPH_IDS }),
+      ).not.toThrow();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -464,11 +464,9 @@ describe("cross-graph validation with sealed graphs", () => {
       path.join(tmpDir, "parent-with-sealed-subgraph.workflow.yaml"),
     );
     try {
-      // Without sealedGraphs — the reference to memory:recall dangles.
       const bare = loadGraphsCollecting([tmpDir]);
       expect(bare.errors.some((e) => /memory:recall/.test(e.message))).toBe(true);
 
-      // With sealedGraphs — validation passes and sealed are present in result.
       const { graphs, errors } = loadGraphsCollecting([tmpDir], {
         sealedGraphs: getSealedGraphs(),
       });
@@ -499,8 +497,6 @@ describe("cross-graph validation with sealed graphs", () => {
 
   it("user-authored graph with sealed id wins over sealed default", () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sealed-override-test-"));
-    // User authors their own memory:recall workflow — mergeSealed must skip
-    // the sealed builder output in favor of the user's file.
     const userYaml = `id: "memory:recall"
 version: "9.9.9"
 name: "User Recall Override"
@@ -533,11 +529,7 @@ nodes:
       path.join(tmpDir, "parent-with-sealed-subgraph.workflow.yaml"),
     );
     try {
-      // Load the user file alone (no sealed merge). Cross-graph validation
-      // would normally fail, but extraAvailableIds unblocks it.
       const { graphs } = loadGraphsCollecting([tmpDir]);
-      // Remove the error-producing validation from the result map — take
-      // a fresh single-graph map and call validateCrossGraphRefs directly.
       const map = new Map(graphs);
       expect(() =>
         validateCrossGraphRefs(map, { extraAvailableIds: SEALED_GRAPH_IDS }),


### PR DESCRIPTION
Cross-graph validation fired before the MCP server's sealed-graph
injection step, so a user workflow that references memory:recall (or
memory:compile) as a subgraph target failed load with "unknown graph"
— even though the sealed workflow would be present at runtime. The
error was then cached in loadErrors and surfaced by freelance_list
and freelance_validate, confusingly alongside memory:recall in the
very same "loaded graphs" output.

Changes:
- New src/memory/sealed.ts centralizes the sealed-graph registry
  (getSealedGraphs, mergeSealedGraphs, SEALED_GRAPH_IDS).
- loadGraphs / loadGraphsCollecting / loadGraphsLayered /
  loadGraphsGraceful accept an optional { sealedGraphs } option and
  merge it into the result map (user-authored entries win) BEFORE
  validateCrossGraphRefs runs.
- validateCrossGraphRefs accepts { extraAvailableIds } for callers
  that want IDs recognized without materializing the graphs — used
  by CLI validate and the freelance_validate tool so sealed-target
  references don't trip validation output.
- src/cli/program.ts (mcp command) resolves memory config first,
  builds sealed graphs when enabled, and threads them to the loader.
- src/server.ts drops its ad-hoc injectSealedGraphs helper; sealed
  graphs now flow through the loader + watcher and a belt-and-braces
  merge covers programmatic callers.

Regression tests: parent-with-sealed-subgraph fixture plus loader and
cli-validate cases covering both the failing and fixed paths.