### PR TITLE
feat(mcp): trim tool descriptions; add memory-workflows guide topic

### DIFF
--- a/src/guide.ts
+++ b/src/guide.ts
@@ -8,6 +8,7 @@ export const GUIDE_TOPICS = [
   "onenter-hooks",
   "multi-agent",
   "meta",
+  "memory-workflows",
   "anti-patterns",
 ] as const;
 
@@ -497,6 +498,36 @@ Start with \`externalKey\` only. After the PR is opened, call \`freelance_meta_s
 - **Set the primary key at start.** It signals intent and avoids "tagged later or never?" ambiguity in your data.
 - **Treat meta as immutable in spirit.** \`meta_set\` allows overwrites for legitimate updates (renamed branch, replaced PR), but routine workflow logic shouldn't churn meta.
 - **Don't duplicate context in meta.** Pick one home per value. Meta is for external lookup; context is for workflow execution.`,
+
+  "memory-workflows": `# Memory Workflows
+
+Freelance ships two sealed workflows that own writes to the knowledge graph. Direct calls to \`memory_emit\` and \`memory_prune\` are gated — they only succeed while a workflow traversal is active. Read tools (\`memory_browse\`, \`memory_inspect\`, \`memory_search\`, \`memory_related\`, \`memory_by_source\`, \`memory_status\`) are always available.
+
+## memory:compile
+
+Read source files, extract atomic claims, and write them to the graph.
+
+**When to use:** building or expanding persistent knowledge about a codebase, design, or reference document. Give it a query that frames what you're compiling (e.g. "how authentication works", "run-sync.js pipeline") and let it read + emit.
+
+**Shape:** three-node loop — \`exploring\` (read source files, delta-check against prior knowledge), \`compiling\` (extract atomic claims, plan entities, emit), \`evaluating\` (check coverage, loop or terminate). onEnter hooks pre-populate entity vocabulary and per-file prior knowledge, so the agent never burns a turn on setup.
+
+**Warm start:** pass \`initialContext: { query, filesReadPaths: [...] }\` to \`freelance_start\` so prior knowledge is available on first arrival.
+
+## memory:recall
+
+Query-driven knowledge recall. Searches existing memory, reads provenance sources, fills gaps between what's known and what the sources say.
+
+**When to use:** you have a question that memory *might* answer but coverage is uncertain. Recall inspects existing entities, reads their source files, compares, and emits only gap propositions.
+
+**Shape:** \`recalling\` → \`sourcing\` → \`comparing\` → \`filling\` → \`evaluating\`. Warm-exit edges short-circuit when existing knowledge already covers the query.
+
+## Authoring guidance lives in the workflow nodes
+
+The proposition rubric (atomicity, independence test, relationship exception) and entity guidance (search hubs, reuse existing names) are carried in the \`compiling\` / \`filling\` nodes' instruction prose — not in this guide and not in the tool descriptions. When you land on one of those nodes via \`freelance_advance\`, the response's \`node.instructions\` field has the full rubric. Read that at emit time.
+
+## User-authored graphs can also use memory tools
+
+The \`memory_emit\` / \`memory_prune\` gate only checks that *some* traversal is active — not specifically one of the sealed workflows. If you author your own graph that writes to memory, carry your own authoring guidance in your node instructions (or reuse the sealed workflow's via a subgraph push).`,
 
   "anti-patterns": `# Anti-Patterns
 

--- a/src/memory/tools.ts
+++ b/src/memory/tools.ts
@@ -35,36 +35,25 @@ export function registerMemoryTools(
     "memory_emit",
     {
       description:
-        "Write propositions to the knowledge graph. Each proposition is one atomic factual claim. Apply the independence test: if either half of a candidate claim could be true while the other is false, it's two propositions, not one. Exception: relationship claims like 'A depends on B' — the edge IS the knowledge; atomizing them destroys graph connectivity. The entities array names every entity the claim is about (1-4): one for subject-verb claims, multiple for relationships. Sources are required, hashed at emit time, and attached per-proposition for drift detection. Dedup is by normalized content hash — same claim with varying case or trailing punctuation is a no-op. Entities resolve by exact then case-insensitive name. Gated: requires an active workflow traversal — start one first.",
+        "Write propositions to the knowledge graph. Each proposition has content (one atomic claim), 1-4 entities, and at least one source file. Sources are hashed at emit time for per-proposition provenance. Dedup is by normalized content hash (case/whitespace/trailing-punctuation insensitive). Entities resolve exact-name first, then case-insensitive. Gated: requires an active workflow traversal — the workflow's node instructions carry the authoring rubric. See `freelance_guide memory-workflows`.",
       inputSchema: {
         propositions: z
           .array(
             z.object({
-              content: z
-                .string()
-                .min(1)
-                .describe(
-                  "One atomic factual claim. If either half could be true while the other is false, emit two propositions instead. Exception: relationship claims ('A depends on B') — keep the edge intact.",
-                ),
+              content: z.string().min(1).describe("One atomic factual claim."),
               entities: z
                 .array(z.string().min(1))
                 .min(1)
                 .max(4)
-                .describe(
-                  "Every entity the claim is about (1-4). One for subject-verb claims; two or more for relationships. Multi-entity props drive graph density via shared edges — reuse existing entity names verbatim where they apply.",
-                ),
+                .describe("Entities this claim is about (1-4 names)."),
               sources: z
                 .array(z.string().min(1))
                 .min(1)
-                .describe(
-                  "Source file paths this proposition was derived from (relative to source root). Each file is hashed at emit time for per-proposition provenance.",
-                ),
+                .describe("Source file paths (relative to source root)."),
               entityKinds: z
                 .record(z.string(), z.string())
                 .optional()
-                .describe(
-                  "Map of entity name to kind (e.g. function, class, type, interface, enum). Sets kind on entity creation.",
-                ),
+                .describe("Map of entity name to kind (e.g. function, class, module)."),
             }),
           )
           .min(1),
@@ -87,7 +76,7 @@ export function registerMemoryTools(
     "memory_browse",
     {
       description:
-        "Find entities by name (partial, case-insensitive), kind, or both. Returns each entity with its total proposition count and its valid (non-stale) count. Orphan entities (valid_proposition_count is 0) are hidden by default — see includeOrphans. Stale propositions happen when source files drift on disk — to refresh, re-run the memory:compile workflow against the changed sources. Use this for 'what entities exist matching X?'; use memory_search instead for 'what propositions mention X?'.",
+        "Find entities by name (partial, case-insensitive), kind, or both. Returns each with total and valid (non-stale) proposition counts. Orphan entities (zero valid props) hidden by default. For proposition-level text search, use memory_search.",
       inputSchema: {
         name: z.string().optional().describe("Partial name match (case-insensitive)"),
         kind: z.string().optional().describe("Filter by entity kind"),
@@ -96,9 +85,7 @@ export function registerMemoryTools(
         includeOrphans: z
           .boolean()
           .optional()
-          .describe(
-            "Include entities whose valid_proposition_count is 0 (every linked proposition is stale or the entity has no propositions). Default false — orphans are hidden so the returned vocabulary reflects what the current sources support.",
-          ),
+          .describe("Include entities with zero valid propositions. Default false."),
       },
     },
     ({ name, kind, limit, offset, includeOrphans }) => {
@@ -114,7 +101,7 @@ export function registerMemoryTools(
     "memory_inspect",
     {
       description:
-        "Full details for a single entity: valid propositions about it (ordered by creation time), co-occurring neighbor entities via shared propositions, and the deduped list of source files that produced any of its propositions. Entity can be specified by id, exact name, or case-insensitive name (resolved in that priority). Use source_files to navigate to provenance, or neighbors to explore the knowledge graph sideways. Stale propositions are refreshed by re-running memory:compile against the changed sources.",
+        "Full details for one entity: valid propositions (by creation time), neighbor entities via shared propositions, and source files. Entity resolved by id, then exact name, then case-insensitive name.",
       inputSchema: {
         entity: z.string().min(1).describe("Entity ID or name"),
       },
@@ -132,7 +119,7 @@ export function registerMemoryTools(
     "memory_by_source",
     {
       description:
-        "Return every proposition whose sources list includes the given file path. Use this to audit what claims a file produced — e.g. after editing a file, see which propositions are now stale and may need re-compilation; or before deleting a file, see what knowledge depends on it. Both valid and stale propositions are included (each has a valid flag). Path may be relative to the source root or absolute.",
+        "Return every proposition sourced from a given file path. Includes both valid and stale entries (each flagged). Use to audit what knowledge a file produced — e.g. after editing to see what's now stale, or before deleting to see what depends on it.",
       inputSchema: {
         filePath: z.string().min(1).describe("File path (relative to source root or absolute)"),
       },
@@ -150,7 +137,7 @@ export function registerMemoryTools(
     "memory_search",
     {
       description:
-        "Full-text search across proposition content via SQLite FTS5, ranked by relevance. Returns matching propositions with their entities and validity status. Query syntax: plain words separated by spaces are OR'd; \"double-quoted phrases\" match exact sequences; prefix* matches word prefixes. Use this for 'what propositions mention X?'; use memory_browse instead for 'what entities exist matching X?'. If a search misses but you later discover the answer through other means, that's a signal memory has a gap — consider running memory:compile against the relevant sources to fill it.",
+        'Full-text search over proposition content via SQLite FTS5, ranked by relevance. Query syntax: plain words are OR\'d, "quoted phrases" match exactly, prefix* matches word prefixes. For entity-level lookup instead of content, use memory_browse.',
       inputSchema: {
         query: z
           .string()
@@ -172,7 +159,7 @@ export function registerMemoryTools(
     "memory_related",
     {
       description:
-        "Show entities related to a given one via shared propositions — two entities are 'related' if at least one proposition names both. Returns neighbors ranked by count of valid shared propositions, each with a sample proposition showing the relationship in context. Use this to navigate the knowledge graph sideways during recall: start from a known entity, follow co-occurrences, jump to adjacent concepts without inspecting each entity individually.",
+        "Show entities related to a given one via shared propositions. Two entities are 'related' if at least one proposition names both. Returns neighbors ranked by valid-shared-proposition count, each with a sample proposition showing the relationship in context.",
       inputSchema: {
         entity: z.string().min(1).describe("Entity ID or name"),
       },
@@ -190,7 +177,7 @@ export function registerMemoryTools(
     "memory_status",
     {
       description:
-        "Health check for the knowledge graph: total propositions, valid (non-stale) count, stale count, and total entities. A high stale count means source files have drifted — consider running memory:compile to refresh. A low stale count means memory is current. Useful at session start (how much knowledge is here?), after file edits (what did my changes invalidate?), or before a recall workflow (is this worth querying?).",
+        "Knowledge graph health check: total proposition count, valid (non-stale) count, stale count, total entity count. A high stale count means sources have drifted.",
       inputSchema: {},
     },
     () => {
@@ -206,18 +193,15 @@ export function registerMemoryTools(
     "memory_prune",
     {
       description:
-        "Scope-bounded delete of proposition_sources rows whose content_hash doesn't match the file at any --keep ref tip (or current disk). Uses git cat-file to read ref blobs without touching the working tree; no branch switching. Rebase/squash/amend robust because it checks tree content, not commit reachability. Unresolvable --keep refs hard-error before touching the db. Intended for manual, user-initiated cleanup — not wired into memory:compile or memory:recall. Gated: requires an active workflow traversal.",
+        "Delete proposition_sources rows whose content_hash doesn't match any --keep ref tip or the current working tree. Uses git cat-file to read ref blobs — no branch switching, rebase/squash/amend robust. Unresolvable refs hard-error before touching the db. Manual cleanup only — not wired into memory:compile or memory:recall. Requires an active workflow traversal.",
       inputSchema: {
         keep: z
           .array(z.string().min(1))
           .min(1)
           .describe(
-            "Preserve refs — anything git rev-parse accepts (branches, tags, remote refs, raw SHAs). A row is preserved when its content_hash matches the file at the tip of any of these refs or the current working tree.",
+            "Git refs to preserve (branches, tags, remote refs, SHAs). Rows matching any ref tip are kept.",
           ),
-        dryRun: z
-          .boolean()
-          .optional()
-          .describe("If true, return the plan without deleting anything."),
+        dryRun: z.boolean().optional().describe("Return the plan without deleting."),
       },
     },
     ({ keep, dryRun }) => {
@@ -235,11 +219,9 @@ export function registerMemoryTools(
     "memory_reset",
     {
       description:
-        "Clear all propositions and entities from the knowledge graph. Operates on the live database handle — safe to call while the MCP is running (no split-brain from deleting files on disk). Requires confirm: true as a guard against accidental resets. Not gated by an active traversal — this is an admin/maintenance operation.",
+        "Clear all propositions and entities from the knowledge graph. Requires confirm: true. Irreversible. Not gated by an active traversal — admin/maintenance operation.",
       inputSchema: {
-        confirm: z
-          .boolean()
-          .describe("Must be true to proceed — deliberate guard against accidents"),
+        confirm: z.boolean().describe("Must be true to proceed."),
       },
     },
     ({ confirm }) => {

--- a/src/tools/advance.ts
+++ b/src/tools/advance.ts
@@ -10,7 +10,7 @@ export function registerAdvanceTool(server: McpServer, deps: FreelanceToolDeps):
     "freelance_advance",
     {
       description:
-        "Take a labeled edge to move a traversal forward by one node. The edge label comes from the current node's validTransitions (returned by any freelance_* call that reports state). Optional contextUpdates are applied before the edge's condition evaluates, so you can set a condition variable in the same call; updates persist even if the advance fails. If the edge's condition evaluates false, the call errors and the current node is unchanged — fix the relevant context and retry. The engine enforces graph topology: you cannot bypass a condition or jump to a node that isn't directly targeted from where you are.",
+        "Move a traversal forward by taking a labeled edge. Edge label must match one of the current node's validTransitions. Optional contextUpdates are applied before the edge condition evaluates and persist even if the advance fails. The engine enforces graph topology — you can't jump to a non-adjacent node.",
       inputSchema: {
         traversalId: z.string().optional(),
         edge: z.string().min(1),

--- a/src/tools/context-set.ts
+++ b/src/tools/context-set.ts
@@ -10,7 +10,7 @@ export function registerContextSetTool(server: McpServer, deps: FreelanceToolDep
     "freelance_context_set",
     {
       description:
-        "Update traversal context without advancing to a new node. Use this to record work results (e.g. `{ testsPass: true, coverage: 0.92 }`) so that the next freelance_advance can evaluate edge conditions against the updated state. Returns the refreshed list of valid transitions with conditionMet re-evaluated — so you can see which edges are now unlocked before taking one. Alternative: pass contextUpdates directly to freelance_advance in a single call; use context_set when you want to check which edges open up before committing.",
+        "Update traversal context without advancing. Record work results (e.g. `{testsPass: true}`) and see which edge conditions are now satisfied before committing. Alternative: pass contextUpdates directly to freelance_advance in a single call.",
       inputSchema: {
         traversalId: z.string().optional(),
         updates: z.record(z.string(), z.unknown()),

--- a/src/tools/distill.ts
+++ b/src/tools/distill.ts
@@ -8,7 +8,7 @@ export function registerDistillTool(server: McpServer): void {
     "freelance_distill",
     {
       description:
-        "Returns an instruction prompt for distilling a completed task into a workflow graph or refining an existing one. Mode 'distill' (default): after you've finished an ad-hoc task worth capturing for reuse, this prompt tells you how to reconstruct the task history into a new .workflow.yaml definition. Mode 'refine': after running a workflow-guided task that felt awkward (gates fired wrong, edges were missing, instructions were vague), this prompt tells you how to review and improve the graph. The tool returns the prompt itself — it doesn't write a graph for you; it hands you the analysis framework so you do the authoring.",
+        "Get an instruction prompt for creating a new workflow graph from a just-completed task ('distill', default) or improving an existing one ('refine'). Returns the analysis framework — you do the authoring.",
       inputSchema: {
         mode: z.enum(["distill", "refine"]).default("distill"),
       },

--- a/src/tools/guide.ts
+++ b/src/tools/guide.ts
@@ -8,7 +8,7 @@ export function registerGuideTool(server: McpServer): void {
     "freelance_guide",
     {
       description:
-        "Authoring guidance for writing .workflow.yaml graph definitions — schema, conditions, subgraphs, source bindings, edge semantics, and common mistakes. Use this when you're creating or refining a workflow graph (for example, after freelance_distill hands you an authoring prompt). NOT the right tool when you're asked to run an existing workflow — for that, call freelance_list and freelance_start. Call with no topic to see the table of contents.",
+        "Reference guide for workflow authoring (schema, edges, subgraphs, hooks, meta, anti-patterns) and for orientation on the sealed memory workflows (memory:compile, memory:recall). Not the right tool to run an existing workflow — for that, call freelance_list and freelance_start. Call with no topic for the table of contents.",
       inputSchema: {
         topic: z.string().optional(),
       },

--- a/src/tools/inspect.ts
+++ b/src/tools/inspect.ts
@@ -10,7 +10,7 @@ export function registerInspectTool(server: McpServer, deps: FreelanceToolDeps):
     "freelance_inspect",
     {
       description:
-        "Read-only introspection of the current traversal state. The primary recovery tool after context compaction — traversal state lives on the server and survives, but your awareness of where you are doesn't. Detail levels: 'position' (default — current node and valid transitions, minimal), 'full' (position plus full context), 'history' (stack + transitions taken so far). Any `meta` tags set at freelance_start are returned at the top level of the response regardless of detail. Does not mutate anything.",
+        "Read-only view of traversal state. Primary recovery tool after context compaction — traversal state lives on the server and survives. Detail: 'position' (default: current node + validTransitions), 'full' (+ context), 'history' (+ stack and transitions taken). Meta tags always included.",
       inputSchema: {
         traversalId: z.string().optional(),
         detail: z.enum(["position", "full", "history"]).default("position"),

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -9,7 +9,7 @@ export function registerListTool(server: McpServer, deps: FreelanceToolDeps): vo
     "freelance_list",
     {
       description:
-        "Discover what Freelance workflows are available. Returns the set of loaded graph definitions (each with id, name, version, nodeCount) plus any active traversals already running. Call this first in any session that might use Freelance — it's the cheapest way to answer 'what can I run?' and 'am I already mid-workflow?' If any .workflow.yaml files failed to load, the result includes a loadErrors array; call freelance_validate for the specific parse or topology errors.",
+        "List loaded workflow graphs and any active traversals. Call first to discover what's available or to resume an in-progress traversal. Response includes loadErrors when .workflow.yaml files failed to parse — call freelance_validate for details.",
       inputSchema: {},
     },
     () => {

--- a/src/tools/meta-set.ts
+++ b/src/tools/meta-set.ts
@@ -10,7 +10,7 @@ export function registerMetaSetTool(server: McpServer, deps: FreelanceToolDeps):
     "freelance_meta_set",
     {
       description:
-        "Merge opaque tags into a traversal's `meta`. Use this when a lookup key (e.g. a PR url, a branch name) only becomes known mid-traversal. New keys are added, existing keys are overwritten. Freelance never interprets the keys or values — they exist purely so external systems can find the traversal by their own business key. Returns the full merged meta.",
+        "Merge opaque string tags into a traversal's meta map. Use when a lookup key (PR url, branch name) becomes known mid-traversal. New keys add, existing keys overwrite. See `freelance_guide meta`.",
       inputSchema: {
         traversalId: z.string().optional(),
         meta: z.record(z.string(), z.string()).refine((m) => Object.keys(m).length > 0, {

--- a/src/tools/reset.ts
+++ b/src/tools/reset.ts
@@ -10,7 +10,7 @@ export function registerResetTool(server: McpServer, deps: FreelanceToolDeps): v
     "freelance_reset",
     {
       description:
-        "Clear a traversal, discarding its stack and context. Use this to start a workflow over from the beginning or to abandon one before starting a different graph. Requires confirm: true — this is a deliberate guard against accidental resets from ambiguous tool-call sequences, not a security check. Destroyed context cannot be recovered.",
+        "Destroy a traversal, discarding its stack and context. Requires confirm: true. Irreversible.",
       inputSchema: {
         traversalId: z.string().optional(),
         confirm: z.boolean(),

--- a/src/tools/sources-check.ts
+++ b/src/tools/sources-check.ts
@@ -11,7 +11,7 @@ export function registerSourcesCheckTool(server: McpServer, deps: FreelanceToolD
     "freelance_sources_check",
     {
       description:
-        "Verify that previously stamped source hashes still match the files on disk. Takes an array of {path, section?, hash} triples (the hash from an earlier freelance_sources_hash call) and returns which have drifted. Use this when you have a specific set of hashes to check — from a CI step, a hand-curated audit list, or a pinned reference you're about to use. For walking every source binding across every loaded graph instead, use freelance_sources_validate.",
+        "Verify previously stamped source hashes against files on disk. Takes {path, section?, hash} triples and returns drifted entries. For bulk validation across every loaded graph (no explicit hashes), use freelance_sources_validate.",
       inputSchema: {
         sources: z
           .array(

--- a/src/tools/sources-hash.ts
+++ b/src/tools/sources-hash.ts
@@ -11,7 +11,7 @@ export function registerSourcesHashTool(server: McpServer, deps: FreelanceToolDe
     "freelance_sources_hash",
     {
       description:
-        "Hash source files (or sections of files) to generate content hashes for graph source bindings. This is an authoring-time tool: when you're writing a workflow node that references a doc or file as provenance, you stamp the current hash here so freelance_sources_check can later detect drift. Each source is a {path, section?} pair; if section is provided and a section resolver is configured (e.g. Markdown heading extraction), only that section's content is hashed — otherwise the full file. Not used at runtime; provenance validation is a build concern.",
+        "Generate content hashes for graph source bindings. Authoring-time tool — stamp hashes so freelance_sources_check can detect drift later. Each entry is a {path, section?} pair; section-scoped hashes require a configured section resolver (e.g. Markdown heading extraction).",
       inputSchema: {
         sources: z
           .array(

--- a/src/tools/sources-validate.ts
+++ b/src/tools/sources-validate.ts
@@ -13,7 +13,7 @@ export function registerSourcesValidateTool(server: McpServer, deps: FreelanceTo
     "freelance_sources_validate",
     {
       description:
-        "Walk every source binding in every loaded graph (or a single graph if graphId is passed) and report drift against the current filesystem. Broader than freelance_sources_check — you don't pass hashes explicitly; this tool reads them from the graph definitions directly. Use when you want an at-a-glance health check of all provenance: run it after a pull, before a release, or when diagnosing why a workflow is behaving unexpectedly against current sources. Returns per-node drift reports with expected vs actual hashes.",
+        "Validate every source binding across loaded graphs (or one graph by graphId) against the filesystem. Reads expected hashes from graph definitions directly. Returns per-node drift reports with expected vs actual hashes. Run after a pull, before a release, or when diagnosing source-drift symptoms.",
       inputSchema: {
         graphId: z.string().optional(),
       },

--- a/src/tools/start.ts
+++ b/src/tools/start.ts
@@ -11,7 +11,7 @@ export function registerStartTool(server: McpServer, deps: FreelanceToolDeps): v
     "freelance_start",
     {
       description:
-        "Begin a new traversal of a workflow graph — this creates a server-side state machine rooted at the graph's start node. Returns a traversalId which is passed to advance/inspect/context_set (or omitted when there's only one active traversal). Call freelance_list first to see available graphs. initialContext is an optional map of key/value pairs the workflow's conditions and instructions can reference from the first node onward. meta is an optional map of opaque string tags (e.g. `{ externalKey: 'DEV-1234' }`) that Freelance indexes but never interprets — they surface on list/inspect/advance responses so external callers can find this traversal by their own business key. If the graph declares `requiredMeta`, start will reject calls that don't supply those keys (unless the start node's onEnter hooks set them). See `freelance_guide meta`.",
+        "Start a new traversal of a workflow graph. Returns the start node's instructions and a traversalId (omit on subsequent calls when only one traversal is active). Pass initialContext for seed state, meta for external lookup tags (ticket id, PR url). If the graph declares requiredMeta, start rejects calls missing those keys. See `freelance_guide meta`.",
       inputSchema: {
         graphId: z.string().min(1),
         initialContext: z.record(z.string(), z.unknown()).optional(),

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -14,7 +14,7 @@ export function registerValidateTool(server: McpServer, deps: FreelanceToolDeps)
     "freelance_validate",
     {
       description:
-        "Validate workflow graph definitions for structural errors. Walks configured graphsDirs, parses every .workflow.yaml, and reports schema errors (missing fields, wrong types), expression errors (invalid edge conditions or validation rules), topology errors (unreachable nodes, cycles without a breaking node, invalid subgraph references), and return schema errors. This is authoring-time validation — runtime conditions are checked by the engine at advance time. Use it to diagnose why a graph isn't appearing in freelance_list, or to validate a new graph before it ships.",
+        "Validate .workflow.yaml files for schema, expression (edge conditions, validation rules), topology (unreachable nodes, unbroken cycles, invalid subgraph refs), and return-schema errors. Authoring-time validation — use to diagnose why a graph isn't loading or to verify a new graph before it ships.",
       inputSchema: {
         graphId: z.string().optional(),
       },


### PR DESCRIPTION
Closes #82.

## Framing

Three surfaces carry instruction to the agent; each has a distinct lifecycle:

| Surface | Lifecycle | Role |
|---|---|---|
| MCP tool descriptions | Cached once at \`tools/list\`; sit in system-prompt context every turn | Describe what the tool does + unique behavioral facts + hard constraints |
| Workflow node \`instructions\` (messages.ts) | Returned fresh in each \`freelance_advance\` response; sits in recent tool-result message | **MVP authoring surface** — agent reads at emit time |
| \`freelance_guide\` topics | On-demand, agent-initiated | Orientation/discovery (\"what is this, when do I use it\") |

Previous attempt (#108, closed) duplicated the memory workflow rubric into new \`memory-tools\` / \`sources\` guide topics. Redundant: the rubric lives in \`messages.ts\` and the agent always sees it at emit time since memory tools are workflow-gated. Closed and reverted.

## What this PR does

- **Trim all 22 tool descriptions** to focused one-liners. Keep unique behavioral facts (dedup normalization, entity resolution priority, FTS5 query syntax, source-root path semantics) and hard gating. Drop rubric text that duplicates \`messages.ts\`.
- **Trim \`memory_emit\` field \`.describe()\` strings** to schema-minimal.
- **Add ONE guide topic: \`memory-workflows\`** — orientation only. Describes memory:compile and memory:recall at a \"what they are / when to use / node shape\" level. Explicitly points the agent at the workflow node instructions for the authoring rubric.
- **Update \`freelance_guide\` tool description** to reference the new topic.

No behavioral changes. All 745 tests pass.

## Numbers

| | Before | After |
|---|---|---|
| Total tool description words | ~1,453 | ~545 |
| Reduction | — | ~62% |
| New guide topics | — | 1 (\`memory-workflows\`) |

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 745/745 pass
- [x] \`npx biome check src/\` — no new violations
- [ ] Smoke-test a memory:compile run against a fixture to sanity-check nothing regressed in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)