### PR TITLE
Simplify freelance MCP plugin configuration to use npx

### DIFF
--- a/plugins/freelance/.mcp.json
+++ b/plugins/freelance/.mcp.json
@@ -1,13 +1,6 @@
 {
   "freelance": {
-    "command": "node",
-    "args": [
-      "/home/jwcam/repos/freelance/dist/bin.js",
-      "mcp",
-      "--workflows",
-      "/home/jwcam/repos/freelance/.freelance",
-      "--workflows",
-      "/home/jwcam/repos/freelance/experiments/.freelance"
-    ]
+    "command": "npx",
+    "args": ["-y", "freelance-mcp@^1", "mcp"]
   }
 }


### PR DESCRIPTION
## Summary
Updated the freelance MCP plugin configuration to use `npx` for launching the freelance-mcp package instead of relying on a local Node.js installation with hardcoded paths.

## Key Changes
- Changed command from `node` to `npx` for better portability
- Replaced local file path reference (`/home/jwcam/repos/freelance/dist/bin.js`) with npm package reference (`freelance-mcp@^1`)
- Simplified arguments from 10 lines to 2 lines by removing hardcoded workflow directory paths
- Added `-y` flag to `npx` to automatically accept package installation prompts

## Benefits
- Eliminates dependency on local repository structure and absolute paths
- Improves portability across different development environments
- Reduces configuration maintenance by using published npm package
- Allows for automatic package updates within the specified version range

https://claude.ai/code/session_01Vs53cYVuE6vHv9KVT7Mi9n