### PR TITLE
fix(memory): drop mtime fast-path from staleness detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Memory drift detection no longer trusts mtime.** The staleness
+  check used an mtime fast-path — if the file's current mtime matched
+  what was recorded at emit time, it skipped the content hash and
+  returned "not changed". But mtime is routinely preserved across real
+  edits: `git checkout`, `rsync -t`, `touch -r`, archive extraction,
+  package managers, and filesystems with coarse mtime resolution all
+  leave an edited file with its original mtime. In those cases the
+  fast-path silently marked stale content as `current_match: true`,
+  defeating the one promise the API makes to readers. Drift is now
+  detected by re-hashing content every time; the per-call cache in
+  `StalenessCache` amortizes reads across source files shared by
+  multiple propositions in one query, so the honest check is cheap in
+  practice. The `mtime_ms` column on `proposition_sources` stays in
+  the schema for existing databases but is no longer written or read.
 - **`.freelance/.gitignore` now upserts when stale.** Previously
   create-if-missing, so pre-1.3 installs carried a legacy file ignoring
   `.state/` — a path that no longer exists — while the new `memory/`

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -78,6 +78,9 @@ CREATE TABLE IF NOT EXISTS proposition_sources (
   proposition_id TEXT NOT NULL REFERENCES propositions(id) ON DELETE CASCADE,
   file_path TEXT NOT NULL,
   content_hash TEXT NOT NULL,
+  -- Retained on the table for pre-1.3.4 rows. Not written to by new emits
+  -- and not read anywhere — mtime proved unsafe as a drift signal (can be
+  -- preserved across edits by git checkout, rsync -t, touch -r, etc.).
   mtime_ms REAL,
   PRIMARY KEY (proposition_id, file_path)
 );

--- a/src/memory/staleness.ts
+++ b/src/memory/staleness.ts
@@ -1,17 +1,18 @@
 /**
  * Per-proposition provenance staleness checking.
  *
- * A proposition is stale when at least one of its source files has
- * drifted since emit time. Drift is detected by mtime-match first
- * (fast path, ~microseconds via fs.statSync) and falls back to a
- * full SHA256 re-hash (slow path) only when mtimes disagree.
+ * A proposition is stale when any of its source files has drifted since
+ * emit time. Drift is detected by re-hashing current content and
+ * comparing against the hash recorded at emit time.
  *
- * The `StalenessCache` is a per-call scratchpad: every public read
- * on MemoryStore creates a fresh cache, threads it through staleness
- * checks to avoid redundant stat()/read() calls within that one
- * operation, and lets it garbage-collect when the call returns.
- * That bounds cache growth to the working set of a single query —
- * no long-lived state, no explicit eviction needed.
+ * Hash is the only authoritative signal — no mtime fast-path. mtime can
+ * be preserved across edits (`git checkout`, `rsync -t`, `touch -r`,
+ * archive extraction, coarse-resolution filesystems), so a stat-based
+ * shortcut silently misses real drift. The per-call `StalenessCache`
+ * below amortizes re-reads across source files shared by multiple
+ * propositions in one query, so the honest hash check is cheap in
+ * practice. Every public read on MemoryStore creates a fresh cache and
+ * lets it garbage-collect when the call returns.
  */
 
 import fs from "node:fs";
@@ -20,20 +21,11 @@ import { hashContent } from "../sources.js";
 import type { Db } from "./db.js";
 
 export interface StalenessCache {
-  mtimes: Map<string, number | null>;
   hashes: Map<string, string | null>;
 }
 
 export function createStalenessCache(): StalenessCache {
-  return { mtimes: new Map(), hashes: new Map() };
-}
-
-function mtimeOf(filePath: string): number | null {
-  try {
-    return fs.statSync(filePath).mtimeMs;
-  } catch {
-    return null;
-  }
+  return { hashes: new Map() };
 }
 
 function hashFile(filePath: string): string | null {
@@ -44,21 +36,6 @@ function hashFile(filePath: string): string | null {
   }
 }
 
-/** Fast path: stat() to get current mtime (~microseconds vs read+hash ~milliseconds). */
-function getCurrentMtime(
-  sourceRoot: string,
-  cache: StalenessCache,
-  filePath: string,
-): number | null {
-  const cached = cache.mtimes.get(filePath);
-  if (cache.mtimes.has(filePath)) return cached ?? null;
-  const resolvedPath = path.resolve(sourceRoot, filePath);
-  const mtime = mtimeOf(resolvedPath);
-  cache.mtimes.set(filePath, mtime);
-  return mtime;
-}
-
-/** Slow path: read + SHA256. Fallback when mtimes disagree (or weren't recorded). */
 function getCurrentFileHash(
   sourceRoot: string,
   cache: StalenessCache,
@@ -72,20 +49,17 @@ function getCurrentFileHash(
   return hash;
 }
 
-/** True if the file's current content hash doesn't match what was stored at emit time. */
+/**
+ * True if the file's current content hash doesn't match what was stored
+ * at emit time. A missing file (unreadable) is treated as changed — the
+ * proposition can't be valid if its source is gone.
+ */
 export function isFileChanged(
   sourceRoot: string,
   cache: StalenessCache,
   filePath: string,
   storedHash: string,
-  storedMtime: number | null,
 ): boolean {
-  if (storedMtime != null) {
-    const currentMtime = getCurrentMtime(sourceRoot, cache, filePath);
-    if (currentMtime !== null && currentMtime === storedMtime) {
-      return false;
-    }
-  }
   const currentHash = getCurrentFileHash(sourceRoot, cache, filePath);
   return currentHash === null || currentHash !== storedHash;
 }
@@ -101,18 +75,17 @@ export function getStalePropositionIds(
   cache: StalenessCache,
 ): Set<string> {
   const rows = db
-    .prepare("SELECT proposition_id, file_path, content_hash, mtime_ms FROM proposition_sources")
+    .prepare("SELECT proposition_id, file_path, content_hash FROM proposition_sources")
     .all() as Array<{
     proposition_id: string;
     file_path: string;
     content_hash: string;
-    mtime_ms: number | null;
   }>;
 
   const stale = new Set<string>();
-  for (const { proposition_id, file_path, content_hash, mtime_ms } of rows) {
+  for (const { proposition_id, file_path, content_hash } of rows) {
     if (stale.has(proposition_id)) continue;
-    if (isFileChanged(sourceRoot, cache, file_path, content_hash, mtime_ms)) {
+    if (isFileChanged(sourceRoot, cache, file_path, content_hash)) {
       stale.add(proposition_id);
     }
   }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -55,14 +55,6 @@ function hashFile(filePath: string): string | null {
   }
 }
 
-function mtimeOf(filePath: string): number | null {
-  try {
-    return fs.statSync(filePath).mtimeMs;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Hash proposition content for dedup. Normalizes superficial variance
  * that doesn't change the claim — case, whitespace runs, trailing
@@ -175,7 +167,7 @@ export class MemoryStore {
       "INSERT OR IGNORE INTO about (proposition_id, entity_id) VALUES (?, ?)",
     );
     const insertPropSource = this.db.prepare(
-      "INSERT OR IGNORE INTO proposition_sources (proposition_id, file_path, content_hash, mtime_ms) VALUES (?, ?, ?, ?)",
+      "INSERT OR IGNORE INTO proposition_sources (proposition_id, file_path, content_hash) VALUES (?, ?, ?)",
     );
 
     for (const prop of propositions) {
@@ -213,8 +205,7 @@ export class MemoryStore {
         if (hash === null) {
           throw new Error(`Cannot read source file "${sourcePath}" during emit.`);
         }
-        const mtime = mtimeOf(resolvedPath);
-        insertPropSource.run(propId, storedPath, hash, mtime);
+        insertPropSource.run(propId, storedPath, hash);
       }
 
       for (const entityName of prop.entities) {
@@ -504,21 +495,13 @@ export class MemoryStore {
 
   private enrichProposition(row: PropositionRow, cache: StalenessCache): PropositionInfo {
     const propSources = this.db
-      .prepare(
-        "SELECT file_path, content_hash, mtime_ms FROM proposition_sources WHERE proposition_id = ?",
-      )
-      .all(row.id) as Array<{ file_path: string; content_hash: string; mtime_ms: number | null }>;
+      .prepare("SELECT file_path, content_hash FROM proposition_sources WHERE proposition_id = ?")
+      .all(row.id) as Array<{ file_path: string; content_hash: string }>;
 
     const sourceFiles = propSources.map((sf) => ({
       path: sf.file_path,
       hash: sf.content_hash,
-      current_match: !isFileChanged(
-        this.sourceRoot,
-        cache,
-        sf.file_path,
-        sf.content_hash,
-        sf.mtime_ms,
-      ),
+      current_match: !isFileChanged(this.sourceRoot, cache, sf.file_path, sf.content_hash),
     }));
 
     const valid = sourceFiles.length === 0 || sourceFiles.every((sf) => sf.current_match);

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -371,6 +371,28 @@ describe("MemoryStore", () => {
       writeFile(tmpDir, "b.ts", "b2");
       expect(store.inspect("Multi").propositions[0].valid).toBe(false);
     });
+
+    it("detects content drift even when mtime is preserved across edits", () => {
+      // Regression guard for the no-mtime-fast-path invariant; see the
+      // header comment in src/memory/staleness.ts for why mtime alone
+      // isn't a trustworthy drift signal.
+      const filePath = path.join(tmpDir, "spec.md");
+      fs.writeFileSync(filePath, "version A content");
+      const pinnedSec = 1700000000;
+      fs.utimesSync(filePath, pinnedSec, pinnedSec);
+
+      store.emit([{ content: "Claim one.", entities: ["X"], sources: ["spec.md"] }]);
+
+      expect(store.inspect("X").propositions[0].valid).toBe(true);
+
+      // Content edit, but mtime restored to the exact pre-edit value.
+      fs.writeFileSync(filePath, "version B completely different content");
+      fs.utimesSync(filePath, pinnedSec, pinnedSec);
+
+      const result = store.inspect("X");
+      expect(result.propositions[0].source_files[0].current_match).toBe(false);
+      expect(result.propositions[0].valid).toBe(false);
+    });
   });
 
   describe("cross-session knowledge", () => {


### PR DESCRIPTION
The previous staleness check returned "not changed" whenever a file's
current mtime matched what was recorded at emit time, skipping the
content hash entirely. But mtime is routinely preserved across real
edits (git checkout, rsync -t, touch -r, archive extraction, coarse-
resolution filesystems), so the shortcut silently reported stale
content as current_match: true — breaking the one promise memory makes
to readers.

Hash is the only authoritative drift signal now. The per-call
StalenessCache amortizes re-reads across source files shared by
multiple propositions in one query, so the honest check is cheap in
practice. The mtime_ms column stays in the schema for existing
databases but is no longer written or read.

https://claude.ai/code/session_012YqourZxYAFfKNE8BPpxUr