### PR TITLE
fix(plugin): pin freelance-mcp to exact version in .mcp.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Plugin `.mcp.json` now pins an exact `freelance-mcp` version** instead
+  of the `^1` range. Caught by a field report after 1.3.2: npx keys its
+  `_npx/<hash>` cache on the raw spec string, so `freelance-mcp@^1`
+  reuses whatever 1.x is already cached and never re-resolves against
+  the registry — a known npm/cli bug ([#7838], [#6804]). Result: the
+  1.3.2 plugin hotfix landed correctly but the *server* running inside
+  it could still be 1.3.0 code on machines that used the plugin during
+  the 1.3.0 → 1.3.1 window. Exact pinning changes the cache key on
+  every release and forces a fresh registry fetch, so `/plugin update`
+  actually delivers server-side fixes. `scripts/sync-plugin-version.mjs`
+  now rewrites the pin from `package.json#version` on every
+  `npm version`, alongside `plugin.json` and `marketplace.json`.
+
+[#7838]: https://github.com/npm/cli/issues/7838
+[#6804]: https://github.com/npm/cli/issues/6804
+
+### User action — stuck on cached 1.3.0?
+
+If `/plugin update` to 1.3.2 didn't surface the PR #63/#64 server fixes,
+your npx cache still has 1.3.0. Once on this release (or any future one),
+the cache key changes and the problem goes away — but to clear an
+already-stale 1.3.0 entry now:
+
+```sh
+# 1. Kill any lingering freelance-mcp processes.
+#    macOS/Linux:
+pkill -f freelance-mcp || true
+#    Windows (PowerShell):
+# Get-CimInstance Win32_Process |
+#   Where-Object { $_.CommandLine -like '*freelance-mcp*' } |
+#   ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
+
+# 2. Clear the stale npx cache entry. `npm cache clean` does NOT touch
+#    _npx — it's a separate directory (npm/cli#6664).
+rm -rf ~/.npm/_npx
+# Windows: rm -rf "$env:LOCALAPPDATA\npm-cache\_npx"
+
+# 3. Restart Claude Code. npx re-resolves and pulls the current version.
+```
+
 ## [1.3.2] - 2026-04-17
 
 Hotfix release for two regressions shipped in 1.3.1.

--- a/plugins/freelance/.mcp.json
+++ b/plugins/freelance/.mcp.json
@@ -1,6 +1,6 @@
 {
   "freelance": {
     "command": "npx",
-    "args": ["-y", "freelance-mcp@^1", "mcp"]
+    "args": ["-y", "freelance-mcp@1.3.2", "mcp"]
   }
 }

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -2,7 +2,7 @@
 /**
  * Keep plugin version metadata in sync with package.json#version.
  *
- * Two files need to track the package version:
+ * Three files need to track the package version:
  *
  *   1. plugins/freelance/.claude-plugin/plugin.json
  *      Claude Code's plugin cache uses plugin.json#version to decide
@@ -13,6 +13,15 @@
  *      The top-level marketplace manifest lists each plugin with its
  *      version. Matches Anthropic's plugin.schema convention so future
  *      Claude Code versions that expect it here work correctly.
+ *
+ *   3. plugins/freelance/.mcp.json (args: freelance-mcp@<exact>)
+ *      The launcher must pin an EXACT version, not a range. npx keys its
+ *      _npx/<hash> cache by the raw spec string, so `freelance-mcp@^1`
+ *      reuses whatever 1.x version happens to be cached even after a new
+ *      release lands on npm (npm/cli#7838, #6804). Bumping the exact
+ *      version on every release changes the cache key and forces a
+ *      fresh registry resolve, so /plugin update actually upgrades the
+ *      server code instead of silently no-op'ing on stale cache entries.
  *
  * Wired via the `version` and `prepublishOnly` npm script hooks.
  */
@@ -26,19 +35,24 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const pkgPath = path.join(repoRoot, "package.json");
 const pluginPath = path.join(repoRoot, "plugins", "freelance", ".claude-plugin", "plugin.json");
 const marketplacePath = path.join(repoRoot, ".claude-plugin", "marketplace.json");
+const mcpPath = path.join(repoRoot, "plugins", "freelance", ".mcp.json");
 
 const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
 const target = pkg.version;
 
-/**
- * Write JSON back with a trailing newline. Returns the previous value
- * (or null if none was set) so the caller can log what changed.
- */
 function syncField(filePath, update) {
   const obj = JSON.parse(fs.readFileSync(filePath, "utf-8"));
   const prev = update(obj);
   fs.writeFileSync(filePath, `${JSON.stringify(obj, null, 2)}\n`);
   return prev;
+}
+
+function logChange(label, prev, next) {
+  if (prev === next) {
+    console.log(`${label} already at ${next}`);
+  } else {
+    console.log(`${label}: ${prev ?? "(none)"} \u2192 ${next}`);
+  }
 }
 
 // --- plugin.json ---
@@ -47,12 +61,7 @@ const prevPluginVersion = syncField(pluginPath, (plugin) => {
   plugin.version = target;
   return prev;
 });
-
-if (prevPluginVersion === target) {
-  console.log(`plugin.json already at ${target}`);
-} else {
-  console.log(`plugin.json: ${prevPluginVersion} \u2192 ${target}`);
-}
+logChange("plugin.json", prevPluginVersion, target);
 
 // --- marketplace.json ---
 const prevMarketplaceVersion = syncField(marketplacePath, (market) => {
@@ -66,14 +75,30 @@ const prevMarketplaceVersion = syncField(marketplacePath, (market) => {
   entry.version = target;
   return prev;
 });
+logChange("marketplace.json", prevMarketplaceVersion, target);
 
-if (prevMarketplaceVersion === target) {
-  console.log(`marketplace.json already at ${target}`);
-} else if (prevMarketplaceVersion === null) {
-  console.log(`marketplace.json: (none) \u2192 ${target}`);
-} else {
-  console.log(`marketplace.json: ${prevMarketplaceVersion} \u2192 ${target}`);
-}
+// --- .mcp.json ---
+const MCP_PKG_ARG = /^freelance-mcp@.+$/;
+const desiredMcpSpec = `freelance-mcp@${target}`;
+const prevMcpSpec = syncField(mcpPath, (config) => {
+  const server = config.freelance;
+  if (!server || !Array.isArray(server.args)) {
+    throw new Error(`.mcp.json: missing freelance.args array; cannot pin launcher version`);
+  }
+  let prev = null;
+  server.args = server.args.map((arg) => {
+    if (typeof arg === "string" && MCP_PKG_ARG.test(arg)) {
+      prev = arg;
+      return desiredMcpSpec;
+    }
+    return arg;
+  });
+  if (prev === null) {
+    throw new Error(`.mcp.json: no freelance-mcp@<spec> arg found in freelance.args; cannot pin`);
+  }
+  return prev;
+});
+logChange(".mcp.json", prevMcpSpec, desiredMcpSpec);
 
 // Biome's JSON formatter collapses short arrays onto a single line;
 // JSON.stringify(obj, null, 2) always expands them. Run biome after the
@@ -81,7 +106,7 @@ if (prevMarketplaceVersion === target) {
 // isn't installed (e.g. running from a packed tarball), skip silently.
 const biomeResult = spawnSync(
   "npx",
-  ["--no-install", "biome", "format", "--write", pluginPath, marketplacePath],
+  ["--no-install", "biome", "format", "--write", pluginPath, marketplacePath, mcpPath],
   { cwd: repoRoot, stdio: "inherit" },
 );
 if (biomeResult.status !== 0 && biomeResult.status !== null) {

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -2,17 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-// Plugin manifest integrity tests. Three files must stay coherent with
-// each other and with package.json:
-//   1. plugins/freelance/.mcp.json — launcher config (must use the
-//      public `npx -y freelance-mcp@^<major>` form so it works on any
-//      machine). Shipped broken in 1.3.1 with hardcoded dev paths (#70).
-//   2. plugins/freelance/.claude-plugin/plugin.json — version the Claude
-//      Code plugin cache uses to refresh installs.
-//   3. .claude-plugin/marketplace.json — marketplace listing version.
-// sync-plugin-version.mjs runs on `npm version` and keeps (2)+(3) in
-// lockstep with package.json. These tests catch manual edits that skip
-// the hook plus the #70 class of bug where .mcp.json ships machine-local.
+// The .mcp.json launcher must pin freelance-mcp exactly, not use a
+// range: npx keys its _npx/<hash> cache by the raw spec string, so
+// `freelance-mcp@^1` reuses any cached 1.x and never re-resolves
+// against the registry (npm/cli#7838, #6804). sync-plugin-version.mjs
+// rewrites the pin on every `npm version`; this file catches manual
+// edits that skip the hook or drop back to a range, plus the #70 class
+// of bug where .mcp.json ships with machine-local dev paths.
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 
@@ -69,21 +65,10 @@ describe("plugin .mcp.json launcher shape", () => {
     }
   });
 
-  it("references the freelance-mcp package with a semver range matching package.json's major", () => {
-    // The launcher pins to ^<major> so `npm publish` of a new patch/minor
-    // reaches users automatically, but a deliberate major bump doesn't
-    // silently break existing installs. If the range drifts off the
-    // current major, the plugin is either stuck on an old major or
-    // pointing at an unreleased one.
+  it("pins freelance-mcp to the exact package.json version", () => {
     const packageArg = server.args.find((a) => a.startsWith("freelance-mcp"));
     expect(packageArg, "freelance-mcp package arg missing").toBeDefined();
-
-    const match = packageArg?.match(/^freelance-mcp@\^(\d+)$/);
-    expect(match, `expected freelance-mcp@^<major>, got "${packageArg}"`).not.toBeNull();
-
-    const pluginMajor = match?.[1];
-    const pkgMajor = pkg.version.split(".")[0];
-    expect(pluginMajor).toBe(pkgMajor);
+    expect(packageArg).toBe(`freelance-mcp@${pkg.version}`);
   });
 
   it("invokes the mcp subcommand", () => {
@@ -92,10 +77,6 @@ describe("plugin .mcp.json launcher shape", () => {
 });
 
 describe("plugin version metadata stays in sync with package.json", () => {
-  // Guards against manual edits that skip the sync-plugin-version hook.
-  // Claude Code's plugin cache uses plugin.json#version to refresh
-  // installs; drift here means users silently don't see updates.
-
   it("plugin.json version matches package.json", () => {
     expect(plugin.version).toBe(pkg.version);
   });


### PR DESCRIPTION
## Summary

- Field report after 1.3.2: users still running 1.3.0 server code even after `/plugin update` pulled the new plugin manifest. Root cause: npx keys `_npx/<hash>` by the raw spec string, so `freelance-mcp@^1` reuses any cached 1.x and never re-resolves against the registry. Documented npm/cli bug ([#7838](https://github.com/npm/cli/issues/7838), [#6804](https://github.com/npm/cli/issues/6804)).
- Fix: pin an exact version in `plugins/freelance/.mcp.json`. The cache key changes every release → fresh registry fetch → `/plugin update` actually delivers the server-side fix.
- `scripts/sync-plugin-version.mjs` rewrites the pin from `package.json#version` on every `npm version` / `prepublishOnly`, alongside `plugin.json` and `marketplace.json`. Pinned to 1.3.2 now.
- CHANGELOG has user-action commands for anyone stuck on a cached 1.3.0 (pkill + `rm -rf ~/.npm/_npx`; `npm cache clean` does not touch `_npx`).

**Stacked on #71** (plugin manifest integrity tests). This PR also flips the `^<major>` shape assertion there to an exact-pin assertion. Base will rebase cleanly once #71 merges.

### Verification

- Source-level: `libnpmexec/lib/index.js` lines 238–249 derive the `_npx/<hash>` directory from a sha512 of the raw spec string. Changing `1.3.0` → `1.3.2` produces a different hash → fresh install dir → fresh fetch (confirmed by npm/cli#6450).
- The MCP Registry versioning guidance actually [recommends](https://modelcontextprotocol.io/registry/versioning) exact semver and prohibits range strings in server metadata, so this also brings us into alignment.
- Alternatives ruled out: `--prefer-online` doesn't fix range resolution (#6804), `--ignore-existing` only affects PATH lookup, `npm cache clean --force` doesn't touch `_npx` (#6664).

### Tradeoffs

- First launch after each release pays one registry round-trip (seconds). Subsequent launches hit warm `_npx/<hash>`.
- Offline bootstrap to a never-installed exact version will hard-fail. Acceptable — we've never supported offline fresh-install.
- Plugin `.mcp.json` and server version now move in lockstep. Already true for `plugin.json` + `marketplace.json`; sync script extended symmetrically.

## Test plan

- [x] `npm run sync-plugin-version` — rewrites `.mcp.json`, `plugin.json`, `marketplace.json`; idempotent on second run.
- [x] `npm run build` — clean.
- [x] `npm test` — 726/726 pass.
- [x] `npx biome check` — clean on all four touched files.
- [ ] On merge + publish: confirm `plugins/freelance/.mcp.json` in the shipped plugin cache contains `freelance-mcp@<current>` (not `^1`).
- [ ] Verify cross-release behavior: bump to 1.3.3 locally, run sync script, confirm `.mcp.json` updates to `freelance-mcp@1.3.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)