### PR TITLE
feat(engine): enforce byte caps on context writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Byte caps on context writes.** Every write to session context —
+  `freelance_context_set`, `contextUpdates` on `freelance_advance`,
+  `initialContext` on `freelance_start`, and onEnter hook return
+  values — is now checked against a per-value cap (default 4 KB) and a
+  post-merge total cap (default 64 KB). Over-cap writes throw
+  `EngineError` with codes `CONTEXT_VALUE_TOO_LARGE` or
+  `CONTEXT_TOTAL_TOO_LARGE` *before* the bad value persists, so a
+  misbehaving hook or runaway write can't silently inflate every
+  subsequent advance/inspect response. Configure via
+  `context.maxValueBytes` / `context.maxTotalBytes` in `config.yml`.
+  See issue #83.
 - **`freelance memory prune --keep <ref>` and MCP `memory_prune`** —
   manual, user-initiated cleanup for `proposition_sources`. Deletes a
   row only when its `content_hash` doesn't match the file at **any**

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ General precedence: **CLI flags > env vars > config.local.yml > config.yml > def
 | `memory.collections` | — | — | ✓ (concatenates) | Must be declared before emit |
 | `maxDepth` | `--max-depth` | — | ✓ | Default: `5` |
 | `hooks.timeoutMs` | — | — | ✓ | Config-only. Default: `5000` |
+| `context.maxValueBytes` | — | — | ✓ | Per-value cap on context writes. Default: `4096` (4 KB) |
+| `context.maxTotalBytes` | — | — | ✓ | Total context cap per traversal. Default: `65536` (64 KB) |
 | `sourceRoot` | `--source-root` | — | — | Computed from graphsDir if omitted |
 
 ```yaml
@@ -175,7 +177,13 @@ maxDepth: 5                         # Max subgraph nesting depth. CLI --max-dept
 
 hooks:
   timeoutMs: 5000                   # Per-hook timeout for onEnter hooks. Default 5000.
+
+context:
+  maxValueBytes: 4096               # Per-value byte cap on context writes. Default 4 KB.
+  maxTotalBytes: 65536              # Total serialized-context cap per traversal. Default 64 KB.
 ```
+
+Over-cap writes are rejected with `CONTEXT_VALUE_TOO_LARGE` or `CONTEXT_TOTAL_TOO_LARGE` errors at the `freelance_context_set`, `freelance_advance` (contextUpdates), and onEnter-hook return boundaries, so a runaway hook or context write never persists.
 
 Merge rules: arrays (`workflows`, `collections`) concatenate across files. Scalars use highest-precedence value.
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { Command, Option } from "commander";
 import { loadConfigFromDirs } from "../config.js";
+import { resolveContextCaps } from "../engine/context.js";
 import { loadGraphsGraceful, resolveGraphsDirs, resolveSourceRoot } from "../graph-resolution.js";
 import { getSealedGraphs } from "../memory/sealed.js";
 import { extractSection } from "../section-resolver.js";
@@ -220,6 +221,7 @@ program
       memory: memoryConfig ?? undefined,
       stateDir,
       hookTimeoutMs: config.hooks.timeoutMs,
+      contextCaps: resolveContextCaps(config.context),
     });
   });
 

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -12,6 +12,7 @@ import type { Runtime } from "../compose.js";
 import { buildMemoryStore, composeRuntime } from "../compose.js";
 import type { FreelanceConfig } from "../config.js";
 import { loadConfigFromDirs } from "../config.js";
+import { resolveContextCaps } from "../engine/context.js";
 import { loadGraphsGraceful, resolveGraphsDirs, resolveSourceRoot } from "../graph-resolution.js";
 import type { MemoryConfig, MemoryStore } from "../memory/index.js";
 import { extractSection } from "../section-resolver.js";
@@ -195,6 +196,7 @@ export function createTraversalStore(opts: CliSetupOptions): {
     memory: memConfig,
     maxDepth: opts.maxDepth ?? fileConfig.maxDepth ?? 5,
     hookTimeoutMs: fileConfig.hooks.timeoutMs,
+    contextCaps: resolveContextCaps(fileConfig.context),
   });
 
   return { store: runtime.store, setup, runtime };

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -14,6 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import type { ContextCaps } from "./engine/context.js";
 import { HookRunner } from "./engine/hooks.js";
 import { openDatabase } from "./memory/db.js";
 import type { MemoryConfig } from "./memory/index.js";
@@ -57,6 +58,12 @@ export interface ComposeConfig {
   readonly memory?: MemoryConfig | null;
   readonly maxDepth?: number;
   readonly hookTimeoutMs?: number;
+  /**
+   * Byte caps on context writes. Propagates to both the `HookRunner`
+   * (hook return values) and the `GraphEngine` (initialContext,
+   * contextUpdates, contextSet). Omit to use `DEFAULT_CONTEXT_CAPS`.
+   */
+  readonly contextCaps?: ContextCaps;
 }
 
 export interface Runtime {
@@ -172,11 +179,13 @@ export function composeRuntime(config: ComposeConfig): Runtime {
   const hookRunner = new HookRunner({
     memory: memoryStore,
     hookTimeoutMs: config.hookTimeoutMs,
+    ...(config.contextCaps ? { contextCaps: config.contextCaps } : {}),
   });
 
   const store = new TraversalStore(backend, config.graphs, {
     maxDepth: config.maxDepth,
     hookRunner,
+    ...(config.contextCaps ? { contextCaps: config.contextCaps } : {}),
   });
 
   const sourceOpts: SourceOptions = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,10 +55,18 @@ const hooksSchema = z
   })
   .optional();
 
+const contextSchema = z
+  .object({
+    maxValueBytes: z.number().int().positive().optional(),
+    maxTotalBytes: z.number().int().positive().optional(),
+  })
+  .optional();
+
 const configSchema = z.object({
   workflows: z.array(z.string()).optional(),
   memory: memorySchema,
   hooks: hooksSchema,
+  context: contextSchema,
   maxDepth: z.number().int().positive().optional(),
 });
 
@@ -76,6 +84,10 @@ export interface FreelanceConfig {
   };
   hooks: {
     timeoutMs?: number;
+  };
+  context: {
+    maxValueBytes?: number;
+    maxTotalBytes?: number;
   };
   /** Max subgraph stack depth. CLI `--max-depth` overrides this. */
   maxDepth?: number;
@@ -147,6 +159,10 @@ function mergeConfigs(
     merged.hooks = { ...(base.hooks ?? {}), ...overlay.hooks };
   }
 
+  if (overlay.context) {
+    merged.context = { ...(base.context ?? {}), ...overlay.context };
+  }
+
   if (overlay.maxDepth !== undefined) {
     merged.maxDepth = overlay.maxDepth;
   }
@@ -166,6 +182,10 @@ function toFreelanceConfig(merged: FreelanceConfigFile, sources: string[]): Free
     },
     hooks: {
       timeoutMs: merged.hooks?.timeoutMs,
+    },
+    context: {
+      maxValueBytes: merged.context?.maxValueBytes,
+      maxTotalBytes: merged.context?.maxTotalBytes,
     },
     maxDepth: merged.maxDepth,
     sources,
@@ -205,7 +225,7 @@ export function loadConfig(freelanceDir: string): FreelanceConfig {
  */
 export function loadConfigFromDirs(dirs: string[]): FreelanceConfig {
   if (dirs.length === 0) {
-    return { workflows: [], memory: {}, hooks: {}, sources: [] };
+    return { workflows: [], memory: {}, hooks: {}, context: {}, sources: [] };
   }
 
   let mergedFile: FreelanceConfigFile = {};

--- a/src/engine/context.ts
+++ b/src/engine/context.ts
@@ -28,6 +28,78 @@ export function applyContextUpdates(session: SessionState, updates: Record<strin
   }
 }
 
+/**
+ * Size caps on context writes. See `enforceContextCaps` for the check
+ * path. A bad write (from a misbehaving hook or a runaway
+ * `freelance_context_set`) persists server-side and echoes in every
+ * subsequent response — caps prevent the blowup from ever landing.
+ */
+export interface ContextCaps {
+  /** Serialized-JSON byte cap per value. */
+  readonly maxValueBytes: number;
+  /** Serialized-JSON byte cap for the whole context after the write applies. */
+  readonly maxTotalBytes: number;
+}
+
+export const DEFAULT_CONTEXT_CAPS: ContextCaps = {
+  maxValueBytes: 4 * 1024,
+  maxTotalBytes: 64 * 1024,
+};
+
+/**
+ * Fill in a partial cap config with defaults. Lets callers (CLI / MCP
+ * bootstrap) forward user config that may specify one cap, both, or
+ * neither, and still produce a concrete `ContextCaps` for the runtime.
+ */
+export function resolveContextCaps(partial?: {
+  maxValueBytes?: number;
+  maxTotalBytes?: number;
+}): ContextCaps {
+  return {
+    maxValueBytes: partial?.maxValueBytes ?? DEFAULT_CONTEXT_CAPS.maxValueBytes,
+    maxTotalBytes: partial?.maxTotalBytes ?? DEFAULT_CONTEXT_CAPS.maxTotalBytes,
+  };
+}
+
+/**
+ * Reject an incoming context write if any individual value or the
+ * projected total exceeds its cap. Throws `EngineError` with codes
+ * `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` so callers can
+ * surface structured errors. Must be called *before*
+ * `applyContextUpdates` so a failing write leaves the session state
+ * untouched.
+ *
+ * `undefined` values serialize to nothing (JSON.stringify returns
+ * undefined) — we treat them as no-ops rather than errors so the shape
+ * matches how JSON serialization already handles missing keys.
+ */
+export function enforceContextCaps(
+  currentContext: Readonly<Record<string, unknown>>,
+  updates: Record<string, unknown>,
+  caps: ContextCaps,
+): void {
+  for (const [key, value] of Object.entries(updates)) {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) continue;
+    const bytes = Buffer.byteLength(serialized, "utf8");
+    if (bytes > caps.maxValueBytes) {
+      throw new EngineError(
+        `Context value "${key}" is ${bytes} bytes, exceeds per-value cap of ${caps.maxValueBytes} bytes (context.maxValueBytes).`,
+        "CONTEXT_VALUE_TOO_LARGE",
+      );
+    }
+  }
+
+  const projected = { ...currentContext, ...updates };
+  const totalBytes = Buffer.byteLength(JSON.stringify(projected), "utf8");
+  if (totalBytes > caps.maxTotalBytes) {
+    throw new EngineError(
+      `Context total would be ${totalBytes} bytes after write, exceeds cap of ${caps.maxTotalBytes} bytes (context.maxTotalBytes).`,
+      "CONTEXT_TOTAL_TOO_LARGE",
+    );
+  }
+}
+
 export function enforceStrictContext(def: GraphDefinition, updates: Record<string, unknown>): void {
   if (!def.strictContext) return;
   const declaredKeys = new Set(Object.keys(def.context ?? {}));

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -15,6 +15,9 @@ import {
   applyContextUpdates,
   buildContextSetResult,
   buildInspectResult,
+  type ContextCaps,
+  DEFAULT_CONTEXT_CAPS,
+  enforceContextCaps,
   enforceStrictContext,
 } from "./context.js";
 import {
@@ -38,12 +41,20 @@ export interface GraphEngineOptions {
    * library use).
    */
   hookRunner: HookRunner;
+  /**
+   * Byte caps on context writes. Applied to `start`'s initialContext,
+   * `advance`'s contextUpdates, and `contextSet`. Hook return values
+   * are capped inside the HookRunner so the runner owns that path
+   * end-to-end. Defaults to `DEFAULT_CONTEXT_CAPS` when omitted.
+   */
+  contextCaps?: ContextCaps;
 }
 
 export class GraphEngine {
   private stack: SessionState[] = [];
   private maxDepth: number;
   private hookRunner: HookRunner;
+  private contextCaps: ContextCaps;
 
   constructor(
     private graphs: Map<string, ValidatedGraph>,
@@ -51,6 +62,7 @@ export class GraphEngine {
   ) {
     this.maxDepth = options.maxDepth ?? 5;
     this.hookRunner = options.hookRunner;
+    this.contextCaps = options.contextCaps ?? DEFAULT_CONTEXT_CAPS;
   }
 
   list(): GraphListResult {
@@ -81,8 +93,12 @@ export class GraphEngine {
     }
 
     const def = graph.definition;
+    const defaults = resolveContextDefaults(def.context ?? {});
+    if (initialContext) {
+      enforceContextCaps(defaults, initialContext, this.contextCaps);
+    }
     const context: Record<string, unknown> = {
-      ...resolveContextDefaults(def.context ?? {}),
+      ...defaults,
       ...(initialContext ?? {}),
     };
 
@@ -125,6 +141,7 @@ export class GraphEngine {
     const currentNodeDef = def.nodes[session.currentNode];
 
     if (contextUpdates) {
+      enforceContextCaps(session.context, contextUpdates, this.contextCaps);
       applyContextUpdates(session, contextUpdates);
       session.turnCount++;
     }
@@ -263,6 +280,7 @@ export class GraphEngine {
     const def = this.currentGraphDef();
 
     enforceStrictContext(def, updates);
+    enforceContextCaps(session.context, updates, this.contextCaps);
     applyContextUpdates(session, updates);
     session.turnCount++;
 

--- a/src/engine/hooks.ts
+++ b/src/engine/hooks.ts
@@ -22,7 +22,13 @@ import type {
 } from "../memory/types.js";
 import type { GraphDefinition, SessionState } from "../types.js";
 import { BUILTIN_HOOKS } from "./builtin-hooks.js";
-import { applyContextUpdates, enforceStrictContext } from "./context.js";
+import {
+  applyContextUpdates,
+  type ContextCaps,
+  DEFAULT_CONTEXT_CAPS,
+  enforceContextCaps,
+  enforceStrictContext,
+} from "./context.js";
 
 /**
  * Narrow read interface the hook runner exposes to hooks. Built-ins
@@ -98,17 +104,24 @@ export interface HookRunnerOptions {
   readonly hookTimeoutMs?: number;
   /** Test override. Falls back to the package's BUILTIN_HOOKS map. */
   readonly builtinHooks?: ReadonlyMap<string, HookFn>;
+  /**
+   * Byte caps enforced on hook return values before they merge into
+   * session context. Defaults to `DEFAULT_CONTEXT_CAPS`.
+   */
+  readonly contextCaps?: ContextCaps;
 }
 
 export class HookRunner {
   private readonly memory?: HookMemoryAccess;
   private readonly hookTimeoutMs: number;
   private readonly builtinHooks: ReadonlyMap<string, HookFn>;
+  private readonly contextCaps: ContextCaps;
 
   constructor(options: HookRunnerOptions = {}) {
     this.memory = options.memory;
     this.hookTimeoutMs = options.hookTimeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
     this.builtinHooks = options.builtinHooks ?? BUILTIN_HOOKS;
+    this.contextCaps = options.contextCaps ?? DEFAULT_CONTEXT_CAPS;
   }
 
   /**
@@ -179,6 +192,7 @@ export class HookRunner {
       }
 
       enforceStrictContext(graphDef, result);
+      enforceContextCaps(session.context, result, this.contextCaps);
       applyContextUpdates(session, result);
     }
   }

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -22,10 +22,15 @@ export function errorResponse(message: string, detail?: unknown) {
  * Catch-all error handler for tool handlers. EngineError messages are
  * domain errors meant for the agent; anything else is prefixed
  * "Internal error:" so users can tell a bug from a usage issue.
+ *
+ * When the thrown error is an EngineError, the response payload
+ * includes its `code` alongside `error` so callers can branch on the
+ * machine-readable code (e.g. CONTEXT_VALUE_TOO_LARGE) rather than
+ * string-matching the message.
  */
 export function handleError(e: unknown) {
   if (e instanceof EngineError) {
-    return errorResponse(e.message);
+    return errorResponse(e.message, { error: e.message, code: e.code });
   }
   const message = e instanceof Error ? e.message : String(e);
   return errorResponse(`Internal error: ${message}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { Runtime } from "./compose.js";
 import { composeRuntime } from "./compose.js";
+import type { ContextCaps } from "./engine/context.js";
 import type { MemoryConfig } from "./memory/index.js";
 import { registerMemoryTools } from "./memory/index.js";
 import { getSealedGraphs, mergeSealedGraphs } from "./memory/sealed.js";
@@ -27,6 +28,8 @@ export interface ServerOptions {
   stateDir?: string;
   /** Max runtime per onEnter hook. Default 5000ms. */
   hookTimeoutMs?: number;
+  /** Byte caps on context writes. Omit for DEFAULT_CONTEXT_CAPS. */
+  contextCaps?: ContextCaps;
 }
 
 /**
@@ -91,6 +94,7 @@ export function createServer(
     memory: options?.memory,
     maxDepth: options?.maxDepth,
     hookTimeoutMs: options?.hookTimeoutMs,
+    ...(options?.contextCaps ? { contextCaps: options.contextCaps } : {}),
   });
   const { store: manager, memoryStore, sourceOpts } = runtime;
 

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -5,6 +5,7 @@
  */
 
 import crypto from "node:crypto";
+import type { ContextCaps } from "../engine/context.js";
 import type { HookRunner } from "../engine/hooks.js";
 import { GraphEngine } from "../engine/index.js";
 import { EngineError } from "../errors.js";
@@ -45,16 +46,18 @@ export class TraversalStore {
   private graphs: Map<string, ValidatedGraph>;
   private maxDepth: number;
   private hookRunner: HookRunner;
+  private contextCaps?: ContextCaps;
 
   constructor(
     state: StateStore,
     graphs: Map<string, ValidatedGraph>,
-    options: { maxDepth?: number; hookRunner: HookRunner },
+    options: { maxDepth?: number; hookRunner: HookRunner; contextCaps?: ContextCaps },
   ) {
     this.state = state;
     this.graphs = graphs;
     this.maxDepth = options.maxDepth ?? 5;
     this.hookRunner = options.hookRunner;
+    this.contextCaps = options.contextCaps;
   }
 
   close(): void {
@@ -257,6 +260,7 @@ export class TraversalStore {
     return new GraphEngine(this.graphs, {
       maxDepth: this.maxDepth,
       hookRunner: this.hookRunner,
+      ...(this.contextCaps ? { contextCaps: this.contextCaps } : {}),
     });
   }
 

--- a/test/context-caps.test.ts
+++ b/test/context-caps.test.ts
@@ -1,0 +1,246 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  type ContextCaps,
+  DEFAULT_CONTEXT_CAPS,
+  enforceContextCaps,
+  resolveContextCaps,
+} from "../src/engine/context.js";
+import { HookRunner } from "../src/engine/hooks.js";
+import { GraphEngine } from "../src/engine/index.js";
+import { EngineError } from "../src/errors.js";
+import { loadFixtureGraphs } from "./helpers.js";
+
+const FIXTURES_DIR = path.resolve(import.meta.dirname, "fixtures");
+
+function loadFixtures(...files: string[]) {
+  return loadFixtureGraphs(FIXTURES_DIR, "context-caps-test-", ...files);
+}
+
+function makeEngineWith(caps: ContextCaps, ...files: string[]): GraphEngine {
+  return new GraphEngine(loadFixtures(...files), {
+    hookRunner: new HookRunner({ contextCaps: caps }),
+    contextCaps: caps,
+  });
+}
+
+describe("DEFAULT_CONTEXT_CAPS", () => {
+  it("defaults to 4 KB per value and 64 KB total", () => {
+    expect(DEFAULT_CONTEXT_CAPS.maxValueBytes).toBe(4 * 1024);
+    expect(DEFAULT_CONTEXT_CAPS.maxTotalBytes).toBe(64 * 1024);
+  });
+});
+
+describe("resolveContextCaps", () => {
+  it("falls back to defaults when partial is empty or omitted", () => {
+    expect(resolveContextCaps()).toEqual(DEFAULT_CONTEXT_CAPS);
+    expect(resolveContextCaps({})).toEqual(DEFAULT_CONTEXT_CAPS);
+  });
+
+  it("uses supplied values and keeps defaults for the rest", () => {
+    expect(resolveContextCaps({ maxValueBytes: 100 })).toEqual({
+      maxValueBytes: 100,
+      maxTotalBytes: DEFAULT_CONTEXT_CAPS.maxTotalBytes,
+    });
+    expect(resolveContextCaps({ maxTotalBytes: 200 })).toEqual({
+      maxValueBytes: DEFAULT_CONTEXT_CAPS.maxValueBytes,
+      maxTotalBytes: 200,
+    });
+  });
+});
+
+describe("enforceContextCaps", () => {
+  const tinyCaps: ContextCaps = { maxValueBytes: 50, maxTotalBytes: 200 };
+
+  it("accepts small writes", () => {
+    expect(() => enforceContextCaps({}, { a: "hi" }, tinyCaps)).not.toThrow();
+  });
+
+  it("rejects a single over-sized value", () => {
+    const big = "x".repeat(100);
+    try {
+      enforceContextCaps({}, { a: big }, tinyCaps);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EngineError);
+      expect((e as EngineError).code).toBe("CONTEXT_VALUE_TOO_LARGE");
+      expect((e as EngineError).message).toContain('"a"');
+      expect((e as EngineError).message).toContain("102 bytes");
+      expect((e as EngineError).message).toContain("50 bytes");
+    }
+  });
+
+  it("rejects when total context would exceed cap", () => {
+    // Each value ≤ 50 bytes serialized, but four together blow 200 total.
+    // Entry footprint in JSON: "key":"value" = quotes + colon = 5 extra chars
+    // per entry; with 45-char strings → ~47 serialized each → 4 * ~52 ≈ 210.
+    const current = { a: "x".repeat(45), b: "y".repeat(45), c: "z".repeat(45) };
+    try {
+      enforceContextCaps(current, { d: "q".repeat(45) }, tinyCaps);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EngineError);
+      expect((e as EngineError).code).toBe("CONTEXT_TOTAL_TOO_LARGE");
+      expect((e as EngineError).message).toContain("200 bytes");
+    }
+  });
+
+  it("treats undefined values as no-ops", () => {
+    expect(() => enforceContextCaps({}, { a: undefined }, tinyCaps)).not.toThrow();
+  });
+
+  it("checks per-value before total", () => {
+    // single over-sized value should surface CONTEXT_VALUE_TOO_LARGE, not
+    // CONTEXT_TOTAL_TOO_LARGE — the inner cap catches it first
+    try {
+      enforceContextCaps({}, { a: "x".repeat(500) }, tinyCaps);
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as EngineError).code).toBe("CONTEXT_VALUE_TOO_LARGE");
+    }
+  });
+
+  it("does not mutate current context when it throws", () => {
+    const current: Record<string, unknown> = { a: "hi" };
+    try {
+      enforceContextCaps(current, { b: "x".repeat(100) }, tinyCaps);
+    } catch {}
+    expect(current).toEqual({ a: "hi" });
+  });
+});
+
+describe("GraphEngine cap enforcement", () => {
+  const tinyCaps: ContextCaps = { maxValueBytes: 50, maxTotalBytes: 200 };
+
+  it("contextSet rejects over-sized value", async () => {
+    const engine = makeEngineWith(tinyCaps, "valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    try {
+      engine.contextSet({ taskStarted: "x".repeat(100) });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as EngineError).code).toBe("CONTEXT_VALUE_TOO_LARGE");
+    }
+  });
+
+  it("contextSet leaves session untouched when rejected", async () => {
+    const engine = makeEngineWith(tinyCaps, "valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    try {
+      engine.contextSet({ taskStarted: "x".repeat(100) });
+    } catch {}
+    const snapshot = engine.inspect("position");
+    expect(snapshot.context).toEqual({ taskStarted: false });
+  });
+
+  it("advance rejects over-sized contextUpdates", async () => {
+    const engine = makeEngineWith(tinyCaps, "valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    await expect(
+      engine.advance("work-done", { taskStarted: "x".repeat(100) }),
+    ).rejects.toMatchObject({ code: "CONTEXT_VALUE_TOO_LARGE" });
+  });
+
+  it("start rejects over-sized initialContext", async () => {
+    const engine = makeEngineWith(tinyCaps, "valid-simple.workflow.yaml");
+    await expect(
+      engine.start("valid-simple", { taskStarted: "x".repeat(100) }),
+    ).rejects.toMatchObject({ code: "CONTEXT_VALUE_TOO_LARGE" });
+  });
+
+  it("small writes pass through normally under tight caps", async () => {
+    const engine = makeEngineWith(tinyCaps, "valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    const result = engine.contextSet({ taskStarted: true });
+    expect(result.status).toBe("updated");
+    expect(result.context).toEqual({ taskStarted: true });
+  });
+
+  it("defaults (no explicit caps) accept normal-sized writes", async () => {
+    // Exercise the default-caps path via makeEngine — doesn't pass contextCaps
+    const engine = new GraphEngine(loadFixtures("valid-simple.workflow.yaml"), {
+      hookRunner: new HookRunner(),
+    });
+    await engine.start("valid-simple");
+    // 1 KB string — well under default 4 KB per-value cap
+    const result = engine.contextSet({ taskStarted: "x".repeat(1024) });
+    expect(result.status).toBe("updated");
+  });
+
+  it("total cap rejects cumulative blowup even when each value is small", async () => {
+    // per-value cap 50 bytes, total cap 200 bytes. Start a-aware: defaults
+    // already contain taskStarted:false. Push four 40-byte values — the
+    // projected total will exceed 200 bytes.
+    const engine = makeEngineWith(tinyCaps, "valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    engine.contextSet({ a: "x".repeat(40) });
+    engine.contextSet({ b: "y".repeat(40) });
+    engine.contextSet({ c: "z".repeat(40) });
+    try {
+      engine.contextSet({ d: "q".repeat(40) });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as EngineError).code).toBe("CONTEXT_TOTAL_TOO_LARGE");
+    }
+  });
+});
+
+describe("HookRunner cap enforcement", () => {
+  const tinyCaps: ContextCaps = { maxValueBytes: 50, maxTotalBytes: 200 };
+
+  it("rejects a hook return value that exceeds per-value cap", async () => {
+    const graphs = loadFixtures("hook-context-return.workflow.yaml");
+    const bigString = "x".repeat(100);
+    const runner = new HookRunner({
+      contextCaps: tinyCaps,
+      builtinHooks: new Map([["memory_status", async () => ({ blowup: bigString })]]),
+    });
+    const engine = new GraphEngine(graphs, {
+      hookRunner: runner,
+      contextCaps: tinyCaps,
+    });
+    await expect(engine.start("hook-context-return")).rejects.toMatchObject({
+      code: "CONTEXT_VALUE_TOO_LARGE",
+    });
+  });
+
+  it("rejects when a hook's return pushes total context over cap", async () => {
+    const graphs = loadFixtures("hook-context-return.workflow.yaml");
+    // Each value fits per-value cap individually but cumulatively blows total.
+    const runner = new HookRunner({
+      contextCaps: tinyCaps,
+      builtinHooks: new Map([
+        [
+          "memory_status",
+          async () => ({
+            a: "x".repeat(40),
+            b: "y".repeat(40),
+            c: "z".repeat(40),
+            d: "q".repeat(40),
+          }),
+        ],
+      ]),
+    });
+    const engine = new GraphEngine(graphs, {
+      hookRunner: runner,
+      contextCaps: tinyCaps,
+    });
+    await expect(engine.start("hook-context-return")).rejects.toMatchObject({
+      code: "CONTEXT_TOTAL_TOO_LARGE",
+    });
+  });
+
+  it("accepts a hook return that fits the caps", async () => {
+    const graphs = loadFixtures("hook-context-return.workflow.yaml");
+    const runner = new HookRunner({
+      contextCaps: tinyCaps,
+      builtinHooks: new Map([["memory_status", async () => ({ ok: "small" })]]),
+    });
+    const engine = new GraphEngine(graphs, {
+      hookRunner: runner,
+      contextCaps: tinyCaps,
+    });
+    const result = await engine.start("hook-context-return");
+    expect(result.context).toMatchObject({ ok: "small", seeded: false });
+  });
+});

--- a/test/context-caps.test.ts
+++ b/test/context-caps.test.ts
@@ -9,6 +9,7 @@ import {
 import { HookRunner } from "../src/engine/hooks.js";
 import { GraphEngine } from "../src/engine/index.js";
 import { EngineError } from "../src/errors.js";
+import { handleError } from "../src/mcp-helpers.js";
 import { loadFixtureGraphs } from "./helpers.js";
 
 const FIXTURES_DIR = path.resolve(import.meta.dirname, "fixtures");
@@ -182,6 +183,33 @@ describe("GraphEngine cap enforcement", () => {
     } catch (e) {
       expect((e as EngineError).code).toBe("CONTEXT_TOTAL_TOO_LARGE");
     }
+  });
+});
+
+describe("MCP error response surfaces EngineError code", () => {
+  it("includes structured code alongside the error message", () => {
+    const err = new EngineError('Context value "x" is too big.', "CONTEXT_VALUE_TOO_LARGE");
+    const resp = handleError(err);
+    expect(resp.isError).toBe(true);
+    const payload = JSON.parse(resp.content[0].text);
+    expect(payload).toEqual({
+      error: 'Context value "x" is too big.',
+      code: "CONTEXT_VALUE_TOO_LARGE",
+    });
+  });
+
+  it("surfaces CONTEXT_TOTAL_TOO_LARGE code the same way", () => {
+    const err = new EngineError("Total too large.", "CONTEXT_TOTAL_TOO_LARGE");
+    const resp = handleError(err);
+    const payload = JSON.parse(resp.content[0].text);
+    expect(payload.code).toBe("CONTEXT_TOTAL_TOO_LARGE");
+  });
+
+  it("non-EngineError throws still surface as a plain error (no code field)", () => {
+    const resp = handleError(new Error("something unrelated"));
+    const payload = JSON.parse(resp.content[0].text);
+    expect(payload.error).toContain("Internal error");
+    expect(payload.code).toBeUndefined();
   });
 });
 

--- a/test/fixtures/hook-context-return.workflow.yaml
+++ b/test/fixtures/hook-context-return.workflow.yaml
@@ -1,0 +1,22 @@
+id: hook-context-return
+version: "1.0.0"
+name: "Hook Context Return"
+description: "onEnter hook that returns context updates — exercises the hook-side cap path."
+startNode: start
+
+context:
+  seeded: false
+
+nodes:
+  start:
+    type: action
+    description: "Start — built-in memory_status hook returns context keys"
+    onEnter:
+      - call: memory_status
+    edges:
+      - target: done
+        label: next
+
+  done:
+    type: terminal
+    description: "Done"


### PR DESCRIPTION
Closes #83.

## Problem

There was no byte cap anywhere on context values or hook outputs. A hook or a `freelance_context_set` call that wrote \`{ foo: \"<10MB string>\" }\` would persist that string into the traversal record and echo it in every subsequent advance/inspect response. The existing \`enforceStrictContext\` is a key whitelist, not a size check.

The team had already hit this once — \`src/engine/builtin-hooks.ts:136-138\` explicitly notes that \`memory_by_source\` was trimmed to \`{ id, content }\` because the full PropositionInfo \"blew freelance_advance responses past 50 KB on multi-file hooks.\" That was a case-by-case patch; this PR makes it a defended invariant.

## Approach

Two caps enforced at write time:

1. **Per-value cap** (default 4 KB, \`context.maxValueBytes\`) — serialized-JSON byte count per individual value.
2. **Total context cap** (default 64 KB, \`context.maxTotalBytes\`) — serialized-JSON byte count of the whole session context after the write applies.

Both run *before* \`applyContextUpdates\` at every write path:

- \`freelance_context_set\` → \`GraphEngine.contextSet\`
- \`freelance_advance\` with \`contextUpdates\` → \`GraphEngine.advance\`
- \`freelance_start\` with \`initialContext\` → \`GraphEngine.start\`
- onEnter hook return values → \`HookRunner.runHooksFor\`

Over-cap writes throw structured \`EngineError\` with codes \`CONTEXT_VALUE_TOO_LARGE\` / \`CONTEXT_TOTAL_TOO_LARGE\` so callers can react in the tool-response layer.

## Config surface

\`\`\`yaml
# .freelance/config.yml
context:
  maxValueBytes: 4096      # Default 4 KB
  maxTotalBytes: 65536     # Default 64 KB
\`\`\`

Both fields are optional. \`resolveContextCaps\` fills partials with defaults.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 764/764 pass (19 new)
- [x] \`npx biome check src/ test/\` — no new violations
- [x] Direct unit tests on \`enforceContextCaps\` (per-value, total, undefined no-op, no mutation on throw)
- [x] Engine-level tests for all four write paths (contextSet, advance, start, hook)
- [x] Session state untouched when a write is rejected
- [x] Defaults accept normal-sized writes

## Out of scope

- Subgraph push/pop context propagation (\`contextMap\` / \`returnMap\`) — those only move values that already passed the cap on the parent/child side, so they can't introduce new unbounded writes. Leaving for a separate issue if ever needed.
- Simplifying \`memory_by_source\`'s hand-rolled \`{ id, content }\` projection now that the cap would catch a regression — noted as a potential follow-up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)