### PR TITLE
docs: add decisions log + debt backlog conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ docs/*
 !docs/memory-architecture-review.md
 !docs/memory-prose-porting.md
 !docs/memory-intent.md
+!docs/decisions.md
+!docs/debt.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,16 @@ After a non-trivial batch of code changes (multiple files or a cohesive multi-st
 
 When iterating on a design (proposal, issue body, new mode/option, added column), check each addition against existing system invariants **before** drafting. If the case the addition addresses isn't expressible in the current schema or types, the addition is solving an imaginary problem — kill it at the premise, not at review. Memory invariants live in `docs/memory-intent.md` (architectural qualities + anti-patterns) and in the schemas under `src/memory/` + `src/schema/`; read both before proposing a new mode, column, or tool. Concrete example: `memory_emit` requires `sources: [min 1]` on every proposition, so there is no "non-source-aligned" proposition — a prune mode scoped to that case would be solving a case the schema makes malformed.
 
+## WHY-comments vs decisions log
+
+Inline WHY comments are fine when a reader scanning *this file* needs the context at the point of reading: a local invariant, a subtle workaround, a non-obvious choice the code itself can't express. When the WHY has cross-file implications — names an invariant other modules rely on, documents a tradeoff a future change elsewhere would break, or captures a decision deliberated in an issue thread — elevate to `docs/decisions.md` and optionally cross-link from the inline comment.
+
+The test: could a contributor refactoring a sibling file violate the invariant without reading this comment? If yes, it belongs in the decisions log, not buried as a comment in one file. Narrating what the code does, referencing the current task/PR, or summarizing obvious flow is never a valid comment — delete on sight.
+
+## Refactor backlog
+
+`/simplify` surfaces findings that aren't always in-scope to fix on the current PR. Anything you decide NOT to fix — out-of-scope, pre-existing, low impact on this path — append as a one-line entry to `docs/debt.md`: `<file>:<line> — <finding> — <rationale for skipping>`. Flat list, no categories, no status column; keep append cheap. Mark entries done by deleting them. Before opening a refactor PR, scan the file for candidates.
+
 ## Releases
 
 npm publishing is **CI-driven by GitHub Releases** (`.github/workflows/publish.yml` fires on `release: published` and runs `npm publish --provenance`). Do NOT `npm publish` from a local machine — the workflow uses an OIDC token and provenance that local publishes won't produce.

--- a/docs/debt.md
+++ b/docs/debt.md
@@ -1,0 +1,15 @@
+# Debt backlog
+
+Refactors, simplifications, and follow-ups surfaced by `/simplify` (or ad-hoc review) that weren't fixed on the PR where they were found. Prevents the "decided against on this PR" bucket from vanishing. See `CLAUDE.md` § "Refactor backlog" for the convention.
+
+## Format
+
+One line per entry:
+
+```
+<file>:<line> — <finding> — <rationale for skipping>
+```
+
+Flat list. No categories, no status column, no prioritization. Delete entries when fixed (git history preserves them). Scan when you want to refactor-hunt.
+
+## Entries

--- a/docs/debt.md
+++ b/docs/debt.md
@@ -13,3 +13,7 @@ One line per entry:
 Flat list. No categories, no status column, no prioritization. Delete entries when fixed (git history preserves them). Scan when you want to refactor-hunt.
 
 ## Entries
+
+- `src/memory/staleness.ts:~32` / `src/memory/prune.ts:~60,~153` — `readFileSync(path, "utf-8")` and `bytes.toString("utf-8")` coerce non-UTF-8 bytes to U+FFFD before hashing, making hashes meaningless for binary source files. Inherited across the whole memory system (emit, staleness, prune); fixing only one site would create inconsistency. Needs a coordinated switch to raw-byte hashing end-to-end.
+- `src/memory/git.ts:~80-120` — hand-rolled parser for `git cat-file --batch` output. Format is stable and we only ever request blobs, so safe today; if we ever ask for trees/commits or git adds header fields, silent mis-threading. Swap to per-spec `git show` (simpler, slower) or a library if this becomes a liability.
+- `src/config.ts:~120` — `memory.prune.keep` concatenates across config files without dedup, so `[main]` in project + `[main]` in local yields `[main, main]`. Harmless (duplicates resolve to the same SHA) but ugly in `freelance config show`. Dedup with a `Set`.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,15 @@
+# Decisions Log
+
+Durable design decisions and cross-file invariants. The canonical home for WHY-context that applies beyond a single file or outlasts the PR that introduced it. See `CLAUDE.md` § "WHY-comments vs decisions log" for the inline-vs-doc test.
+
+## Format
+
+Each entry:
+
+- **Short heading** — the invariant or decision in a phrase
+- One or two paragraphs of prose explaining the decision, the tradeoffs considered, and what would break if it were reversed
+- Optional link to the PR or issue that decided it
+
+Append chronologically. When a later decision supersedes an earlier one, add a new entry that references and replaces the old — don't rewrite history. An entry that's been superseded is a breadcrumb for future readers wondering why the code looks the way it does.
+
+## Entries


### PR DESCRIPTION
Two conventions to keep cross-file WHY-context and deferred refactors
from vanishing into inline comments or /simplify skip-decisions.

- `docs/decisions.md` — canonical home for invariants and decisions
  whose blast radius crosses files. Inline WHY comments stay for
  file-local context; anything a sibling refactor could violate
  without reading gets elevated. CLAUDE.md § "WHY-comments vs
  decisions log" defines the test.
- `docs/debt.md` — flat list of `/simplify` findings not fixed on
  the PR where they were surfaced. Prevents "decided against"
  findings from disappearing; preserves a triage queue for refactor
  PRs. CLAUDE.md § "Refactor backlog" defines the format.

Both docs start empty. Entries accumulate organically; the value is
in the convention, not a pre-populated list. `.gitignore` updated to
un-ignore the two new docs alongside the existing committed specs.

https://claude.ai/code/session_013ezsRoNYSoD25tvqxg8iYd