### PR TITLE
feat(memory): hide orphan entities from memory_browse by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`memory_browse` now hides orphan entities by default** — those whose
+  `valid_proposition_count` is 0 because every linked proposition is
+  derived from a source file that has since drifted. Without the filter
+  the vocabulary returned to the agent (and surfaced as
+  `context.entities` on `memory:compile` / `memory:recall`) leaked
+  names from superseded drafts — e.g. a rename in a spec file left the
+  old entity visible indefinitely because `emit()` is append-only per
+  source. Pass `includeOrphans: true` (MCP tool, hook arg) or
+  `--include-orphans` (CLI) to see all entities — useful for audit
+  tooling that wants to find prune candidates.
+
 ### Fixed
 
 - **Memory drift detection no longer trusts mtime.** The staleness

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -33,7 +33,13 @@ export function memoryStatus(store: MemoryStore): void {
 
 export function memoryBrowse(
   store: MemoryStore,
-  opts?: { name?: string; kind?: string; limit?: string; offset?: string },
+  opts?: {
+    name?: string;
+    kind?: string;
+    limit?: string;
+    offset?: string;
+    includeOrphans?: boolean;
+  },
 ): void {
   try {
     const result = store.browse({
@@ -41,6 +47,7 @@ export function memoryBrowse(
       kind: opts?.kind,
       limit: opts?.limit ? parseInt(opts.limit, 10) : undefined,
       offset: opts?.offset ? parseInt(opts.offset, 10) : undefined,
+      includeOrphans: opts?.includeOrphans,
     });
     if (cli.json) {
       outputJson(result);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -378,7 +378,11 @@ addWorkflowsOpt(
     .option("--name <pattern>", "Partial name match (case-insensitive)")
     .option("--kind <kind>", "Filter by entity kind")
     .option("--limit <n>", "Maximum results")
-    .option("--offset <n>", "Skip first N results"),
+    .option("--offset <n>", "Skip first N results")
+    .option(
+      "--include-orphans",
+      "Include entities whose valid_proposition_count is 0 (hidden by default)",
+    ),
 ).action((opts) => {
   const { store } = createMemoryStore({ workflows: opts.workflows });
   try {

--- a/src/engine/builtin-hooks.ts
+++ b/src/engine/builtin-hooks.ts
@@ -45,6 +45,17 @@ function optionalInt(args: Record<string, unknown>, key: string): number | undef
   return v;
 }
 
+function optionalBool(args: Record<string, unknown>, key: string): boolean | undefined {
+  const v = args[key];
+  if (v === undefined || v === null) return undefined;
+  if (typeof v !== "boolean") {
+    throw new TypeError(
+      `Hook arg "${key}" must be a boolean; got ${typeof v} (${JSON.stringify(v)})`,
+    );
+  }
+  return v;
+}
+
 function requireString(args: Record<string, unknown>, key: string): string {
   const v = args[key];
   if (typeof v !== "string" || v.length === 0) {
@@ -85,6 +96,7 @@ const memoryBrowse: HookFn = async (ctx) => {
       kind: optionalString(ctx.args, "kind"),
       limit: optionalInt(ctx.args, "limit"),
       offset: optionalInt(ctx.args, "offset"),
+      includeOrphans: optionalBool(ctx.args, "includeOrphans"),
     }),
   };
 };

--- a/src/engine/hooks.ts
+++ b/src/engine/hooks.ts
@@ -35,7 +35,13 @@ import { applyContextUpdates, enforceStrictContext } from "./context.js";
  */
 export interface HookMemoryAccess {
   status(): StatusResult;
-  browse(options?: { name?: string; kind?: string; limit?: number; offset?: number }): BrowseResult;
+  browse(options?: {
+    name?: string;
+    kind?: string;
+    limit?: number;
+    offset?: number;
+    includeOrphans?: boolean;
+  }): BrowseResult;
   search(query: string, options?: { limit?: number }): SearchResult;
   related(entityIdOrName: string): RelatedResult;
   bySource(filePath: string): BySourceResult;

--- a/src/memory/messages.ts
+++ b/src/memory/messages.ts
@@ -36,7 +36,7 @@ export const compileMessages = {
         "## What you arrive with\n" +
         "Three onEnter hooks have already populated this node's context for you, so you don't burn turns on routine lookups:\n" +
         "- context.total_propositions / valid_propositions / stale_propositions / total_entities (from memory_status) — the rough size of the existing knowledge.\n" +
-        "- context.entities (from memory_browse, up to 50) — the existing entity vocabulary. Skim these names; they are what the compiling node will steer toward when it plans hubs.\n" +
+        "- context.entities (from memory_browse, up to 50) — the existing entity vocabulary. Orphan entities (valid_proposition_count: 0, every linked proposition is stale) are filtered out so the names here reflect what current sources support. Skim these names; they are what the compiling node will steer toward when it plans hubs.\n" +
         "- context.priorKnowledgeByPath (from memory_by_source) — propositions already known per file in context.filesReadPaths (each entry is { id, content } — no hashes, no timestamps; content is what you need to judge overlap). See the graph-aware reading section below.\n\n" +
         "## Warm start — if you already know which files you want to compile\n" +
         "Pass them as `initialContext.filesReadPaths` when calling freelance_start. The onEnter hooks fire AFTER initialContext is applied, so priorKnowledgeByPath is populated on your very first arrival — no wasted lap. Without initialContext, filesReadPaths starts empty and the first arrival's priorKnowledgeByPath is `{}`; hooks only re-fire on node arrival, so setting filesReadPaths via freelance_context_set does NOT re-query memory_by_source until you loop back through compiling/evaluating and land on exploring a second time.\n\n" +
@@ -129,7 +129,7 @@ export const recallMessages = {
         "## What you arrive with\n" +
         "Two onEnter hooks have already populated this node's context — you don't need to call memory_status or memory_browse manually:\n" +
         "- context.total_propositions / valid_propositions / stale_propositions / total_entities (from memory_status) — the rough size of what's known.\n" +
-        "- context.entities (from memory_browse, up to 50) — the existing entity vocabulary.\n\n" +
+        "- context.entities (from memory_browse, up to 50) — the existing entity vocabulary. Orphan entities (every linked proposition is stale) are filtered out.\n\n" +
         "## What this node does\n" +
         "Skim context.entities against the query. For the 1–5 entities most likely to carry relevant knowledge, call memory_inspect (and memory_related when you want neighbor context) to pull their full proposition lists and source files. " +
         "These targeted inspect calls are the agent's job — there's no good way to pre-fetch them automatically because we don't know which entities matter until we read context.entities.\n\n" +

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -317,53 +317,62 @@ export class MemoryStore {
     kind?: string;
     limit?: number;
     offset?: number;
+    includeOrphans?: boolean;
   }): BrowseResult {
     const cache = createStalenessCache();
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
+    const includeOrphans = options?.includeOrphans ?? false;
 
     let where = "1=1";
-    const params: unknown[] = [];
+    const whereParams: unknown[] = [];
 
     if (options?.name) {
       where += " AND LOWER(e.name) LIKE ?";
-      params.push(`%${options.name.toLowerCase()}%`);
+      whereParams.push(`%${options.name.toLowerCase()}%`);
     }
     if (options?.kind) {
       where += " AND e.kind = ?";
-      params.push(options.kind);
+      whereParams.push(options.kind);
     }
 
+    const stalePropIds = getStalePropositionIds(this.db, this.sourceRoot, cache);
+    const staleParams = [...stalePropIds];
+    const notStale =
+      staleParams.length > 0
+        ? `a.proposition_id NOT IN (${staleParams.map(() => "?").join(",")})`
+        : "1";
+    const having = includeOrphans ? "" : "HAVING valid_count > 0";
+
+    const selectExpr = `
+      SELECT e.*,
+        COUNT(a.proposition_id) as proposition_count,
+        COUNT(CASE WHEN a.proposition_id IS NOT NULL AND ${notStale} THEN 1 END) as valid_count
+      FROM entities e
+      LEFT JOIN about a ON e.id = a.entity_id
+      WHERE ${where}
+      GROUP BY e.id
+      ${having}`;
+
     const total = (
-      this.db.prepare(`SELECT COUNT(*) as total FROM entities e WHERE ${where}`).get(...params) as {
-        total: number;
-      }
+      this.db
+        .prepare(`SELECT COUNT(*) as total FROM (${selectExpr})`)
+        .get(...staleParams, ...whereParams) as { total: number }
     ).total;
 
     const rows = this.db
-      .prepare(
-        `SELECT e.*, COUNT(a.proposition_id) as proposition_count
-       FROM entities e
-       LEFT JOIN about a ON e.id = a.entity_id
-       WHERE ${where}
-       GROUP BY e.id
-       ORDER BY e.created_at DESC
-       LIMIT ? OFFSET ?`,
-      )
-      .all(...params, limit, offset) as Array<EntityRow & { proposition_count: number }>;
+      .prepare(`${selectExpr} ORDER BY e.created_at DESC LIMIT ? OFFSET ?`)
+      .all(...staleParams, ...whereParams, limit, offset) as Array<
+      EntityRow & { proposition_count: number; valid_count: number }
+    >;
 
-    const stalePropIds = getStalePropositionIds(this.db, this.sourceRoot, cache);
-
-    const entities: EntityInfo[] = rows.map((row) => {
-      const validCount = countValidForEntity(this.db, row.id, stalePropIds);
-      return {
-        id: row.id,
-        name: row.name,
-        kind: row.kind,
-        proposition_count: row.proposition_count,
-        valid_proposition_count: validCount,
-      };
-    });
+    const entities: EntityInfo[] = rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      kind: row.kind,
+      proposition_count: row.proposition_count,
+      valid_proposition_count: row.valid_count,
+    }));
 
     return { entities, total };
   }

--- a/src/memory/tools.ts
+++ b/src/memory/tools.ts
@@ -86,17 +86,23 @@ export function registerMemoryTools(
     "memory_browse",
     {
       description:
-        "Find entities by name (partial, case-insensitive), kind, or both. Returns each entity with its total proposition count and its valid (non-stale) count. Stale propositions happen when source files drift on disk — to refresh, re-run the memory:compile workflow against the changed sources. Use this for 'what entities exist matching X?'; use memory_search instead for 'what propositions mention X?'.",
+        "Find entities by name (partial, case-insensitive), kind, or both. Returns each entity with its total proposition count and its valid (non-stale) count. Orphan entities (valid_proposition_count is 0) are hidden by default — see includeOrphans. Stale propositions happen when source files drift on disk — to refresh, re-run the memory:compile workflow against the changed sources. Use this for 'what entities exist matching X?'; use memory_search instead for 'what propositions mention X?'.",
       inputSchema: {
         name: z.string().optional().describe("Partial name match (case-insensitive)"),
         kind: z.string().optional().describe("Filter by entity kind"),
         limit: z.number().int().min(1).max(200).default(50).optional(),
         offset: z.number().int().min(0).default(0).optional(),
+        includeOrphans: z
+          .boolean()
+          .optional()
+          .describe(
+            "Include entities whose valid_proposition_count is 0 (every linked proposition is stale or the entity has no propositions). Default false — orphans are hidden so the returned vocabulary reflects what the current sources support.",
+          ),
       },
     },
-    ({ name, kind, limit, offset }) => {
+    ({ name, kind, limit, offset, includeOrphans }) => {
       try {
-        return jsonResponse(store.browse({ name, kind, limit, offset }));
+        return jsonResponse(store.browse({ name, kind, limit, offset, includeOrphans }));
       } catch (e) {
         return handleError(e);
       }

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -184,6 +184,53 @@ describe("MemoryStore", () => {
       expect(page1.total).toBe(5);
       expect(page1.entities).toHaveLength(2);
     });
+
+    it("hides orphan entities (every linked proposition is stale) by default", () => {
+      writeFile(tmpDir, "active.ts", "x");
+      writeFile(tmpDir, "dropped.ts", "y");
+
+      store.emit([
+        { content: "Live fact.", entities: ["Live"], sources: ["active.ts"] },
+        { content: "Abandoned fact.", entities: ["Abandoned"], sources: ["dropped.ts"] },
+      ]);
+
+      // Drift only the file that supports the Abandoned entity. Live stays
+      // valid; Abandoned's sole proposition becomes stale, and the entity
+      // should drop out of browse.
+      writeFile(tmpDir, "dropped.ts", "z-changed");
+
+      const defaulted = store.browse();
+      expect(defaulted.total).toBe(1);
+      expect(defaulted.entities.map((e) => e.name)).toEqual(["Live"]);
+
+      const all = store.browse({ includeOrphans: true });
+      expect(all.total).toBe(2);
+      expect(all.entities.map((e) => e.name).sort()).toEqual(["Abandoned", "Live"]);
+      const abandoned = all.entities.find((e) => e.name === "Abandoned");
+      expect(abandoned?.proposition_count).toBe(1);
+      expect(abandoned?.valid_proposition_count).toBe(0);
+    });
+
+    it("pagination total matches the orphan-filtered set", () => {
+      writeFile(tmpDir, "active.ts", "x");
+      writeFile(tmpDir, "dropped.ts", "y");
+
+      for (let i = 0; i < 3; i++) {
+        store.emit([{ content: `Live ${i}.`, entities: [`Live${i}`], sources: ["active.ts"] }]);
+      }
+      for (let i = 0; i < 2; i++) {
+        store.emit([{ content: `Gone ${i}.`, entities: [`Gone${i}`], sources: ["dropped.ts"] }]);
+      }
+
+      writeFile(tmpDir, "dropped.ts", "z-changed");
+
+      const filtered = store.browse({ limit: 10 });
+      expect(filtered.total).toBe(3);
+      expect(filtered.entities).toHaveLength(3);
+
+      const unfiltered = store.browse({ limit: 10, includeOrphans: true });
+      expect(unfiltered.total).toBe(5);
+    });
   });
 
   describe("inspect", () => {


### PR DESCRIPTION
memory_browse returned entities whose every linked proposition was
derived from a source file that had since drifted, so the vocabulary
surfaced to memory:compile / memory:recall via context.entities carried
names from superseded drafts. emit() is append-only per source, so
there is no implicit GC on recompile — the orphan lingers until the
database is reset.

Filter is in SQL (HAVING valid_count > 0) against the valid count the
same GROUP BY now computes inline, so pagination and total reflect the
filtered set without an N+1 per-entity countValidForEntity fan-out.

includeOrphans: true on the MCP tool / hook arg, or --include-orphans
on the CLI, restores the prior behaviour for audit tooling that wants
to find prune candidates.

First follow-up from #75; remaining items (emit-time GC, near-dup
dedup, entity clustering, contradiction surface) tracked separately.

https://claude.ai/code/session_01Lw4bfqR2wrPYLjZhidjwF9