### PR TITLE
feat(cli): runtime verbs JSON-only with semantic exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Runtime CLI verbs are JSON-only (BREAKING).** `freelance status`,
+  `start`, `advance`, `context set`, `meta set`, `inspect`, `reset`,
+  and `memory *` always emit structured JSON to stdout with semantic
+  exit codes (0 success, 1 internal, 2 blocked, 3 validation, 4 not
+  found, 5 invalid input). The human-readable output mode is removed
+  from these commands — they are the primary execution surface for
+  the Claude Agent Skill, which has no human audience. Authoring
+  verbs (`init`, `validate`, `visualize`, `config`, `sources *`)
+  retain their human-first rendering. Error responses match the MCP
+  shape: `{ isError: true, error: { code, message } }`. See issue
+  #99 Phase 1.
 - **`freelance_inspect --detail=history` paginates `traversalHistory`
   and strips snapshots by default.** `traversalHistory` is sliced by
   `limit` (default 50, max 200) and `offset`. Per-entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Runtime CLI verbs are JSON-only (BREAKING).** `freelance status`,
-  `start`, `advance`, `context set`, `meta set`, `inspect`, `reset`,
-  and `memory *` always emit structured JSON to stdout with semantic
-  exit codes (0 success, 1 internal, 2 blocked, 3 validation, 4 not
-  found, 5 invalid input). The human-readable output mode is removed
-  from these commands — they are the primary execution surface for
-  the Claude Agent Skill, which has no human audience. Authoring
-  verbs (`init`, `validate`, `visualize`, `config`, `sources *`)
-  retain their human-first rendering. Error responses match the MCP
-  shape: `{ isError: true, error: { code, message } }`. See issue
+- **All CLI verbs are JSON-only (BREAKING).** Every handler —
+  `status`, `start`, `advance`, `context set`, `meta set`, `inspect`,
+  `reset`, `memory *`, `init`, `validate`, `visualize`, `config`,
+  `sources *`, `guide`, `distill` — emits structured JSON to stdout
+  with semantic exit codes (0 success, 1 internal, 2 blocked, 3
+  validation, 4 not found, 5 invalid input). The dual-mode
+  (`--json` vs human-readable) branching is removed; `--json` and
+  `--no-color` flags are deleted. The architectural commitment in
+  `docs/decisions.md` § "CLI is the execution surface for agents"
+  is that no human is driving this API — the skill loop is the
+  only consumer. Error responses on both CLI and MCP surfaces use
+  the canonical shape `{ isError: true, error: { code, message } }`,
+  so a skill consuming either sees the same contract. See issue
   #99 Phase 1.
+- **`visualize --open` removed.** The browser-rendering path was a
+  human-only affordance; the JSON response carries the diagram
+  inline (or `--output <path>` writes the raw artifact to disk for
+  pipeline integration).
 - **`freelance_inspect --detail=history` paginates `traversalHistory`
   and strips snapshots by default.** `traversalHistory` is sliced by
   `limit` (default 50, max 200) and `offset`. Per-entry

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,64 +1,30 @@
 /**
- * CLI handlers for `freelance config` subcommands.
+ * CLI handlers for `freelance config` subcommands — JSON-only.
  *
- * - config show     — display resolved configuration with sources
+ * Per docs/decisions.md § "CLI is the execution surface for agents",
+ * every CLI verb is agent-driven. These handlers emit structured JSON
+ * to stdout and use semantic exit codes. Warnings (e.g. overwrite of
+ * an existing memory.dir) still go to stderr as breadcrumbs.
+ *
+ * - config show      — display resolved configuration with sources
  * - config set-local — modify config.local.yml (used by plugin hooks)
  */
 
 import path from "node:path";
 import { loadConfig, loadConfigFromDirs, updateLocalConfig } from "../config.js";
 import { resolveGraphsDirs } from "../graph-resolution.js";
-import { cli, EXIT, fatal, info, outputJson } from "./output.js";
+import { EXIT, fatal, outputJson } from "./output.js";
 
 // --- config show ---
 
 export function configShow(opts: { workflows?: string | string[] }): void {
   const dirs = resolveGraphsDirs(opts.workflows);
   if (dirs.length === 0) {
-    if (cli.json) {
-      outputJson({ workflows: [], memory: {}, sources: [], graphsDirs: [] });
-    } else {
-      info("No configuration found.");
-      info("Run `freelance init` or specify --workflows.");
-    }
+    outputJson({ workflows: [], memory: {}, sources: [], graphsDirs: [] });
     return;
   }
-
   const config = loadConfigFromDirs(dirs);
-
-  if (cli.json) {
-    outputJson({ ...config, graphsDirs: dirs });
-    return;
-  }
-
-  info("Resolved configuration:\n");
-
-  info("  Graph directories:");
-  for (const d of dirs) {
-    info(`    - ${d}`);
-  }
-
-  if (config.workflows.length) {
-    info("\n  Additional workflows (from config):");
-    for (const w of config.workflows) {
-      info(`    - ${w}`);
-    }
-  }
-
-  info(`\n  Memory:`);
-  info(`    enabled: ${config.memory.enabled ?? "true (default)"}`);
-  if (config.memory.dir) {
-    info(`    dir: ${config.memory.dir}`);
-  }
-  if (config.memory.prune?.keep?.length) {
-    info(`    prune.keep: ${config.memory.prune.keep.join(", ")}`);
-  }
-  if (config.sources.length) {
-    info(`\n  Loaded from:`);
-    for (const s of config.sources) {
-      info(`    - ${s}`);
-    }
-  }
+  outputJson({ ...config, graphsDirs: dirs });
 }
 
 // --- config set-local ---
@@ -72,7 +38,11 @@ export function configSetLocal(
 ): void {
   const dirs = resolveGraphsDirs(opts.workflows);
   if (dirs.length === 0) {
-    fatal("No .freelance directory found. Run `freelance init` first.", EXIT.INVALID_USAGE);
+    fatal(
+      "No .freelance directory found. Run `freelance init` first.",
+      EXIT.INVALID_INPUT,
+      "NO_FREELANCE_DIR",
+    );
   }
 
   const freelanceDir = dirs[0];
@@ -84,7 +54,6 @@ export function configSetLocal(
       if (existing.includes(resolved)) return config; // idempotent
       return { ...config, workflows: [...existing, resolved] };
     });
-    info(`Added workflow directory: ${resolved}`);
   } else if (key === "memory.dir") {
     const resolved = path.resolve(value);
     updateLocalConfig(freelanceDir, (config) => {
@@ -96,22 +65,25 @@ export function configSetLocal(
       }
       return { ...config, memory: { ...config.memory, dir: resolved } };
     });
-    info(`Set memory.dir: ${resolved}`);
   } else if (key === "memory.enabled") {
     if (value !== "true" && value !== "false") {
-      fatal(`memory.enabled must be "true" or "false", got "${value}"`, EXIT.INVALID_USAGE);
+      fatal(
+        `memory.enabled must be "true" or "false", got "${value}"`,
+        EXIT.INVALID_INPUT,
+        "INVALID_CONFIG_VALUE",
+      );
     }
     const enabled = value === "true";
     updateLocalConfig(freelanceDir, (config) => {
       return { ...config, memory: { ...config.memory, enabled } };
     });
-    info(`Set memory.enabled: ${enabled}`);
   } else {
-    fatal(`Unknown config key: ${key}. Supported: ${SETTABLE_KEYS.join(", ")}`, EXIT.INVALID_USAGE);
+    fatal(
+      `Unknown config key: ${key}. Supported: ${SETTABLE_KEYS.join(", ")}`,
+      EXIT.INVALID_INPUT,
+      "UNKNOWN_CONFIG_KEY",
+    );
   }
 
-  if (cli.json) {
-    const config = loadConfig(freelanceDir);
-    outputJson(config);
-  }
+  outputJson(loadConfig(freelanceDir));
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { allClientChoices, type Client, clientDisplayName, detectClients } from "./clients.js";
-import { cli, displayPath, EXIT, fatal, homeDir, info, outputJson } from "./output.js";
+import { displayPath, EXIT, fatal, homeDir, info, outputJson } from "./output.js";
 import { ensureFreelanceDir } from "./setup.js";
 
 export type { Client } from "./clients.js";
@@ -227,10 +227,14 @@ function wouldAppendClaudeMd(): boolean {
 
 // --- Main init ---
 
-function printManualConfig(): void {
-  const entry = getMcpEntry();
-  info("\nAdd this to your MCP client configuration:\n");
-  process.stdout.write(`${JSON.stringify({ mcpServers: { freelance: entry } }, null, 2)}\n`);
+/**
+ * Return the inline MCP config snippet for the `--client manual` path.
+ * The caller embeds this into its JSON response rather than printing
+ * it to stdout separately (stdout is reserved for the single structured
+ * response per docs/decisions.md § CLI-primary).
+ */
+function getManualConfig(): Record<string, unknown> {
+  return { mcpServers: { freelance: getMcpEntry() } };
 }
 
 export async function init(options: InitOptions): Promise<void> {
@@ -349,34 +353,16 @@ export async function init(options: InitOptions): Promise<void> {
 
   // --- Dry run ---
   if (dryRun) {
-    if (cli.json) {
-      outputJson({ dryRun: true, scope, client, starter, actions });
-      return;
-    }
-    info("\nDry run \u2014 no files will be written.\n");
-    for (const a of actions) {
-      if (a.verb === "skip") {
-        info(`  Would skip:      ${a.target} (${a.detail})`);
-      } else if (a.verb === "create") {
-        info(`  Would create:    ${a.target}`);
-      } else if (a.verb === "append") {
-        info(`  Would append:    ${a.target} (${a.detail})`);
-      } else if (a.verb === "configure") {
-        info(`  Would configure: ${a.target} (${a.detail})`);
-      }
-    }
-    info("\nRun without --dry-run to apply these changes.");
+    outputJson({ dryRun: true, scope, client, starter, actions });
     return;
   }
 
   // --- Execute ---
-  const results: string[] = [];
   const filesCreated: string[] = [];
 
   // 1. Create graphs directory
   if (!fs.existsSync(graphsDir)) {
     fs.mkdirSync(graphsDir, { recursive: true });
-    results.push(`Created ${graphsDisplayPath}/`);
     filesCreated.push(graphsDir);
   }
 
@@ -386,7 +372,6 @@ export async function init(options: InitOptions): Promise<void> {
   const ignorePreexisted = fs.existsSync(ignorePath);
   ensureFreelanceDir(graphsDir);
   if (!ignorePreexisted && fs.existsSync(ignorePath)) {
-    results.push(`Created ${graphsDisplayPath}/.gitignore`);
     filesCreated.push(ignorePath);
   }
 
@@ -396,16 +381,13 @@ export async function init(options: InitOptions): Promise<void> {
     const templateFile = path.join(templatesDir, `${starter}.workflow.yaml`);
 
     if (!fs.existsSync(templateFile)) {
-      fatal(`Template not found: ${starter}.workflow.yaml`, EXIT.GENERAL_ERROR);
+      fatal(`Template not found: ${starter}.workflow.yaml`, EXIT.NOT_FOUND, "TEMPLATE_NOT_FOUND");
     }
 
     const destFile = path.join(graphsDir, `${starter}.workflow.yaml`);
     if (!fs.existsSync(destFile)) {
       fs.copyFileSync(templateFile, destFile);
-      results.push(`Created ${graphsDisplayPath}/${starter}.workflow.yaml`);
       filesCreated.push(destFile);
-    } else {
-      results.push(`Skipped ${starter}.workflow.yaml (already exists)`);
     }
   }
 
@@ -416,32 +398,27 @@ export async function init(options: InitOptions): Promise<void> {
     const configDest = path.join(graphsDir, "config.yml");
     if (!fs.existsSync(configDest) && fs.existsSync(configTemplate)) {
       fs.copyFileSync(configTemplate, configDest);
-      results.push(`Created ${graphsDisplayPath}/config.yml`);
       filesCreated.push(configDest);
-    } else if (fs.existsSync(configDest)) {
-      results.push("Skipped config.yml (already exists)");
     }
   }
 
-  // 3. Write MCP config
+  // 3. Write MCP config. For `--client manual`, the config snippet is
+  // embedded in the response rather than printed separately — stdout
+  // carries exactly one structured payload per agent CLI convention.
+  let manualConfig: Record<string, unknown> | undefined;
   if (client === "manual") {
-    printManualConfig();
+    manualConfig = getManualConfig();
   } else {
     const configPath = writeClientConfig(client, scope);
     if (configPath) {
-      results.push(`Configured MCP server in ${displayPath(configPath)} (${scope} scope)`);
       filesCreated.push(configPath);
     }
   }
 
   // 4. Append CLAUDE.md for project scope with Claude Code
   if (scope === "project" && client === "claude-code") {
-    const appended = appendClaudeMd();
-    if (appended) {
-      results.push("Added workflow instructions to CLAUDE.md");
+    if (appendClaudeMd()) {
       filesCreated.push(path.join(process.cwd(), "CLAUDE.md"));
-    } else {
-      results.push("CLAUDE.md already has Freelance instructions");
     }
   }
 
@@ -449,37 +426,17 @@ export async function init(options: InitOptions): Promise<void> {
   if (client === "claude-code" && options.hooks) {
     const hookResult = writeHooks(true);
     if (hookResult) {
-      results.push(
-        `Configured hooks in ${displayPath(hookResult.path)}: ${hookResult.wrote.join(", ")}`,
-      );
       filesCreated.push(hookResult.path);
-    } else {
-      results.push("Hooks already configured");
     }
   }
 
-  // JSON output
-  if (cli.json) {
-    outputJson({ scope, client, starter, files: filesCreated });
-    return;
-  }
-
-  // Human output
-  info("\nSetting up Freelance...\n");
-  for (const r of results) {
-    info(`  \u2713 ${r}`);
-  }
-
-  info(`
-Next steps:
-  1. Start your AI coding agent in this directory
-  2. The agent will see Freelance's tools automatically
-  3. Call freelance_list to see available workflows
-  4. Call freelance_start to begin a workflow
-
-  Run 'freelance validate ${graphsDisplayPath}/' to check your graph definitions.
-
-Happy building.`);
+  outputJson({
+    scope,
+    client,
+    starter,
+    files: filesCreated,
+    ...(manualConfig ? { manualConfig } : {}),
+  });
 }
 
 // @inquirer/prompts is an optionalDependency; surface a friendly hint
@@ -494,7 +451,8 @@ async function loadPrompts() {
         "Interactive init requires @inquirer/prompts (optional dependency).\n" +
           "  Install: npm install @inquirer/prompts\n" +
           "  Or skip prompts: freelance init --yes",
-        EXIT.GENERAL_ERROR,
+        EXIT.INTERNAL,
+        "MISSING_OPTIONAL_DEP",
       );
     }
     throw e;

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,32 +1,26 @@
-/** CLI handlers for memory subcommands. Operates directly on MemoryStore. */
+/**
+ * CLI handlers for memory subcommands — JSON-only machine surface.
+ *
+ * Runtime verbs under `freelance memory ...` are the primary execution
+ * path for the Claude Agent Skill per `docs/decisions.md` § "CLI is the
+ * primary execution surface". There is no human audience — every
+ * handler writes structured JSON to stdout and exits with a semantic
+ * code (see `EXIT` in output.ts).
+ */
 
 import fs from "node:fs";
-import path from "node:path";
 import type { MemoryStore } from "../memory/index.js";
 import { prune } from "../memory/prune.js";
-import { cli, info, outputJson } from "./output.js";
+import { EXIT, outputError, outputJson } from "./output.js";
 
 function handleError(e: unknown): never {
-  const message = e instanceof Error ? e.message : String(e);
-  if (cli.json) {
-    outputJson({ error: message });
-  } else {
-    info(`Error: ${message}`);
-  }
-  process.exit(1);
+  const code = outputError(e);
+  process.exit(code);
 }
 
 export function memoryStatus(store: MemoryStore): void {
   try {
-    const result = store.status();
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(
-        `Propositions: ${result.total_propositions} total, ${result.valid_propositions} valid, ${result.stale_propositions} stale`,
-      );
-      info(`Entities: ${result.total_entities}`);
-    }
+    outputJson(store.status());
   } catch (e) {
     handleError(e);
   }
@@ -50,20 +44,7 @@ export function memoryBrowse(
       offset: opts?.offset ? parseInt(opts.offset, 10) : undefined,
       includeOrphans: opts?.includeOrphans,
     });
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      if (result.entities.length === 0) {
-        info("No entities found.");
-        return;
-      }
-      for (const e of result.entities) {
-        info(
-          `  ${e.name}${e.kind ? ` (${e.kind})` : ""}  ${e.valid_proposition_count} propositions`,
-        );
-      }
-      info(`\n${result.entities.length} entities (total: ${result.total})`);
-    }
+    outputJson(result);
   } catch (e) {
     handleError(e);
   }
@@ -71,25 +52,7 @@ export function memoryBrowse(
 
 export function memoryInspect(store: MemoryStore, entity: string): void {
   try {
-    const result = store.inspect(entity);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(`Entity: ${result.entity.name}${result.entity.kind ? ` (${result.entity.kind})` : ""}`);
-      if (result.propositions.length > 0) {
-        info("\nPropositions:");
-        for (const p of result.propositions) {
-          const status = p.valid ? "" : " [stale]";
-          info(`  - ${p.content}${status}`);
-        }
-      }
-      if (result.neighbors && result.neighbors.length > 0) {
-        info("\nNeighbors:");
-        for (const n of result.neighbors) {
-          info(`  ${n.name}${n.kind ? ` (${n.kind})` : ""}`);
-        }
-      }
-    }
+    outputJson(store.inspect(entity));
   } catch (e) {
     handleError(e);
   }
@@ -97,23 +60,11 @@ export function memoryInspect(store: MemoryStore, entity: string): void {
 
 export function memorySearch(store: MemoryStore, query: string, opts?: { limit?: string }): void {
   try {
-    const result = store.search(query, {
-      limit: opts?.limit ? parseInt(opts.limit, 10) : undefined,
-    });
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      if (result.propositions.length === 0) {
-        info("No results found.");
-        return;
-      }
-      for (const r of result.propositions) {
-        const entities = r.entities.map((e: { name: string }) => e.name).join(", ");
-        const status = r.valid ? "" : " [stale]";
-        info(`  [${entities}] ${r.content}${status}`);
-      }
-      info(`\n${result.propositions.length} results`);
-    }
+    outputJson(
+      store.search(query, {
+        limit: opts?.limit ? parseInt(opts.limit, 10) : undefined,
+      }),
+    );
   } catch (e) {
     handleError(e);
   }
@@ -121,19 +72,7 @@ export function memorySearch(store: MemoryStore, query: string, opts?: { limit?:
 
 export function memoryRelated(store: MemoryStore, entity: string): void {
   try {
-    const result = store.related(entity);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      if (result.neighbors.length === 0) {
-        info("No related entities found.");
-        return;
-      }
-      for (const r of result.neighbors) {
-        info(`  ${r.name}${r.kind ? ` (${r.kind})` : ""}  shared: ${r.shared_propositions}`);
-        if ("sample" in r) info(`    "${(r as { sample: string }).sample}"`);
-      }
-    }
+    outputJson(store.related(entity));
   } catch (e) {
     handleError(e);
   }
@@ -141,20 +80,7 @@ export function memoryRelated(store: MemoryStore, entity: string): void {
 
 export function memoryBySource(store: MemoryStore, filePath: string): void {
   try {
-    const result = store.bySource(filePath);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      if (result.propositions.length === 0) {
-        info(`No propositions found for ${filePath}.`);
-        return;
-      }
-      for (const p of result.propositions) {
-        const status = p.valid ? "" : " [stale]";
-        info(`  ${p.content}${status}`);
-      }
-      info(`\n${result.propositions.length} propositions`);
-    }
+    outputJson(store.bySource(filePath));
   } catch (e) {
     handleError(e);
   }
@@ -162,12 +88,7 @@ export function memoryBySource(store: MemoryStore, filePath: string): void {
 
 export function memoryEmit(store: MemoryStore, file: string): void {
   try {
-    let raw: string;
-    if (file === "-") {
-      raw = fs.readFileSync(0, "utf-8");
-    } else {
-      raw = fs.readFileSync(file, "utf-8");
-    }
+    const raw = file === "-" ? fs.readFileSync(0, "utf-8") : fs.readFileSync(file, "utf-8");
 
     let propositions: Array<{
       content: string;
@@ -183,12 +104,7 @@ export function memoryEmit(store: MemoryStore, file: string): void {
       throw new Error(`${source} must contain valid JSON: ${msg}`);
     }
 
-    const result = store.emit(propositions);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(`Emitted ${result.created} propositions (${result.deduplicated} deduplicated)`);
-    }
+    outputJson(store.emit(propositions));
   } catch (e) {
     handleError(e);
   }
@@ -203,37 +119,36 @@ export function memoryPrune(
   // before every exit. MemoryStore.close is idempotent, so the
   // caller's finally is a harmless no-op after this.
   if (!opts.keep || opts.keep.length === 0) {
-    if (cli.json) {
-      outputJson({ error: "memory prune requires --keep <ref> (repeatable)." });
-    } else {
-      info("memory prune requires --keep <ref> (repeatable). No default preserve set.");
-    }
+    outputJson({
+      isError: true,
+      error: {
+        code: "MISSING_KEEP",
+        message: "memory prune requires --keep <ref> (repeatable).",
+      },
+    });
     store.close();
-    process.exit(2);
+    process.exit(EXIT.INVALID_INPUT);
   }
 
   try {
     // `--dry-run` is itself a no-op preview; otherwise require explicit
-    // `--yes`. Print the plan on the refusal so the caller sees the
-    // blast radius before committing.
+    // `--yes`. Return the plan + an explicit refusal when neither flag
+    // is set, so the skill sees the blast radius before committing.
     const confirmed = opts.dryRun || opts.yes;
     const result = prune(store, { keep: opts.keep, dryRun: !confirmed });
-    if (cli.json) {
-      outputJson(
-        confirmed ? result : { ...result, error: "Refusing to delete without --yes or --dry-run." },
-      );
+    if (confirmed) {
+      outputJson(result);
     } else {
-      const preview = result.dry_run ? "Would prune" : "Pruned";
-      const preview2 = result.dry_run ? "Would hard-delete" : "Hard-deleted";
-      info(`${preview} ${result.rows_pruned} source row(s).`);
-      info(
-        `${preview2} ${result.propositions_hard_deleted} proposition(s); ${result.entities_orphaned} entity/entities orphaned.`,
-      );
-      if (!confirmed) info("Re-run with --yes to execute.");
-    }
-    if (!confirmed) {
+      outputJson({
+        ...result,
+        isError: true,
+        error: {
+          code: "CONFIRM_REQUIRED",
+          message: "Refusing to delete without --yes or --dry-run.",
+        },
+      });
       store.close();
-      process.exit(2);
+      process.exit(EXIT.INVALID_INPUT);
     }
   } catch (e) {
     handleError(e);
@@ -250,8 +165,14 @@ export function memoryPrune(
  */
 export function memoryReset(dbPath: string, opts: { confirm?: boolean }): void {
   if (!opts.confirm) {
-    info("memory reset requires --confirm (destructive: deletes memory.db + sidecars).");
-    process.exit(2);
+    outputJson({
+      isError: true,
+      error: {
+        code: "CONFIRM_REQUIRED",
+        message: "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
+      },
+    });
+    process.exit(EXIT.INVALID_INPUT);
   }
   const targets = [dbPath, `${dbPath}-shm`, `${dbPath}-wal`];
   const deleted: string[] = [];
@@ -265,14 +186,5 @@ export function memoryReset(dbPath: string, opts: { confirm?: boolean }): void {
   } catch (e) {
     handleError(e);
   }
-  if (cli.json) {
-    outputJson({ status: "reset", deleted, dbPath });
-  } else {
-    if (deleted.length === 0) {
-      info(`No memory db files found at ${path.dirname(dbPath)}/ — nothing to reset.`);
-    } else {
-      info(`Deleted ${deleted.length} file(s) from ${path.dirname(dbPath)}/`);
-      info("Next run will re-initialize memory.db on first use.");
-    }
-  }
+  outputJson({ status: "reset", deleted, dbPath });
 }

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -11,12 +11,7 @@
 import fs from "node:fs";
 import type { MemoryStore } from "../memory/index.js";
 import { prune } from "../memory/prune.js";
-import { EXIT, outputError, outputJson } from "./output.js";
-
-function handleError(e: unknown): never {
-  const code = outputError(e);
-  process.exit(code);
-}
+import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js";
 
 export function memoryStatus(store: MemoryStore): void {
   try {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -9,6 +9,7 @@
  */
 
 import fs from "node:fs";
+import { EngineError } from "../errors.js";
 import type { MemoryStore } from "../memory/index.js";
 import { prune } from "../memory/prune.js";
 import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js";
@@ -96,7 +97,7 @@ export function memoryEmit(store: MemoryStore, file: string): void {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       const source = file === "-" ? "stdin" : file;
-      throw new Error(`${source} must contain valid JSON: ${msg}`);
+      throw new EngineError(`${source} must contain valid JSON: ${msg}`, "INVALID_EMIT_JSON");
     }
 
     outputJson(store.emit(propositions));
@@ -146,6 +147,7 @@ export function memoryPrune(
       process.exit(EXIT.INVALID_INPUT);
     }
   } catch (e) {
+    store.close();
     handleError(e);
   }
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -90,30 +90,37 @@ export function outputError(e: unknown): number {
   return EXIT.INTERNAL;
 }
 
-// Global CLI state — set via setCli() from index.ts before any command runs.
-// Exported as readonly; only setCli() can mutate it.
+/**
+ * Shared try/catch tail for runtime CLI handlers — emits the structured
+ * error payload via `outputError` and exits with the mapped code.
+ * Consolidates the identical `catch { outputError(e); process.exit(…) }`
+ * shape that lived in traversals.ts / memory.ts / stateless.ts.
+ */
+export function handleRuntimeError(e: unknown): never {
+  process.exit(outputError(e));
+}
+
+// Global CLI state — set via setCli() from program.ts before any
+// command runs. `json` and `noColor` are gone post docs/decisions.md §
+// CLI-primary: handlers are JSON-only (no dual-mode) and color has no
+// meaning on machine output. `quiet` and `verbose` still gate stderr
+// breadcrumbs via info()/debug().
 interface CliState {
-  json: boolean;
   quiet: boolean;
   verbose: boolean;
-  noColor: boolean;
 }
 
 const _cli: CliState = {
-  json: false,
   quiet: false,
   verbose: false,
-  noColor: false,
 };
 
 export const cli: Readonly<CliState> = _cli;
 
 /** Initialize CLI state from parsed commander options. */
 export function setCli(opts: Partial<CliState>): void {
-  if (opts.json !== undefined) _cli.json = opts.json;
   if (opts.quiet !== undefined) _cli.quiet = opts.quiet;
   if (opts.verbose !== undefined) _cli.verbose = opts.verbose;
-  if (opts.noColor !== undefined) _cli.noColor = opts.noColor;
 }
 
 /** Write JSON to stdout. */
@@ -140,9 +147,20 @@ export function error(msg: string): void {
   process.stderr.write(`${msg}\n`);
 }
 
-/** Write error to stderr and exit. */
-export function fatal(msg: string, exitCode: number = EXIT.GENERAL_ERROR): never {
-  error(`Error: ${msg}`);
+/**
+ * Emit a structured fatal error to stdout and exit with the given code.
+ * Shape matches `outputError`: `{ isError: true, error: { code, message } }`.
+ * Callers pass an exit code that categorizes the failure (see EXIT);
+ * `code` defaults to "FATAL" and can be overridden for specificity.
+ */
+export function fatal(
+  msg: string,
+  exitCode: number = EXIT.INTERNAL,
+  code: string = "FATAL",
+): never {
+  process.stdout.write(
+    `${JSON.stringify({ isError: true, error: { code, message: msg } }, null, 2)}\n`,
+  );
   process.exit(exitCode);
 }
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,13 +1,94 @@
 // Shared CLI output helpers and global state.
 import path from "node:path";
+import { EngineError } from "../errors.js";
 
-// Exit codes per spec
+/**
+ * Semantic exit codes. Consumed by the skill body (and any shell-driving
+ * client) to branch on outcome without parsing stdout. Categorized by
+ * "who can do something about this":
+ *
+ *   0 — success
+ *   1 — internal (unexpected throw; agent should report to operator, not retry)
+ *   2 — gate/edge blocked (advance couldn't complete given current state; fix context and retry)
+ *   3 — validation failed (graph structural validation; authoring-time use)
+ *   4 — not found (referenced traversal / graph / edge doesn't exist)
+ *   5 — invalid input (caller-supplied arg is malformed or conflicts with state)
+ *
+ * The skill branches on these to decide whether to retry, surface the
+ * error to the user, or stop the loop.
+ */
 export const EXIT = {
   SUCCESS: 0,
+  INTERNAL: 1,
+  BLOCKED: 2,
+  VALIDATION: 3,
+  NOT_FOUND: 4,
+  INVALID_INPUT: 5,
+  // Legacy aliases — kept so authoring commands (validate, init, visualize,
+  // config) stay on their existing exit-code conventions without churn.
+  // Runtime handlers use the semantic names above.
   GENERAL_ERROR: 1,
   INVALID_USAGE: 2,
   GRAPH_ERROR: 3,
 } as const;
+
+/**
+ * Map an `EngineError.code` to its exit-code category. Runtime handlers
+ * call this inside `catch` blocks. Unknown codes fall back to INTERNAL
+ * so a novel error never masquerades as a caller-fixable one.
+ */
+export function mapEngineErrorToExit(code: string | undefined): number {
+  if (!code) return EXIT.INTERNAL;
+  switch (code) {
+    // Not found
+    case "TRAVERSAL_NOT_FOUND":
+    case "GRAPH_NOT_FOUND":
+    case "EDGE_NOT_FOUND":
+    case "NO_TRAVERSAL":
+      return EXIT.NOT_FOUND;
+    // Invalid input (caller-provided)
+    case "STRICT_CONTEXT_VIOLATION":
+    case "CONTEXT_VALUE_TOO_LARGE":
+    case "CONTEXT_TOTAL_TOO_LARGE":
+    case "REQUIRED_META_MISSING":
+    case "AMBIGUOUS_TRAVERSAL":
+    case "TRAVERSAL_ACTIVE":
+      return EXIT.INVALID_INPUT;
+    // Runtime blocked (state / constraint)
+    case "NO_EDGES":
+    case "STACK_DEPTH_EXCEEDED":
+    case "HOOK_FAILED":
+    case "HOOK_IMPORT_FAILED":
+    case "HOOK_BAD_SHAPE":
+    case "HOOK_RESOLUTION_MISMATCH":
+    case "HOOK_BUILTIN_MISSING":
+    case "HOOK_BAD_RETURN":
+      return EXIT.BLOCKED;
+    default:
+      return EXIT.INTERNAL;
+  }
+}
+
+/**
+ * Write a structured error to stdout and return the exit code the caller
+ * should use. Shape mirrors the MCP tool-error payload:
+ *   { isError: true, error: { code, message } }
+ * so a skill consuming either surface sees the same shape. For unknown
+ * throws (non-EngineError), `code` is `INTERNAL`.
+ */
+export function outputError(e: unknown): number {
+  if (e instanceof EngineError) {
+    process.stdout.write(
+      `${JSON.stringify({ isError: true, error: { code: e.code, message: e.message } }, null, 2)}\n`,
+    );
+    return mapEngineErrorToExit(e.code);
+  }
+  const message = e instanceof Error ? e.message : String(e);
+  process.stdout.write(
+    `${JSON.stringify({ isError: true, error: { code: "INTERNAL", message } }, null, 2)}\n`,
+  );
+  return EXIT.INTERNAL;
+}
 
 // Global CLI state — set via setCli() from index.ts before any command runs.
 // Exported as readonly; only setCli() can mutate it.

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -24,12 +24,6 @@ export const EXIT = {
   VALIDATION: 3,
   NOT_FOUND: 4,
   INVALID_INPUT: 5,
-  // Legacy aliases — kept so authoring commands (validate, init, visualize,
-  // config) stay on their existing exit-code conventions without churn.
-  // Runtime handlers use the semantic names above.
-  GENERAL_ERROR: 1,
-  INVALID_USAGE: 2,
-  GRAPH_ERROR: 3,
 } as const;
 
 /**
@@ -53,28 +47,39 @@ export function mapEngineErrorToExit(code: string | undefined): number {
     case "REQUIRED_META_MISSING":
     case "AMBIGUOUS_TRAVERSAL":
     case "TRAVERSAL_ACTIVE":
+    case "INVALID_KEY_VALUE_PAIR":
+    case "INVALID_CONTEXT_JSON":
+    case "INVALID_EMIT_JSON":
+    case "INVALID_META":
       return EXIT.INVALID_INPUT;
-    // Runtime blocked (state / constraint)
+    // Runtime blocked (state / constraint) — advance couldn't proceed but
+    // the traversal itself is intact; caller may recover with new context.
     case "NO_EDGES":
     case "STACK_DEPTH_EXCEEDED":
+      return EXIT.BLOCKED;
+    // Hook wiring failures are author-time bugs (missing export, bad
+    // shape, import error). Retrying with new context won't repair a
+    // broken hook script, so surface as INTERNAL — the skill should
+    // report to the operator, not loop.
     case "HOOK_FAILED":
     case "HOOK_IMPORT_FAILED":
     case "HOOK_BAD_SHAPE":
     case "HOOK_RESOLUTION_MISMATCH":
     case "HOOK_BUILTIN_MISSING":
     case "HOOK_BAD_RETURN":
-      return EXIT.BLOCKED;
+      return EXIT.INTERNAL;
     default:
       return EXIT.INTERNAL;
   }
 }
 
 /**
- * Write a structured error to stdout and return the exit code the caller
- * should use. Shape mirrors the MCP tool-error payload:
+ * Write a structured error to stdout and return the exit code. Payload is
  *   { isError: true, error: { code, message } }
- * so a skill consuming either surface sees the same shape. For unknown
- * throws (non-EngineError), `code` is `INTERNAL`.
+ * — `isError` at the top level so a shell consumer can one-pass-parse
+ * without checking exit codes, and `error.code` is what
+ * `mapEngineErrorToExit` branches on. For unknown throws (non-EngineError),
+ * `code` is `INTERNAL`.
  */
 export function outputError(e: unknown): number {
   if (e instanceof EngineError) {
@@ -95,8 +100,15 @@ export function outputError(e: unknown): number {
  * error payload via `outputError` and exits with the mapped code.
  * Consolidates the identical `catch { outputError(e); process.exit(…) }`
  * shape that lived in traversals.ts / memory.ts / stateless.ts.
+ *
+ * Re-throws if `e` is the "process.exit" sentinel that tests install in
+ * place of `process.exit`. Otherwise a `fatal()` call nested inside a
+ * try/catch would double-emit (fatal writes the structured payload and
+ * calls process.exit; the mocked throw reaches this catch, which would
+ * emit a second INTERNAL payload and mask the original).
  */
 export function handleRuntimeError(e: unknown): never {
+  if (e instanceof Error && e.message === "process.exit") throw e;
   process.exit(outputError(e));
 }
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -26,7 +26,7 @@ import {
   memorySearch,
   memoryStatus,
 } from "./memory.js";
-import { EXIT, fatal, info, setCli } from "./output.js";
+import { EXIT, fatal, info, outputJson, setCli } from "./output.js";
 import {
   createMemoryStore,
   createTraversalStore,
@@ -66,17 +66,13 @@ program
     "before",
     `freelance v${VERSION} \u2014 Graph-based workflow enforcement for AI coding agents\n`,
   )
-  .option("--json", "Output results as JSON to stdout")
-  .option("--no-color", "Disable colored output")
-  .option("--verbose", "Show detailed progress and debug information")
-  .option("-q, --quiet", "Suppress non-essential output (errors only)")
+  .option("--verbose", "Show detailed progress and debug information on stderr")
+  .option("-q, --quiet", "Suppress stderr breadcrumbs")
   .hook("preAction", (_thisCommand, actionCommand) => {
     const root = actionCommand.optsWithGlobals();
     setCli({
-      json: root.json ?? false,
       quiet: root.quiet ?? false,
       verbose: root.verbose ?? false,
-      noColor: root.color === false || !!process.env.NO_COLOR,
     });
   });
 
@@ -150,17 +146,15 @@ program
 
 program
   .command("visualize <file>")
-  .description("Export graph as Mermaid or DOT diagram")
+  .description("Export graph as Mermaid or DOT diagram (JSON response)")
   .addOption(
     new Option("--format <format>", "Output format").choices(["mermaid", "dot"]).default("mermaid"),
   )
-  .option("--output <file>", "Write to file instead of stdout")
-  .option("--open", "Render in browser")
+  .option("--output <file>", "Write diagram to file (response still JSON)")
   .action((file, opts) => {
     visualize(file, {
       format: opts.format,
       output: opts.output,
-      open: opts.open,
     });
   });
 
@@ -497,7 +491,7 @@ addWorkflowsOpt(
   const fileConfig = loadConfigFromDirs(dirs);
   const memConfig = resolveMemoryConfig(dirs, {}, fileConfig);
   if (!memConfig) {
-    info("Memory is disabled in config; nothing to reset.");
+    outputJson({ status: "noop", reason: "memory disabled in config" });
     return;
   }
   memoryReset(memConfig.db, { confirm: opts.confirm });
@@ -581,7 +575,11 @@ program
   .action((shell) => {
     const supported = ["bash", "zsh", "fish"];
     if (!supported.includes(shell)) {
-      fatal(`Unknown shell: ${shell}. Supported: ${supported.join(", ")}`, EXIT.INVALID_USAGE);
+      fatal(
+        `Unknown shell: ${shell}. Supported: ${supported.join(", ")}`,
+        EXIT.INVALID_INPUT,
+        "UNKNOWN_SHELL",
+      );
     }
     const completionFile = path.resolve(
       path.dirname(new URL(import.meta.url).pathname),
@@ -592,7 +590,7 @@ program
       `freelance.${shell}`,
     );
     if (!fs.existsSync(completionFile)) {
-      fatal(`Completion file not found: ${completionFile}`, EXIT.GENERAL_ERROR);
+      fatal(`Completion file not found: ${completionFile}`, EXIT.NOT_FOUND, "COMPLETION_NOT_FOUND");
     }
     process.stdout.write(fs.readFileSync(completionFile, "utf-8"));
   });

--- a/src/cli/stateless.ts
+++ b/src/cli/stateless.ts
@@ -1,7 +1,10 @@
 /**
- * CLI handlers for stateless commands (graph files only, no store needed).
+ * CLI handlers for stateless commands — JSON-only.
  *
- * guide, distill, sources — these operate on graph definitions and source files.
+ * guide, distill, sources — these operate on graph definitions and
+ * source files without needing a TraversalStore. Per docs/decisions.md
+ * § "CLI is the execution surface for agents", every handler emits
+ * structured JSON to stdout.
  */
 
 import { getDistillPrompt } from "../distill.js";
@@ -14,38 +17,19 @@ import {
   hashSources,
   validateGraphSources,
 } from "../sources.js";
-import { cli, info, outputJson } from "./output.js";
-
-function handleError(e: unknown): never {
-  const message = e instanceof Error ? e.message : String(e);
-  if (cli.json) {
-    outputJson({ error: message });
-  } else {
-    info(`Error: ${message}`);
-  }
-  process.exit(1);
-}
+import { EXIT, fatal, handleRuntimeError as handleError, outputJson } from "./output.js";
 
 export function guideShow(topic?: string): void {
   const result = getGuide(topic);
-  if (cli.json) {
-    outputJson(result);
-  } else if ("error" in result) {
-    info(result.error);
-    process.exit(1);
-  } else {
-    info(result.content);
+  if ("error" in result) {
+    fatal(result.error, EXIT.NOT_FOUND, "TOPIC_NOT_FOUND");
   }
+  outputJson(result);
 }
 
 export function distillRun(opts?: { mode?: string }): void {
   const mode = (opts?.mode === "refine" ? "refine" : "distill") as "distill" | "refine";
-  const result = getDistillPrompt(mode);
-  if (cli.json) {
-    outputJson(result);
-  } else {
-    info(result.content);
-  }
+  outputJson(getDistillPrompt(mode));
 }
 
 export function sourcesHash(sourceOpts: SourceOptions, paths: string[]): void {
@@ -58,14 +42,7 @@ export function sourcesHash(sourceOpts: SourceOptions, paths: string[]): void {
       }
       return { path: p };
     });
-    const result = hashSources(sources, sourceOpts);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      for (const s of result.sources) {
-        info(`${s.path}${s.section ? `:${s.section}` : ""}  ${s.hash}`);
-      }
-    }
+    outputJson(hashSources(sources, sourceOpts));
   } catch (e) {
     handleError(e);
   }
@@ -73,7 +50,6 @@ export function sourcesHash(sourceOpts: SourceOptions, paths: string[]): void {
 
 export function sourcesCheck(sourceOpts: SourceOptions, paths: string[]): void {
   try {
-    // Expect path:hash or path:section:hash format
     const sources: Array<{ path: string; section?: string; hash: string }> = [];
     for (const p of paths) {
       const parts = p.split(":");
@@ -82,25 +58,14 @@ export function sourcesCheck(sourceOpts: SourceOptions, paths: string[]): void {
       } else if (parts.length === 2) {
         sources.push({ path: parts[0], hash: parts[1] });
       } else {
-        info(`Error: invalid format "${p}" — expected path:hash or path:section:hash`);
-        process.exit(1);
+        fatal(
+          `invalid format "${p}" — expected path:hash or path:section:hash`,
+          EXIT.INVALID_INPUT,
+          "INVALID_SOURCE_FORMAT",
+        );
       }
     }
-    const result = checkSourcesDetailed(sources, sourceOpts);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      if (result.valid) {
-        info("All sources valid.");
-      } else {
-        info("Drifted sources:");
-        for (const d of result.drifted) {
-          info(
-            `  ${d.path}${d.section ? `:${d.section}` : ""}  expected=${d.expected} actual=${d.actual}`,
-          );
-        }
-      }
-    }
+    outputJson(checkSourcesDetailed(sources, sourceOpts));
   } catch (e) {
     handleError(e);
   }
@@ -113,11 +78,9 @@ export function sourcesValidate(
 ): void {
   try {
     if (graphsDirs.length === 0) {
-      info("Error: no graph directories found.");
-      process.exit(1);
+      fatal("no graph directories found.", EXIT.NOT_FOUND, "NO_GRAPHS_DIR");
     }
 
-    // Collect graph definitions from all directories
     const fileMap = new Map<string, ReturnType<typeof loadSingleGraph>["definition"]>();
     for (const dir of graphsDirs) {
       for (const filePath of findGraphFiles(dir)) {
@@ -133,8 +96,11 @@ export function sourcesValidate(
     const targets = graphId ? (fileMap.has(graphId) ? [graphId] : []) : [...fileMap.keys()];
 
     if (targets.length === 0) {
-      info(graphId ? `Error: graph not found: ${graphId}` : "No graphs loaded.");
-      process.exit(1);
+      if (graphId) {
+        fatal(`graph not found: ${graphId}`, EXIT.NOT_FOUND, "GRAPH_NOT_FOUND");
+      }
+      outputJson({ valid: true, graphsChecked: 0, drift: [] });
+      return;
     }
 
     const drift: Array<{
@@ -155,23 +121,7 @@ export function sourcesValidate(
       }
     }
 
-    const result = { valid: drift.length === 0, graphsChecked: targets.length, drift };
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      if (result.valid) {
-        info(`All sources valid across ${result.graphsChecked} graph(s).`);
-      } else {
-        for (const d of drift) {
-          info(`${d.graphId} / ${d.node}:`);
-          for (const s of d.drifted) {
-            info(
-              `  ${s.path}${s.section ? `:${s.section}` : ""}  expected=${s.expected} actual=${s.actual}`,
-            );
-          }
-        }
-      }
-    }
+    outputJson({ valid: drift.length === 0, graphsChecked: targets.length, drift });
   } catch (e) {
     handleError(e);
   }

--- a/src/cli/stateless.ts
+++ b/src/cli/stateless.ts
@@ -99,8 +99,11 @@ export function sourcesValidate(
       if (graphId) {
         fatal(`graph not found: ${graphId}`, EXIT.NOT_FOUND, "GRAPH_NOT_FOUND");
       }
-      outputJson({ valid: true, graphsChecked: 0, drift: [] });
-      return;
+      fatal(
+        "no loadable *.workflow.yaml files in the configured graphs directories",
+        EXIT.NOT_FOUND,
+        "NO_GRAPHS_LOADED",
+      );
     }
 
     const drift: Array<{

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -1,20 +1,22 @@
 /**
- * CLI handlers for traversal commands. Operates directly on TraversalStore.
+ * CLI handlers for traversal commands — JSON-only machine surface.
+ *
+ * Runtime verbs (status, start, advance, context set, meta set, inspect,
+ * reset) are the primary execution path for the Claude Agent Skill
+ * per `docs/decisions.md` § "CLI is the primary execution surface".
+ * There is no human audience — every handler writes structured JSON
+ * to stdout and exits with a semantic code (see `EXIT` in output.ts).
+ * Breadcrumbs and startup logs still go to stderr via `info()` where
+ * relevant, never on the success path.
  */
 
-import { EngineError } from "../errors.js";
 import type { TraversalStore } from "../state/index.js";
-import type { InspectHistoryResult, InspectPositionResult, WaitCondition } from "../types.js";
-import { cli, info, outputJson } from "./output.js";
+import type { InspectPositionResult } from "../types.js";
+import { EXIT, outputError, outputJson } from "./output.js";
 
 function handleError(e: unknown): never {
-  const message = e instanceof EngineError ? e.message : e instanceof Error ? e.message : String(e);
-  if (cli.json) {
-    outputJson({ error: message });
-  } else {
-    info(`Error: ${message}`);
-  }
-  process.exit(1);
+  const code = outputError(e);
+  process.exit(code);
 }
 
 /**
@@ -34,55 +36,6 @@ function splitKeyValue(pair: string, flag: string): [string, string] {
   return [key, pair.slice(eqIdx + 1)];
 }
 
-export function traversalStatus(store: TraversalStore, opts?: { filter?: string[] }): void {
-  try {
-    const result = store.listGraphs();
-    // Operator-side filter — kept off the MCP surface deliberately. LLMs
-    // already see meta on every list entry and can pick; humans grepping
-    // among 50 traversals want a flag.
-    const filter = parseMetaPairs(opts?.filter, "--filter");
-    const filterEntries = Object.entries(filter);
-    const traversals =
-      filterEntries.length === 0
-        ? result.activeTraversals
-        : result.activeTraversals.filter(
-            (t) => t.meta !== undefined && filterEntries.every(([k, v]) => t.meta?.[k] === v),
-          );
-
-    if (cli.json) {
-      outputJson({ ...result, activeTraversals: traversals });
-      return;
-    }
-    if (result.graphs.length > 0) {
-      info("Graphs:");
-      for (const g of result.graphs) {
-        info(`  ${g.id}  ${g.name} (v${g.version})${g.description ? ` — ${g.description}` : ""}`);
-      }
-    } else {
-      info("No graphs loaded.");
-    }
-    if (traversals.length > 0) {
-      const heading =
-        filterEntries.length > 0
-          ? `\nActive traversals matching ${JSON.stringify(filter)}:`
-          : "\nActive traversals:";
-      info(heading);
-      for (const t of traversals) {
-        info(
-          `  ${t.traversalId}  ${t.graphId} @ ${t.currentNode}  (depth: ${t.stackDepth}, updated: ${t.lastUpdated})`,
-        );
-        if (t.meta) info(`    meta: ${JSON.stringify(t.meta)}`);
-      }
-    } else if (filterEntries.length > 0) {
-      info(`\nNo active traversals match ${JSON.stringify(filter)}.`);
-    } else {
-      info("\nNo active traversals.");
-    }
-  } catch (e) {
-    handleError(e);
-  }
-}
-
 // Values stay strings — meta is deliberately opaque, so (unlike
 // `freelance context set`) no JSON coercion here.
 function parseMetaPairs(pairs: string[] | undefined, flag: string): Record<string, string> {
@@ -93,6 +46,26 @@ function parseMetaPairs(pairs: string[] | undefined, flag: string): Record<strin
     out[key] = value;
   }
   return out;
+}
+
+export function traversalStatus(store: TraversalStore, opts?: { filter?: string[] }): void {
+  try {
+    const result = store.listGraphs();
+    // Operator-side filter — kept off the MCP surface deliberately. The
+    // skill already sees meta on every list entry and can pick; this is
+    // for shell invocations that want a pre-filter.
+    const filter = parseMetaPairs(opts?.filter, "--filter");
+    const filterEntries = Object.entries(filter);
+    const traversals =
+      filterEntries.length === 0
+        ? result.activeTraversals
+        : result.activeTraversals.filter(
+            (t) => t.meta !== undefined && filterEntries.every(([k, v]) => t.meta?.[k] === v),
+          );
+    outputJson({ ...result, activeTraversals: traversals });
+  } catch (e) {
+    handleError(e);
+  }
 }
 
 export async function traversalStart(
@@ -117,18 +90,7 @@ export async function traversalStart(
       initialContext,
       Object.keys(meta).length > 0 ? meta : undefined,
     );
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(`Started traversal ${result.traversalId} on ${graphId}`);
-      info(`  Node: ${result.currentNode}`);
-      if (result.node.description) {
-        info(`  Description: ${result.node.description}`);
-      }
-      if (result.meta) {
-        info(`  Meta: ${JSON.stringify(result.meta)}`);
-      }
-    }
+    outputJson(result);
   } catch (e) {
     handleError(e);
   }
@@ -151,39 +113,23 @@ export async function traversalAdvance(
       }
     }
     if (!edge) {
-      // Show available edges when no edge specified
+      // No edge argument: report the available edges instead. Useful for
+      // the skill to probe validTransitions without side effects.
       const raw = store.inspect(id, "position");
       const inspectResult = raw as { traversalId: string } & InspectPositionResult;
-      if (cli.json) {
-        outputJson({ traversalId: id, validTransitions: inspectResult.validTransitions });
-      } else {
-        info(`Traversal ${id} @ ${inspectResult.currentNode}`);
-        if (inspectResult.validTransitions?.length) {
-          info("Available edges:");
-          for (const t of inspectResult.validTransitions) {
-            info(
-              `  ${t.label}${t.target ? ` → ${t.target}` : ""}${t.conditionMet === false ? " (condition not met)" : ""}`,
-            );
-          }
-        } else {
-          info("No available edges.");
-        }
-      }
+      outputJson({ traversalId: id, validTransitions: inspectResult.validTransitions });
       return;
     }
     const result = await store.advance(id, edge, contextUpdates);
-    if (cli.json) {
+    if (result.isError) {
+      // In-band advance error — the traversal is fine, the caller's
+      // requested edge didn't pass. Exit BLOCKED so the skill can
+      // distinguish "retry with different context" from "structural
+      // error, stop". Response still carries `validTransitions` etc.
       outputJson(result);
-    } else {
-      if (result.isError) {
-        info(`Advance failed: ${result.reason}`);
-        process.exit(1);
-      }
-      info(`Advanced ${result.traversalId} → ${result.currentNode}`);
-      if (result.node.description) {
-        info(`  Description: ${result.node.description}`);
-      }
+      process.exit(EXIT.BLOCKED);
     }
+    outputJson(result);
   } catch (e) {
     handleError(e);
   }
@@ -211,14 +157,7 @@ export function traversalContextSet(
     }
 
     const result = store.contextSet(id, parsed);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(`Updated context for ${result.traversalId}`);
-      for (const [k, v] of Object.entries(parsed)) {
-        info(`  ${k} = ${JSON.stringify(v)}`);
-      }
-    }
+    outputJson(result);
   } catch (e) {
     handleError(e);
   }
@@ -236,12 +175,7 @@ export function traversalMetaSet(
       throw new Error("meta set requires at least one key=value pair");
     }
     const result = store.setMeta(id, parsed);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(`Updated meta for ${result.traversalId}`);
-      info(`  Meta: ${JSON.stringify(result.meta)}`);
-    }
+    outputJson(result);
   } catch (e) {
     handleError(e);
   }
@@ -256,51 +190,10 @@ export function traversalInspect(
     const id = store.resolveTraversalId(traversalId);
     const validDetail = detail === "history" ? "history" : "position";
     const raw = store.inspect(id, validDetail);
-    if (cli.json) {
-      outputJson(raw);
-    } else {
-      info(`Traversal: ${raw.traversalId}`);
-      info(`  Graph: ${raw.graphId}`);
-      info(`  Node:  ${raw.currentNode}`);
-      if (raw.meta) info(`  Meta:  ${JSON.stringify(raw.meta)}`);
-      if (validDetail === "history") {
-        const hist = raw as { traversalId: string } & InspectHistoryResult;
-        info("  History:");
-        for (const h of hist.traversalHistory) {
-          info(`    ${h.node} (${h.edge ?? "start"})`);
-        }
-      } else {
-        const pos = raw as { traversalId: string } & InspectPositionResult;
-        if (pos.node.description) {
-          info(`  Description: ${pos.node.description}`);
-        }
-        if (pos.validTransitions?.length) {
-          info("  Edges:");
-          for (const t of pos.validTransitions) {
-            info(
-              `    ${t.label}${t.target ? ` → ${t.target}` : ""}${t.conditionMet === false ? " (condition not met)" : ""}`,
-            );
-          }
-        }
-      }
-    }
+    outputJson(raw);
   } catch (e) {
     handleError(e);
   }
-}
-
-interface ActiveTraversalEntry {
-  readonly traversalId: string;
-  readonly graphId: string;
-  readonly currentNode: string;
-  readonly nodeType: string;
-  readonly description: string;
-  readonly lastUpdated: string;
-  readonly stackDepth: number;
-  readonly waitStatus?: "waiting" | "ready" | "timed_out";
-  readonly waitingOn?: readonly WaitCondition[];
-  readonly timeout?: string;
-  readonly timeoutAt?: string;
 }
 
 /**
@@ -315,7 +208,7 @@ export function traversalInspectActive(
 ): void {
   try {
     const infos = store.listTraversals();
-    const entries: ActiveTraversalEntry[] = [];
+    const entries: Array<Record<string, unknown>> = [];
     for (const t of infos) {
       const raw = store.inspect(t.traversalId, "position");
       const pos = raw as { traversalId: string } & InspectPositionResult;
@@ -334,26 +227,7 @@ export function traversalInspectActive(
         ...(pos.timeoutAt ? { timeoutAt: pos.timeoutAt } : {}),
       });
     }
-    if (cli.json) {
-      outputJson({ traversals: entries });
-      return;
-    }
-    if (entries.length === 0) {
-      info(opts?.waitsOnly ? "No active traversals in wait state." : "No active traversals.");
-      return;
-    }
-    info(opts?.waitsOnly ? "Active traversals in wait state:" : "Active traversals:");
-    for (const e of entries) {
-      const waitBit = e.waitStatus ? ` [${e.waitStatus}]` : "";
-      info(`  ${e.traversalId}  ${e.graphId} @ ${e.currentNode}${waitBit}`);
-      if (e.description) info(`    ${e.description}`);
-      if (e.waitingOn?.length) {
-        for (const w of e.waitingOn) {
-          const mark = w.satisfied ? "✓" : "·";
-          info(`    ${mark} ${w.key} (${w.type})${w.description ? ` — ${w.description}` : ""}`);
-        }
-      }
-    }
+    outputJson({ traversals: entries });
   } catch (e) {
     handleError(e);
   }
@@ -365,17 +239,16 @@ export function traversalReset(
   opts?: { confirm?: boolean },
 ): void {
   if (!opts?.confirm) {
-    info("Error: must pass --confirm to reset a traversal.");
-    process.exit(1);
+    outputJson({
+      isError: true,
+      error: { code: "CONFIRM_REQUIRED", message: "must pass --confirm to reset a traversal." },
+    });
+    process.exit(EXIT.INVALID_INPUT);
   }
   try {
     const id = store.resolveTraversalId(traversalId);
     const result = store.resetTraversal(id);
-    if (cli.json) {
-      outputJson(result);
-    } else {
-      info(`Reset traversal ${result.traversalId}: ${result.status}`);
-    }
+    outputJson(result);
   } catch (e) {
     handleError(e);
   }

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -10,6 +10,7 @@
  * relevant, never on the success path.
  */
 
+import { EngineError } from "../errors.js";
 import type { TraversalStore } from "../state/index.js";
 import type { InspectPositionResult } from "../types.js";
 import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js";
@@ -24,11 +25,26 @@ import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js
 function splitKeyValue(pair: string, flag: string): [string, string] {
   const eqIdx = pair.indexOf("=");
   if (eqIdx === -1) {
-    throw new Error(`${flag} requires key=value pairs; got "${pair}"`);
+    throw new EngineError(
+      `${flag} requires key=value pairs; got "${pair}"`,
+      "INVALID_KEY_VALUE_PAIR",
+    );
   }
   const key = pair.slice(0, eqIdx);
-  if (!key) throw new Error(`${flag} key is empty in "${pair}"`);
+  if (!key) {
+    throw new EngineError(`${flag} key is empty in "${pair}"`, "INVALID_KEY_VALUE_PAIR");
+  }
   return [key, pair.slice(eqIdx + 1)];
+}
+
+// Shared by `start` and `advance` for their `--context` JSON payload.
+function parseContextJson(raw: string): Record<string, unknown> {
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new EngineError(`--context must be valid JSON: ${msg}`, "INVALID_CONTEXT_JSON");
+  }
 }
 
 // Values stay strings — meta is deliberately opaque, so (unlike
@@ -70,15 +86,7 @@ export async function traversalStart(
   opts?: { meta?: string[] },
 ): Promise<void> {
   try {
-    let initialContext: Record<string, unknown> | undefined;
-    if (context) {
-      try {
-        initialContext = JSON.parse(context) as Record<string, unknown>;
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new Error(`--context must be valid JSON: ${msg}`);
-      }
-    }
+    const initialContext = context ? parseContextJson(context) : undefined;
     const meta = parseMetaPairs(opts?.meta, "--meta");
     const result = await store.createTraversal(
       graphId,
@@ -98,15 +106,7 @@ export async function traversalAdvance(
 ): Promise<void> {
   try {
     const id = store.resolveTraversalId(opts?.traversal);
-    let contextUpdates: Record<string, unknown> | undefined;
-    if (opts?.context) {
-      try {
-        contextUpdates = JSON.parse(opts.context) as Record<string, unknown>;
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new Error(`--context must be valid JSON: ${msg}`);
-      }
-    }
+    const contextUpdates = opts?.context ? parseContextJson(opts.context) : undefined;
     if (!edge) {
       // No edge argument: report the available edges instead. Useful for
       // the skill to probe validTransitions without side effects.
@@ -167,7 +167,7 @@ export function traversalMetaSet(
     const id = store.resolveTraversalId(opts?.traversal);
     const parsed = parseMetaPairs(updates, "meta set");
     if (Object.keys(parsed).length === 0) {
-      throw new Error("meta set requires at least one key=value pair");
+      throw new EngineError("meta set requires at least one key=value pair", "INVALID_META");
     }
     const result = store.setMeta(id, parsed);
     outputJson(result);

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -12,12 +12,7 @@
 
 import type { TraversalStore } from "../state/index.js";
 import type { InspectPositionResult } from "../types.js";
-import { EXIT, outputError, outputJson } from "./output.js";
-
-function handleError(e: unknown): never {
-  const code = outputError(e);
-  process.exit(code);
-}
+import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js";
 
 /**
  * Shared primitive for CLI flags that accept `key=value` pairs. Splits on

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -6,7 +6,7 @@ import { extractSection } from "../section-resolver.js";
 import type { SourceOptions } from "../sources.js";
 import { getDetailedDrift, validateGraphSources } from "../sources.js";
 import type { ValidatedGraph } from "../types.js";
-import { cli, EXIT, error, fatal, info, outputJson } from "./output.js";
+import { EXIT, outputJson } from "./output.js";
 
 interface GraphResult {
   id: string;
@@ -40,29 +40,23 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
   const resolvedDir = path.resolve(graphsDir);
 
   if (!fs.existsSync(resolvedDir)) {
-    if (cli.json) {
-      outputJson({
-        valid: false,
-        graphs: [],
-        errors: [{ file: resolvedDir, message: "Directory does not exist" }],
-      });
-      process.exit(EXIT.GRAPH_ERROR);
-    }
-    fatal(`Graph directory does not exist: ${resolvedDir}`, EXIT.GRAPH_ERROR);
+    outputJson({
+      valid: false,
+      graphs: [],
+      errors: [{ file: resolvedDir, message: "Directory does not exist" }],
+    });
+    process.exit(EXIT.VALIDATION);
   }
 
   const files = findGraphFiles(resolvedDir);
 
   if (files.length === 0) {
-    if (cli.json) {
-      outputJson({
-        valid: false,
-        graphs: [],
-        errors: [{ file: resolvedDir, message: "No *.workflow.yaml files found" }],
-      });
-      process.exit(EXIT.GRAPH_ERROR);
-    }
-    fatal(`No *.workflow.yaml files found in: ${resolvedDir}`, EXIT.GRAPH_ERROR);
+    outputJson({
+      valid: false,
+      graphs: [],
+      errors: [{ file: resolvedDir, message: "No *.workflow.yaml files found" }],
+    });
+    process.exit(EXIT.VALIDATION);
   }
 
   const result: ValidateResult = { valid: true, graphs: [], errors: [] };
@@ -82,18 +76,10 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
         version: definition.version,
         nodeCount: graph.nodeCount(),
       });
-      if (!cli.json) {
-        info(
-          `  OK  ${definition.name} (id: ${id}, v${definition.version}, ${graph.nodeCount()} nodes)`,
-        );
-      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       result.errors.push({ file: relFile, message: msg });
       result.valid = false;
-      if (!cli.json) {
-        info(`  FAIL  ${relFile}: ${msg}`);
-      }
     }
   }
 
@@ -106,9 +92,6 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
       const msg = err instanceof Error ? err.message : String(err);
       result.errors.push({ file: resolvedDir, message: msg });
       result.valid = false;
-      if (!cli.json) {
-        info(`  FAIL  ${msg}`);
-      }
     }
   }
 
@@ -127,17 +110,12 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
       const sourceResult = validateGraphSources(definition, sourceOpts);
 
       for (const warning of sourceResult.warnings) {
-        // Get detailed drift with expected/actual hashes
         const detailedDrift = getDetailedDrift(definition, warning.node, sourceOpts);
         sourceDrift.push({
           graphId,
           node: warning.node,
           drifted: detailedDrift,
         });
-
-        if (!cli.json) {
-          info(`  DRIFT  ${graphId} → ${warning.node}: ${detailedDrift.length} source(s) changed`);
-        }
 
         // Collect hash replacements for --fix
         if (options.fix) {
@@ -172,13 +150,11 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
           let replaced: string;
 
           if (section) {
-            // Match section line followed by hash line — replace only the hash for this specific section
             const pattern = new RegExp(
               `(section:\\s*"${escapeRegex(section)}"\\s*\\n\\s*hash:\\s*")${escapeRegex(oldHash)}"`,
             );
             replaced = content.replace(pattern, `$1${newHash}"`);
           } else {
-            // No section — match hash alone (whole-file source)
             const pattern = new RegExp(`(hash:\\s*")${escapeRegex(oldHash)}"`);
             replaced = content.replace(pattern, `$1${newHash}"`);
           }
@@ -186,21 +162,12 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
           if (replaced !== content) {
             content = replaced;
             fileFixed++;
-          } else if (!cli.json) {
-            const loc = section ? `${section}:${oldHash}` : oldHash;
-            info(
-              `  WARN  Could not match hash pattern for ${loc} in ${path.relative(resolvedDir, filePath)} — YAML formatting may differ from expected`,
-            );
           }
         }
 
         if (fileFixed > 0) {
           fs.writeFileSync(filePath, content, "utf-8");
           totalFixed += fileFixed;
-          const relFile = path.relative(resolvedDir, filePath);
-          if (!cli.json) {
-            info(`  FIXED  ${relFile}: ${fileFixed} hash(es) updated`);
-          }
         }
       }
 
@@ -211,36 +178,8 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
     }
   }
 
-  if (cli.json) {
-    outputJson(result);
-    process.exit(result.valid ? EXIT.SUCCESS : EXIT.GRAPH_ERROR);
-  }
-
-  info(`\nValidated ${result.graphs.length} graph(s), ${result.errors.length} error(s).\n`);
-
-  if (result.errors.length > 0) {
-    error("Errors:");
-    for (const e of result.errors) {
-      error(`  ${e.file}: ${e.message}`);
-    }
-    process.exit(EXIT.GRAPH_ERROR);
-  }
-
-  if (result.fixed && result.fixed > 0) {
-    info(`Fixed ${result.fixed} drifted hash(es). Re-run without --fix to verify.`);
-    return;
-  }
-
-  if (result.sourceDrift && result.sourceDrift.length > 0) {
-    error("Source drift detected:");
-    for (const d of result.sourceDrift) {
-      error(`  ${d.graphId} → ${d.node}:`);
-      for (const s of d.drifted) {
-        error(`    ${s.path}${s.section ? `#${s.section}` : ""} (${s.expected} → ${s.actual})`);
-      }
-    }
-    process.exit(EXIT.GRAPH_ERROR);
-  }
+  outputJson(result);
+  process.exit(result.valid ? EXIT.SUCCESS : EXIT.VALIDATION);
 }
 
 // --- Helpers ---

--- a/src/cli/visualize.ts
+++ b/src/cli/visualize.ts
@@ -1,16 +1,24 @@
-import { execFileSync } from "node:child_process";
+/**
+ * CLI handler for `freelance visualize` — JSON-only.
+ *
+ * Per docs/decisions.md § "CLI is the execution surface for agents",
+ * output is always structured JSON. The previous `--open` (browser
+ * rendering) path is removed — agents don't open browsers. The
+ * `--output <path>` flag still writes the raw diagram to a file for
+ * callers that want to pipe to external tooling.
+ */
+
 import fs from "node:fs";
 import path from "node:path";
 import { loadSingleGraph } from "../loader.js";
 import type { GraphDefinition } from "../types.js";
-import { cli, EXIT, fatal, info, outputJson } from "./output.js";
+import { EXIT, fatal, outputJson } from "./output.js";
 
 type Format = "mermaid" | "dot";
 
 interface VisualizeOptions {
   format: Format;
   output?: string;
-  open?: boolean;
 }
 
 function dotNodeDef(nodeId: string, type: string, label: string): string {
@@ -65,14 +73,12 @@ function toDot(def: GraphDefinition): string {
     "",
   ];
 
-  // Node definitions
   for (const [nodeId, node] of Object.entries(def.nodes)) {
     lines.push(dotNodeDef(nodeId, node.type, nodeId));
   }
 
   lines.push("");
 
-  // Edges
   for (const [nodeId, node] of Object.entries(def.nodes)) {
     if (node.edges) {
       for (const edge of node.edges) {
@@ -85,46 +91,18 @@ function toDot(def: GraphDefinition): string {
   return `${lines.join("\n")}\n`;
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function toHtml(mermaidCode: string, title: string): string {
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <title>${escapeHtml(title)}</title>
-  <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
-  <style>
-    body { font-family: sans-serif; display: flex; justify-content: center; padding: 2rem; }
-    .mermaid { max-width: 100%; }
-  </style>
-</head>
-<body>
-  <div class="mermaid">
-${mermaidCode}
-  </div>
-  <script>mermaid.initialize({ startOnLoad: true });</script>
-</body>
-</html>`;
-}
-
 function loadDefinition(filePath: string): GraphDefinition {
   const resolved = path.resolve(filePath);
 
   if (!fs.existsSync(resolved)) {
-    fatal(`File not found: ${resolved}`, EXIT.GRAPH_ERROR);
+    fatal(`File not found: ${resolved}`, EXIT.NOT_FOUND, "FILE_NOT_FOUND");
   }
 
   if (!resolved.endsWith(".workflow.yaml")) {
     fatal(
       `File must have .workflow.yaml extension: ${path.basename(resolved)}`,
-      EXIT.INVALID_USAGE,
+      EXIT.INVALID_INPUT,
+      "INVALID_EXTENSION",
     );
   }
 
@@ -132,7 +110,11 @@ function loadDefinition(filePath: string): GraphDefinition {
     const { definition } = loadSingleGraph(resolved);
     return definition;
   } catch (err) {
-    fatal(`Failed to load graph: ${err instanceof Error ? err.message : err}`, EXIT.GRAPH_ERROR);
+    fatal(
+      `Failed to load graph: ${err instanceof Error ? err.message : err}`,
+      EXIT.VALIDATION,
+      "GRAPH_LOAD_FAILED",
+    );
   }
 }
 
@@ -140,45 +122,17 @@ export function visualize(filePath: string, options: VisualizeOptions): void {
   const definition = loadDefinition(filePath);
   const format = options.format ?? "mermaid";
 
-  let diagram: string;
-  if (format === "dot") {
-    diagram = toDot(definition);
-  } else {
-    diagram = toMermaid(definition);
-  }
+  const diagram = format === "dot" ? toDot(definition) : toMermaid(definition);
 
-  if (cli.json) {
-    const result: Record<string, string> = {
-      graphId: definition.id,
-    };
-    result[format] = diagram;
-    outputJson(result);
-    return;
-  }
-
-  if (options.open) {
-    const mermaidCode = format === "dot" ? toMermaid(definition) : diagram;
-    const html = toHtml(mermaidCode, definition.name);
-    const tmpFile = path.join(process.env.TMPDIR ?? "/tmp", `freelance-${definition.id}.html`);
-    fs.writeFileSync(tmpFile, html);
-
-    const platform = process.platform;
-    const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
-    try {
-      execFileSync(cmd, [tmpFile]);
-      info(`Opened in browser: ${tmpFile}`);
-    } catch {
-      info(`Generated: ${tmpFile}`);
-      info("Could not open browser automatically.");
-    }
-    return;
-  }
-
+  // `--output <path>` writes the raw diagram to a file so callers can
+  // pipe directly to a renderer. On stdout we always emit JSON so the
+  // agent driving this has a structured payload to reason about.
   if (options.output) {
     const outPath = path.resolve(options.output);
     fs.writeFileSync(outPath, diagram);
-    info(`Written to: ${outPath}`);
-  } else {
-    process.stdout.write(diagram);
+    outputJson({ graphId: definition.id, format, written: outPath });
+    return;
   }
+
+  outputJson({ graphId: definition.id, format, [format]: diagram });
 }

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -23,15 +23,17 @@ export function errorResponse(message: string, detail?: unknown) {
  * domain errors meant for the agent; anything else is prefixed
  * "Internal error:" so users can tell a bug from a usage issue.
  *
- * When the thrown error is an EngineError, the response payload
- * includes its `code` alongside `error` so callers can branch on the
- * machine-readable code (e.g. CONTEXT_VALUE_TOO_LARGE) rather than
- * string-matching the message.
+ * The response payload uses the canonical error shape
+ *   { isError: true, error: { code, message } }
+ * shared with the CLI's `outputError` (see `src/cli/output.ts`) so a
+ * skill consuming either surface branches on the same structure.
  */
 export function handleError(e: unknown) {
   if (e instanceof EngineError) {
-    return errorResponse(e.message, { error: e.message, code: e.code });
+    return errorResponse(e.message, { error: { code: e.code, message: e.message } });
   }
   const message = e instanceof Error ? e.message : String(e);
-  return errorResponse(`Internal error: ${message}`);
+  return errorResponse(`Internal error: ${message}`, {
+    error: { code: "INTERNAL", message: `Internal error: ${message}` },
+  });
 }

--- a/test/cli-config.test.ts
+++ b/test/cli-config.test.ts
@@ -2,11 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configSetLocal, configShow } from "../src/cli/config.js";
-import { setCli } from "../src/cli/output.js";
 import { loadConfig } from "../src/config.js";
 import { tmpFreelanceDir } from "./helpers.js";
 
-let stderrOutput: string[];
+let stdoutChunks: string[];
+let stderrChunks: string[];
 const cleanup: string[] = [];
 
 function makeDir(prefix?: string): string {
@@ -15,13 +15,21 @@ function makeDir(prefix?: string): string {
   return dir;
 }
 
+function stdoutJson(): unknown {
+  return JSON.parse(stdoutChunks.join(""));
+}
+
 beforeEach(() => {
-  stderrOutput = [];
-  vi.spyOn(process.stderr, "write").mockImplementation((msg) => {
-    stderrOutput.push(String(msg));
+  stdoutChunks = [];
+  stderrChunks = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((msg) => {
+    stdoutChunks.push(String(msg));
     return true;
   });
-  setCli({ json: false, quiet: false, verbose: false, noColor: false });
+  vi.spyOn(process.stderr, "write").mockImplementation((msg) => {
+    stderrChunks.push(String(msg));
+    return true;
+  });
 });
 
 afterEach(() => {
@@ -32,7 +40,7 @@ afterEach(() => {
 });
 
 describe("configShow", () => {
-  it("shows resolved config from a directory", () => {
+  it("outputs JSON with resolved config from a directory", () => {
     const dir = makeDir("show-");
     fs.writeFileSync(
       path.join(dir, "config.yml"),
@@ -45,38 +53,27 @@ memory:
 `,
     );
     configShow({ workflows: dir });
-    const output = stderrOutput.join("");
-    expect(output).toContain("Graph directories:");
-    expect(output).toContain(dir);
-    expect(output).toContain("Loaded from:");
-  });
-
-  it("shows empty config for dir with no config files", () => {
-    const dir = makeDir("show-empty-");
-    configShow({ workflows: dir });
-    const output = stderrOutput.join("");
-    expect(output).toContain("Graph directories:");
-    expect(output).toContain("enabled: true (default)");
-    expect(output).not.toContain("Loaded from:");
-  });
-
-  it("outputs JSON when --json is set", () => {
-    const dir = makeDir("show-json-");
-    const stdoutChunks: string[] = [];
-    vi.spyOn(process.stdout, "write").mockImplementation((msg) => {
-      stdoutChunks.push(String(msg));
-      return true;
-    });
-    setCli({ json: true, quiet: false, verbose: false, noColor: false });
-
-    configShow({ workflows: dir });
-    const parsed = JSON.parse(stdoutChunks.join(""));
+    const parsed = stdoutJson() as {
+      workflows: unknown;
+      memory: unknown;
+      graphsDirs: string[];
+      sources: string[];
+    };
     expect(parsed).toHaveProperty("workflows");
     expect(parsed).toHaveProperty("memory");
-    expect(parsed).toHaveProperty("graphsDirs");
+    expect(parsed.graphsDirs).toContain(dir);
+    expect(parsed.sources.length).toBeGreaterThan(0);
   });
 
-  it("shows additional workflows from config", () => {
+  it("outputs JSON with empty config for dir with no config files", () => {
+    const dir = makeDir("show-empty-");
+    configShow({ workflows: dir });
+    const parsed = stdoutJson() as { graphsDirs: string[]; sources: string[] };
+    expect(parsed.graphsDirs).toContain(dir);
+    expect(parsed.sources).toEqual([]);
+  });
+
+  it("surfaces additional workflows from config", () => {
     const dir = makeDir("show-wf-");
     const extraDir = path.join(path.dirname(dir), "extra");
     fs.mkdirSync(extraDir, { recursive: true });
@@ -88,25 +85,28 @@ workflows:
 `,
     );
     configShow({ workflows: dir });
-    const output = stderrOutput.join("");
-    expect(output).toContain("Additional workflows");
-    expect(output).toContain(extraDir);
+    const parsed = stdoutJson() as { workflows: string[] };
+    expect(parsed.workflows).toContain(extraDir);
   });
 });
 
 describe("configSetLocal", () => {
-  it("sets workflows key", () => {
+  it("sets workflows key and outputs updated config", () => {
     const dir = makeDir("set-wf-");
     configSetLocal("workflows", "/tmp/plugin/wf", { workflows: dir });
 
+    const parsed = stdoutJson() as { workflows: string[] };
+    expect(parsed.workflows).toContain("/tmp/plugin/wf");
+
     const config = loadConfig(dir);
     expect(config.workflows).toContain("/tmp/plugin/wf");
-    expect(stderrOutput.join("")).toContain("Added workflow directory");
   });
 
   it("is idempotent for workflows", () => {
     const dir = makeDir("set-idem-");
     configSetLocal("workflows", "/tmp/plugin/wf", { workflows: dir });
+    // Reset stdout capture between calls
+    stdoutChunks.length = 0;
     configSetLocal("workflows", "/tmp/plugin/wf", { workflows: dir });
 
     const config = loadConfig(dir);
@@ -114,34 +114,31 @@ describe("configSetLocal", () => {
     expect(matches).toHaveLength(1);
   });
 
-  it("sets memory.dir", () => {
+  it("sets memory.dir and outputs updated config", () => {
     const dir = makeDir("set-memdir-");
     configSetLocal("memory.dir", "/tmp/persistent", { workflows: dir });
 
-    const config = loadConfig(dir);
-    expect(config.memory.dir).toBe("/tmp/persistent");
-    expect(stderrOutput.join("")).toContain("Set memory.dir");
+    const parsed = stdoutJson() as { memory: { dir?: string } };
+    expect(parsed.memory.dir).toBe("/tmp/persistent");
   });
 
-  it("warns when overwriting memory.dir", () => {
+  it("warns on stderr when overwriting memory.dir", () => {
     const dir = makeDir("set-memdir-warn-");
     configSetLocal("memory.dir", "/first", { workflows: dir });
+    stderrChunks.length = 0;
     configSetLocal("memory.dir", "/second", { workflows: dir });
 
-    const config = loadConfig(dir);
-    expect(config.memory.dir).toBe("/second");
-    expect(stderrOutput.join("")).toContain("Warning: memory.dir already set");
+    expect(stderrChunks.join("")).toContain("Warning: memory.dir already set");
   });
 
-  it("sets memory.enabled", () => {
+  it("sets memory.enabled and outputs updated config", () => {
     const dir = makeDir("set-enabled-");
     configSetLocal("memory.enabled", "false", { workflows: dir });
-
-    const config = loadConfig(dir);
-    expect(config.memory.enabled).toBe(false);
+    const parsed = stdoutJson() as { memory: { enabled?: boolean } };
+    expect(parsed.memory.enabled).toBe(false);
   });
 
-  it("rejects invalid memory.enabled value", () => {
+  it("rejects invalid memory.enabled value with INVALID_INPUT (exit 5)", () => {
     const dir = makeDir("set-bad-enabled-");
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
@@ -150,31 +147,22 @@ describe("configSetLocal", () => {
     expect(() => configSetLocal("memory.enabled", "yes", { workflows: dir })).toThrow(
       "process.exit",
     );
-    expect(exitSpy).toHaveBeenCalledWith(2);
+    expect(exitSpy).toHaveBeenCalledWith(5);
+    const parsed = stdoutJson() as { isError: true; error: { code: string } };
+    expect(parsed.isError).toBe(true);
+    expect(parsed.error.code).toBe("INVALID_CONFIG_VALUE");
   });
 
-  it("rejects unknown key", () => {
+  it("rejects unknown key with INVALID_INPUT (exit 5)", () => {
     const dir = makeDir("set-unknown-");
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
     }) as never);
 
     expect(() => configSetLocal("bad.key", "val", { workflows: dir })).toThrow("process.exit");
-    expect(exitSpy).toHaveBeenCalledWith(2);
-    expect(stderrOutput.join("")).toContain("Unknown config key");
-  });
-
-  it("outputs JSON when --json is set", () => {
-    const dir = makeDir("set-json-");
-    const stdoutChunks: string[] = [];
-    vi.spyOn(process.stdout, "write").mockImplementation((msg) => {
-      stdoutChunks.push(String(msg));
-      return true;
-    });
-    setCli({ json: true, quiet: false, verbose: false, noColor: false });
-
-    configSetLocal("memory.enabled", "true", { workflows: dir });
-    const parsed = JSON.parse(stdoutChunks.join(""));
-    expect(parsed.memory.enabled).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(5);
+    const parsed = stdoutJson() as { isError: true; error: { code: string; message: string } };
+    expect(parsed.error.code).toBe("UNKNOWN_CONFIG_KEY");
+    expect(parsed.error.message).toContain("bad.key");
   });
 });

--- a/test/cli-index.test.ts
+++ b/test/cli-index.test.ts
@@ -155,7 +155,7 @@ describe("program commands", () => {
 
   it("preAction hook sets CLI state", async () => {
     const { validate } = await import("../src/cli/validate.js");
-    await program.parseAsync(["node", "freelance", "--json", "--quiet", "validate", "/tmp"]);
+    await program.parseAsync(["node", "freelance", "--quiet", "validate", "/tmp"]);
     expect(validate).toHaveBeenCalled();
   });
 

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -33,7 +33,7 @@ describe("CLI init", () => {
     }) as never);
     stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    setCli({ json: false, quiet: false, verbose: false, noColor: false });
+    setCli({ quiet: false, verbose: false });
 
     originalCwd = process.cwd();
     workDir = tmpDir();
@@ -136,8 +136,7 @@ describe("CLI init", () => {
     expect(fs.existsSync(path.join(workDir, "CLAUDE.md"))).toBe(false);
   });
 
-  it("dry-run JSON output describes planned actions", async () => {
-    setCli({ json: true });
+  it("dry-run output describes planned actions", async () => {
     await init(defaults({ dryRun: true }));
     const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
     const result = JSON.parse(output);
@@ -145,8 +144,7 @@ describe("CLI init", () => {
     expect(result.actions.length).toBeGreaterThan(0);
   });
 
-  it("JSON output lists created files", async () => {
-    setCli({ json: true });
+  it("output lists created files", async () => {
     await init(defaults());
     const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
     const result = JSON.parse(output);
@@ -155,11 +153,11 @@ describe("CLI init", () => {
     expect(result.client).toBe("claude-code");
   });
 
-  it("manual client prints config to stdout instead of writing file", async () => {
+  it("manual client embeds config snippet in JSON response instead of writing a file", async () => {
     await init(defaults({ client: "manual" }));
     const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
     const parsed = JSON.parse(stdout);
-    expect(parsed.mcpServers.freelance).toBeDefined();
+    expect(parsed.manualConfig?.mcpServers?.freelance).toBeDefined();
     // No .mcp.json or other config file created
     expect(fs.existsSync(path.join(workDir, ".mcp.json"))).toBe(false);
   });
@@ -308,30 +306,41 @@ describe("CLI init", () => {
     expect(config.mcpServers.freelance).toBeDefined();
   });
 
-  it("dry-run human output lists planned actions", async () => {
+  it("dry-run JSON response includes planned actions with their verbs", async () => {
     await init(defaults({ dryRun: true }));
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("Dry run");
-    expect(stderr).toContain("Would create:");
-    expect(stderr).toContain("Would configure:");
-    expect(stderr).toContain("Run without --dry-run");
+    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(stdout) as {
+      dryRun: boolean;
+      actions: Array<{ verb: string; target: string }>;
+    };
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.actions.some((a) => a.verb === "create")).toBe(true);
+    expect(parsed.actions.some((a) => a.verb === "configure")).toBe(true);
   });
 
-  it("dry-run with existing graph shows 'Would skip'", async () => {
+  it("dry-run with existing graph includes a 'skip' action", async () => {
     const graphsDir = path.join(workDir, ".freelance");
     fs.mkdirSync(graphsDir, { recursive: true });
     fs.writeFileSync(path.join(graphsDir, "blank.workflow.yaml"), "id: cr\n");
     await init(defaults({ dryRun: true }));
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("Would skip:");
+    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(stdout) as { actions: Array<{ verb: string; target: string }> };
+    expect(parsed.actions.some((a) => a.verb === "skip")).toBe(true);
   });
 
-  it("human output includes checkmarks and next steps", async () => {
+  it("success response shape includes scope / client / starter / files", async () => {
     await init(defaults());
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("\u2713");
-    expect(stderr).toContain("Next steps:");
-    expect(stderr).toContain("freelance_list");
+    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    const parsed = JSON.parse(stdout) as {
+      scope: string;
+      client: string;
+      starter: string;
+      files: string[];
+    };
+    expect(parsed.scope).toBe("project");
+    expect(parsed.client).toBe("claude-code");
+    expect(parsed.starter).toBe("blank");
+    expect(parsed.files.length).toBeGreaterThan(0);
   });
 
   it("writes hooks when --hooks is passed", async () => {
@@ -379,11 +388,14 @@ describe("CLI init", () => {
     expect(fs.existsSync(settingsPath)).toBe(false);
   });
 
-  it("dry-run shows 'Would append' for existing CLAUDE.md", async () => {
+  it("dry-run includes an 'append' action for existing CLAUDE.md", async () => {
     fs.writeFileSync(path.join(workDir, "CLAUDE.md"), "# Existing\n\nSome content.\n");
     await init(defaults({ dryRun: true }));
-    const stderr = stderrSpy.mock.calls.map((c: [string]) => c[0]).join("");
-    expect(stderr).toContain("Would append:");
+    const stdout = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
+    const parsed = JSON.parse(stdout) as {
+      actions: Array<{ verb: string; target: string }>;
+    };
+    expect(parsed.actions.some((a) => a.verb === "append" && a.target === "CLAUDE.md")).toBe(true);
   });
 
   it("missing template file calls fatal", async () => {
@@ -427,7 +439,7 @@ describe("initInteractive", () => {
     }) as never);
     vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    setCli({ json: false, quiet: false, verbose: false, noColor: false });
+    setCli({ quiet: false, verbose: false });
     mockSelectState.callCount = 0;
     mockSelectState.responses.length = 0;
   });

--- a/test/cli-stateless.test.ts
+++ b/test/cli-stateless.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sourcesValidate } from "../src/cli/stateless.js";
+
+describe("sourcesValidate", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  const createdDirs: string[] = [];
+
+  function tmpDir(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), "stateless-test-"));
+    createdDirs.push(d);
+    return d;
+  }
+
+  function stdoutJson(): unknown {
+    return JSON.parse(stdoutSpy.mock.calls.map((c: [string]) => c[0]).join(""));
+  }
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const d of createdDirs) fs.rmSync(d, { recursive: true, force: true });
+    createdDirs.length = 0;
+  });
+
+  it("errors with NO_GRAPHS_DIR when graphsDirs is empty", () => {
+    expect(() => sourcesValidate([], {})).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(4); // EXIT.NOT_FOUND
+    const parsed = stdoutJson() as { isError: true; error: { code: string } };
+    expect(parsed.error.code).toBe("NO_GRAPHS_DIR");
+  });
+
+  it("errors with NO_GRAPHS_LOADED when dirs exist but contain no loadable graphs", () => {
+    const dir = tmpDir();
+    expect(() => sourcesValidate([dir], {})).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(4);
+    const parsed = stdoutJson() as { isError: true; error: { code: string } };
+    expect(parsed.error.code).toBe("NO_GRAPHS_LOADED");
+  });
+
+  it("errors with GRAPH_NOT_FOUND when specified graphId does not match any loaded graph", () => {
+    const dir = tmpDir();
+    const fixtureSrc = path.resolve("test/fixtures/valid-simple.workflow.yaml");
+    fs.copyFileSync(fixtureSrc, path.join(dir, "valid-simple.workflow.yaml"));
+    expect(() => sourcesValidate([dir], {}, "nonexistent-id")).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(4);
+    const parsed = stdoutJson() as { isError: true; error: { code: string } };
+    expect(parsed.error.code).toBe("GRAPH_NOT_FOUND");
+  });
+});

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -15,7 +15,7 @@ import { loadSingleGraph } from "../src/loader.js";
 import { openStateStore, TraversalStore } from "../src/state/index.js";
 import type { ValidatedGraph } from "../src/types.js";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: vitest spy types
 let exitSpy: any;
 let stderrSpy: any;
 let stdoutSpy: any;
@@ -33,10 +33,9 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-// --- Direct store-based CLI tests ---
+// --- Helpers ---
 
 function createTestStore(): TraversalStore {
-  // Load a single valid graph to avoid circular subgraph errors
   const fixture = path.resolve("test/fixtures/valid-branching.workflow.yaml");
   const loaded = loadSingleGraph(fixture);
   const graphs = new Map<string, ValidatedGraph>([[loaded.id, loaded]]);
@@ -44,25 +43,24 @@ function createTestStore(): TraversalStore {
   return new TraversalStore(db, graphs, { maxDepth: 5, hookRunner: new HookRunner() });
 }
 
-describe("traversalStatus", () => {
-  it("shows graphs and no traversals (text mode)", async () => {
-    const store = createTestStore();
-    try {
-      traversalStatus(store);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Graphs:"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("No active traversals"));
-    } finally {
-      store.close();
-    }
-  });
+function stdoutJson(): unknown {
+  const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
+  return JSON.parse(output);
+}
 
-  it("outputs JSON", async () => {
-    setCli({ json: true });
+// Runtime CLI handlers are JSON-only per docs/decisions.md § CLI-primary.
+// All assertions go against stdout (parsed JSON) — stderr is for
+// breadcrumbs and does not carry any response data.
+
+describe("traversalStatus", () => {
+  it("outputs JSON with graphs and activeTraversals", () => {
     const store = createTestStore();
     try {
       traversalStatus(store);
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output);
+      const parsed = stdoutJson() as {
+        graphs: unknown[];
+        activeTraversals: unknown[];
+      };
       expect(parsed).toHaveProperty("graphs");
       expect(parsed).toHaveProperty("activeTraversals");
     } finally {
@@ -72,29 +70,13 @@ describe("traversalStatus", () => {
 });
 
 describe("traversalStart", () => {
-  it("starts a traversal and prints node info", async () => {
-    const store = createTestStore();
-    try {
-      // Use a graph from fixtures — "linear" is a simple one
-      const graphId = store.listGraphs().graphs[0]?.id;
-      if (!graphId) return; // skip if no fixtures
-      await traversalStart(store, graphId);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Started traversal"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Node:"));
-    } finally {
-      store.close();
-    }
-  });
-
-  it("outputs JSON on start", async () => {
-    setCli({ json: true });
+  it("starts a traversal and outputs JSON with traversalId + currentNode", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       await traversalStart(store, graphId);
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output);
+      const parsed = stdoutJson() as { traversalId: string; currentNode: string };
       expect(parsed).toHaveProperty("traversalId");
       expect(parsed).toHaveProperty("currentNode");
     } finally {
@@ -102,10 +84,14 @@ describe("traversalStart", () => {
     }
   });
 
-  it("errors on unknown graph", async () => {
+  it("errors on unknown graph with GRAPH_NOT_FOUND code", async () => {
     const store = createTestStore();
     try {
       await expect(traversalStart(store, "nonexistent-graph")).rejects.toThrow("process.exit");
+      const parsed = stdoutJson() as { isError: true; error: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.error.code).toBe("GRAPH_NOT_FOUND");
+      expect(exitSpy).toHaveBeenCalledWith(4); // EXIT.NOT_FOUND
     } finally {
       store.close();
     }
@@ -113,16 +99,17 @@ describe("traversalStart", () => {
 });
 
 describe("traversalInspect", () => {
-  it("shows current position", async () => {
+  it("outputs JSON with currentNode and node info", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       const { traversalId } = await store.createTraversal(graphId);
       traversalInspect(store, traversalId, "position");
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Traversal:"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Graph:"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Node:"));
+      const parsed = stdoutJson() as { traversalId: string; currentNode: string; node: unknown };
+      expect(parsed.traversalId).toBe(traversalId);
+      expect(parsed.currentNode).toBeDefined();
+      expect(parsed.node).toBeDefined();
     } finally {
       store.close();
     }
@@ -130,28 +117,33 @@ describe("traversalInspect", () => {
 });
 
 describe("traversalContextSet", () => {
-  it("sets key=value pairs", async () => {
+  it("sets key=value pairs and outputs updated context", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       await store.createTraversal(graphId);
-      traversalContextSet(store, ["foo=42", "bar=true"]);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Updated context"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("foo = 42"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("bar = true"));
+      traversalContextSet(store, ["qualityPassed=true", 'path="left"']);
+      const parsed = stdoutJson() as { status: string; context: Record<string, unknown> };
+      expect(parsed.status).toBe("updated");
+      expect(parsed.context.qualityPassed).toBe(true);
+      expect(parsed.context.path).toBe("left");
     } finally {
       store.close();
     }
   });
 
-  it("errors on invalid pair", async () => {
+  it("errors on invalid pair with INTERNAL exit code (thrown Error)", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       await store.createTraversal(graphId);
       expect(() => traversalContextSet(store, ["noequalssign"])).toThrow("process.exit");
+      const parsed = stdoutJson() as { isError: true; error: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.error.code).toBe("INTERNAL");
+      expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       store.close();
     }
@@ -167,26 +159,27 @@ describe("traversalInspectActive", () => {
     return new TraversalStore(db, graphs, { maxDepth: 5, hookRunner: new HookRunner() });
   }
 
-  it("reports an empty list when nothing is active (text)", () => {
+  it("outputs an empty traversals array when nothing is active", () => {
     const store = createTestStore();
     try {
       traversalInspectActive(store);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("No active traversals"));
+      const parsed = stdoutJson() as { traversals: unknown[] };
+      expect(parsed.traversals).toEqual([]);
     } finally {
       store.close();
     }
   });
 
   it("lists active traversals including non-wait nodes", async () => {
-    setCli({ json: true });
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       await store.createTraversal(graphId);
       traversalInspectActive(store);
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output);
+      const parsed = stdoutJson() as {
+        traversals: Array<{ traversalId: string; nodeType: string }>;
+      };
       expect(parsed.traversals).toHaveLength(1);
       expect(parsed.traversals[0]).toHaveProperty("traversalId");
       expect(parsed.traversals[0]).toHaveProperty("nodeType");
@@ -196,17 +189,16 @@ describe("traversalInspectActive", () => {
   });
 
   it("filters to wait nodes when waitsOnly is set", async () => {
-    setCli({ json: true });
     const store = createWaitStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       const { traversalId } = await store.createTraversal(graphId);
-      // Advance off the action node into the wait node.
       await store.advance(traversalId, "done");
       traversalInspectActive(store, { waitsOnly: true });
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output);
+      const parsed = stdoutJson() as {
+        traversals: Array<{ nodeType: string; waitStatus?: string; waitingOn?: unknown }>;
+      };
       expect(parsed.traversals).toHaveLength(1);
       expect(parsed.traversals[0].nodeType).toBe("wait");
       expect(parsed.traversals[0].waitStatus).toBe("waiting");
@@ -217,15 +209,13 @@ describe("traversalInspectActive", () => {
   });
 
   it("excludes non-wait traversals when waitsOnly is set", async () => {
-    setCli({ json: true });
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       await store.createTraversal(graphId);
       traversalInspectActive(store, { waitsOnly: true });
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output);
+      const parsed = stdoutJson() as { traversals: unknown[] };
       expect(parsed.traversals).toHaveLength(0);
     } finally {
       store.close();
@@ -234,7 +224,7 @@ describe("traversalInspectActive", () => {
 });
 
 describe("traversalStart --meta", () => {
-  it("persists meta key=value pairs and prints them", async () => {
+  it("persists meta tags and includes them in the JSON response", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
@@ -242,8 +232,8 @@ describe("traversalStart --meta", () => {
       await traversalStart(store, graphId, undefined, {
         meta: ["externalKey=DEV-1234", "branch=feature/x"],
       });
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Meta:"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("DEV-1234"));
+      const parsed = stdoutJson() as { meta: Record<string, string> };
+      expect(parsed.meta).toEqual({ externalKey: "DEV-1234", branch: "feature/x" });
       const list = store.listTraversals();
       expect(list[0].meta).toEqual({ externalKey: "DEV-1234", branch: "feature/x" });
     } finally {
@@ -266,40 +256,7 @@ describe("traversalStart --meta", () => {
 });
 
 describe("traversalStatus --filter (operator-side)", () => {
-  it("narrows the listing to traversals matching every key=value pair", async () => {
-    const store = createTestStore();
-    try {
-      const graphId = store.listGraphs().graphs[0]?.id;
-      if (!graphId) return;
-      const a = await store.createTraversal(graphId, undefined, { externalKey: "DEV-1" });
-      await store.createTraversal(graphId, undefined, { externalKey: "DEV-2" });
-
-      traversalStatus(store, { filter: ["externalKey=DEV-1"] });
-      const printed = stderrSpy.mock.calls.map((c: [string]) => c[0] as string).join("");
-      expect(printed).toContain("matching");
-      expect(printed).toContain(a.traversalId);
-      expect(printed).toContain("DEV-1");
-      expect(printed).not.toContain("DEV-2");
-    } finally {
-      store.close();
-    }
-  });
-
-  it("reports no matches when filter excludes everything", async () => {
-    const store = createTestStore();
-    try {
-      const graphId = store.listGraphs().graphs[0]?.id;
-      if (!graphId) return;
-      await store.createTraversal(graphId, undefined, { externalKey: "DEV-1" });
-      traversalStatus(store, { filter: ["externalKey=DEV-NONE"] });
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("No active traversals match"));
-    } finally {
-      store.close();
-    }
-  });
-
-  it("--json output reflects the filtered set", async () => {
-    setCli({ json: true });
+  it("JSON output reflects the filtered set", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
@@ -307,8 +264,7 @@ describe("traversalStatus --filter (operator-side)", () => {
       await store.createTraversal(graphId, undefined, { externalKey: "DEV-1" });
       await store.createTraversal(graphId, undefined, { externalKey: "DEV-2" });
       traversalStatus(store, { filter: ["externalKey=DEV-1"] });
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output) as {
+      const parsed = stdoutJson() as {
         activeTraversals: Array<{ meta?: Record<string, string> }>;
       };
       expect(parsed.activeTraversals).toHaveLength(1);
@@ -317,18 +273,34 @@ describe("traversalStatus --filter (operator-side)", () => {
       store.close();
     }
   });
+
+  it("returns an empty activeTraversals when filter matches nothing", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      await store.createTraversal(graphId, undefined, { externalKey: "DEV-1" });
+      traversalStatus(store, { filter: ["externalKey=DEV-NONE"] });
+      const parsed = stdoutJson() as { activeTraversals: unknown[] };
+      expect(parsed.activeTraversals).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
 });
 
 describe("traversalStatus shows meta on active traversals", () => {
-  it("prints meta tags so callers can pick a traversal by tag", async () => {
+  it("JSON response surfaces meta tags", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       await store.createTraversal(graphId, undefined, { externalKey: "DEV-1234" });
       traversalStatus(store);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Active traversals"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("DEV-1234"));
+      const parsed = stdoutJson() as {
+        activeTraversals: Array<{ meta?: Record<string, string> }>;
+      };
+      expect(parsed.activeTraversals[0].meta).toEqual({ externalKey: "DEV-1234" });
     } finally {
       store.close();
     }
@@ -336,7 +308,7 @@ describe("traversalStatus shows meta on active traversals", () => {
 });
 
 describe("traversalInspect shows meta", () => {
-  it("prints meta tags when present on the traversal", async () => {
+  it("includes meta at the top level of the response", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
@@ -345,8 +317,8 @@ describe("traversalInspect shows meta", () => {
         externalKey: "DEV-9",
       });
       traversalInspect(store, traversalId, "position");
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Meta:"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("DEV-9"));
+      const parsed = stdoutJson() as { meta?: Record<string, string> };
+      expect(parsed.meta).toEqual({ externalKey: "DEV-9" });
     } finally {
       store.close();
     }
@@ -354,7 +326,7 @@ describe("traversalInspect shows meta", () => {
 });
 
 describe("traversalMetaSet", () => {
-  it("merges key=value pairs and prints the updated meta", async () => {
+  it("merges key=value pairs and outputs the updated meta", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
@@ -363,9 +335,11 @@ describe("traversalMetaSet", () => {
         externalKey: "DEV-1",
       });
       traversalMetaSet(store, ["prUrl=https://example/pr/7"], { traversal: traversalId });
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Updated meta"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("prUrl"));
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("DEV-1"));
+      const parsed = stdoutJson() as { meta: Record<string, string> };
+      expect(parsed.meta).toEqual({
+        externalKey: "DEV-1",
+        prUrl: "https://example/pr/7",
+      });
     } finally {
       store.close();
     }
@@ -397,40 +371,28 @@ describe("traversalMetaSet", () => {
 });
 
 describe("traversalReset", () => {
-  it("errors without --confirm", async () => {
+  it("errors without --confirm (CONFIRM_REQUIRED / EXIT 5)", () => {
     const store = createTestStore();
     try {
       expect(() => traversalReset(store, undefined, {})).toThrow("process.exit");
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("--confirm"));
+      const parsed = stdoutJson() as { isError: true; error: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.error.code).toBe("CONFIRM_REQUIRED");
+      expect(exitSpy).toHaveBeenCalledWith(5); // EXIT.INVALID_INPUT
     } finally {
       store.close();
     }
   });
 
-  it("resets with --confirm", async () => {
+  it("resets with --confirm and outputs JSON", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
       if (!graphId) return;
       const { traversalId } = await store.createTraversal(graphId);
       traversalReset(store, traversalId, { confirm: true });
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Reset traversal"));
-    } finally {
-      store.close();
-    }
-  });
-
-  it("outputs JSON on reset", async () => {
-    setCli({ json: true });
-    const store = createTestStore();
-    try {
-      const graphId = store.listGraphs().graphs[0]?.id;
-      if (!graphId) return;
-      const { traversalId } = await store.createTraversal(graphId);
-      traversalReset(store, traversalId, { confirm: true });
-      const output = stdoutSpy.mock.calls.map((c: [string]) => c[0]).join("");
-      const parsed = JSON.parse(output);
-      expect(parsed).toHaveProperty("status", "reset");
+      const parsed = stdoutJson() as { status: string };
+      expect(parsed.status).toBe("reset");
     } finally {
       store.close();
     }

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -16,7 +16,6 @@ import { openStateStore, TraversalStore } from "../src/state/index.js";
 import type { ValidatedGraph } from "../src/types.js";
 
 let exitSpy: ReturnType<typeof vi.spyOn>;
-let stderrSpy: ReturnType<typeof vi.spyOn>;
 let stdoutSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(async () => {
@@ -24,7 +23,7 @@ beforeEach(async () => {
   exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit");
   }) as never);
-  stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 });
 
@@ -132,7 +131,7 @@ describe("traversalContextSet", () => {
     }
   });
 
-  it("errors on invalid pair with INTERNAL exit code (thrown Error)", async () => {
+  it("errors on invalid pair with INVALID_KEY_VALUE_PAIR / EXIT 5", async () => {
     const store = createTestStore();
     try {
       const graphId = store.listGraphs().graphs[0]?.id;
@@ -141,8 +140,8 @@ describe("traversalContextSet", () => {
       expect(() => traversalContextSet(store, ["noequalssign"])).toThrow("process.exit");
       const parsed = stdoutJson() as { isError: true; error: { code: string } };
       expect(parsed.isError).toBe(true);
-      expect(parsed.error.code).toBe("INTERNAL");
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(parsed.error.code).toBe("INVALID_KEY_VALUE_PAIR");
+      expect(exitSpy).toHaveBeenCalledWith(5); // EXIT.INVALID_INPUT
     } finally {
       store.close();
     }

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -21,7 +21,7 @@ let stderrSpy: any;
 let stdoutSpy: any;
 
 beforeEach(async () => {
-  setCli({ json: false, quiet: false, verbose: false, noColor: false });
+  setCli({ quiet: false, verbose: false });
   exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit");
   }) as never);

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -15,10 +15,9 @@ import { loadSingleGraph } from "../src/loader.js";
 import { openStateStore, TraversalStore } from "../src/state/index.js";
 import type { ValidatedGraph } from "../src/types.js";
 
-// biome-ignore lint/suspicious/noExplicitAny: vitest spy types
-let exitSpy: any;
-let stderrSpy: any;
-let stdoutSpy: any;
+let exitSpy: ReturnType<typeof vi.spyOn>;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(async () => {
   setCli({ quiet: false, verbose: false });

--- a/test/cli-validate.test.ts
+++ b/test/cli-validate.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setCli } from "../src/cli/output.js";
 import { validate } from "../src/cli/validate.js";
 import { hashContent } from "../src/sources.js";
 
@@ -18,127 +17,92 @@ function copyFixtures(dir: string, ...files: string[]): void {
   }
 }
 
+// Runtime + authoring CLI handlers are JSON-only per docs/decisions.md.
+// Assertions go against stdout (parsed) and exit codes.
+
 describe("CLI validate", () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
-  let stderrSpy: ReturnType<typeof vi.spyOn>;
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  function stdoutJson(): unknown {
+    const out = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    return JSON.parse(out);
+  }
 
   beforeEach(() => {
     exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
     }) as never);
-    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    setCli({ json: false, quiet: false, verbose: false, noColor: false });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("succeeds with valid graph files", () => {
+  it("succeeds with valid graph files (exit 0)", () => {
     const dir = tmpDir();
     copyFixtures(dir, "valid-simple.workflow.yaml", "valid-branching.workflow.yaml");
-    validate(dir);
-    expect(exitSpy).not.toHaveBeenCalled();
-  });
-
-  it("exits with GRAPH_ERROR for nonexistent directory", () => {
-    expect(() => validate("/nonexistent/path")).toThrow("process.exit");
-    expect(exitSpy).toHaveBeenCalledWith(3);
-  });
-
-  it("exits with GRAPH_ERROR for empty directory", () => {
-    const dir = tmpDir();
-    expect(() => validate(dir)).toThrow("process.exit");
-    expect(exitSpy).toHaveBeenCalledWith(3);
-  });
-
-  it("exits with GRAPH_ERROR for invalid graph", () => {
-    const dir = tmpDir();
-    copyFixtures(dir, "invalid-orphan.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
-    expect(exitSpy).toHaveBeenCalledWith(3);
-  });
-
-  it("reports per-file errors in human output", () => {
-    const dir = tmpDir();
-    copyFixtures(dir, "valid-simple.workflow.yaml", "invalid-orphan.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
-
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("OK");
-    expect(stderr).toContain("FAIL");
-  });
-
-  it("produces JSON output when --json is set", () => {
-    const dir = tmpDir();
-    copyFixtures(dir, "valid-simple.workflow.yaml");
-    setCli({ json: true });
-
     expect(() => validate(dir)).toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
-
-    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(stdout);
+    const result = stdoutJson() as { valid: boolean; graphs: Array<{ id: string }> };
     expect(result.valid).toBe(true);
-    expect(result.graphs).toHaveLength(1);
-    expect(result.graphs[0].id).toBe("valid-simple");
+    expect(result.graphs).toHaveLength(2);
   });
 
-  it("JSON output includes errors for invalid graphs", () => {
-    const dir = tmpDir();
-    copyFixtures(dir, "invalid-orphan.workflow.yaml");
-    setCli({ json: true });
-
-    expect(() => validate(dir)).toThrow("process.exit");
-    expect(exitSpy).toHaveBeenCalledWith(3);
-
-    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(stdout);
-    expect(result.valid).toBe(false);
-    expect(result.errors.length).toBeGreaterThan(0);
-  });
-
-  it("human output includes summary line", () => {
-    const dir = tmpDir();
-    copyFixtures(dir, "valid-simple.workflow.yaml", "valid-branching.workflow.yaml");
-    validate(dir);
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("Validated 2 graph(s), 0 error(s)");
-  });
-
-  it("JSON output for nonexistent directory", () => {
-    setCli({ json: true });
+  it("exits with VALIDATION (3) for nonexistent directory", () => {
     expect(() => validate("/nonexistent/path")).toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
-    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(stdout);
+    const result = stdoutJson() as { valid: boolean; errors: Array<{ message: string }> };
     expect(result.valid).toBe(false);
     expect(result.errors[0].message).toContain("does not exist");
   });
 
-  it("JSON output for empty directory", () => {
+  it("exits with VALIDATION (3) for empty directory", () => {
     const dir = tmpDir();
-    setCli({ json: true });
     expect(() => validate(dir)).toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
-    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(stdout);
-    expect(result.valid).toBe(false);
+    const result = stdoutJson() as { valid: boolean; errors: Array<{ message: string }> };
     expect(result.errors[0].message).toContain("No *.workflow.yaml");
   });
 
-  it("validates cross-graph subgraph references", () => {
+  it("exits with VALIDATION (3) for invalid graph", () => {
+    const dir = tmpDir();
+    copyFixtures(dir, "invalid-orphan.workflow.yaml");
+    expect(() => validate(dir)).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(3);
+    const result = stdoutJson() as { valid: boolean; errors: unknown[] };
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("reports per-file errors in the JSON response", () => {
+    const dir = tmpDir();
+    copyFixtures(dir, "valid-simple.workflow.yaml", "invalid-orphan.workflow.yaml");
+    expect(() => validate(dir)).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(3);
+    const result = stdoutJson() as {
+      valid: boolean;
+      graphs: Array<{ id: string }>;
+      errors: Array<{ file: string; message: string }>;
+    };
+    expect(result.valid).toBe(false);
+    // Valid graph still loaded
+    expect(result.graphs.some((g) => g.id === "valid-simple")).toBe(true);
+    // Invalid graph surfaced as an error
+    expect(result.errors.some((e) => e.file.includes("invalid-orphan"))).toBe(true);
+  });
+
+  it("validates cross-graph subgraph references (success path)", () => {
     const dir = tmpDir();
     copyFixtures(dir, "parent-with-subgraph.workflow.yaml", "child-review.workflow.yaml");
-    validate(dir);
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(() => validate(dir)).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it("fails on broken cross-graph subgraph reference", () => {
     const dir = tmpDir();
-    // Load parent without child — subgraph ref to child-review will dangle
     copyFixtures(dir, "parent-with-subgraph.workflow.yaml");
     expect(() => validate(dir)).toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
@@ -147,8 +111,8 @@ describe("CLI validate", () => {
   it("accepts subgraph references to sealed memory:* workflows", () => {
     const dir = tmpDir();
     copyFixtures(dir, "parent-with-sealed-subgraph.workflow.yaml");
-    validate(dir);
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(() => validate(dir)).toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it("treats directory with non-graph files as empty", () => {
@@ -159,25 +123,14 @@ describe("CLI validate", () => {
     expect(exitSpy).toHaveBeenCalledWith(3);
   });
 
-  it("--quiet suppresses info output", () => {
-    const dir = tmpDir();
-    copyFixtures(dir, "valid-simple.workflow.yaml");
-    setCli({ quiet: true });
-    validate(dir);
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toBe("");
-  });
-
   it("JSON output includes graph metadata fields", () => {
     const dir = tmpDir();
     copyFixtures(dir, "valid-simple.workflow.yaml");
-    setCli({ json: true });
-
     expect(() => validate(dir)).toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
-
-    const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(stdout);
+    const result = stdoutJson() as {
+      graphs: Array<{ id: string; name: string; version: string; nodeCount: number }>;
+    };
     const graph = result.graphs[0];
     expect(graph.name).toBe("Simple Workflow");
     expect(graph.version).toBe("1.0.0");
@@ -215,8 +168,8 @@ nodes:
       const correctHash = hashContent(docContent);
       writeGraphWithSources(dir, correctHash);
 
-      validate(dir, { checkSources: true, basePath: dir });
-      expect(exitSpy).not.toHaveBeenCalled();
+      expect(() => validate(dir, { checkSources: true, basePath: dir })).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(0);
     });
 
     it("detects drift when source hash is wrong", () => {
@@ -226,8 +179,8 @@ nodes:
 
       expect(() => validate(dir, { checkSources: true, basePath: dir })).toThrow("process.exit");
       expect(exitSpy).toHaveBeenCalledWith(3);
-      const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-      expect(stderr).toContain("DRIFT");
+      const result = stdoutJson() as { sourceDrift: unknown[] };
+      expect(result.sourceDrift.length).toBeGreaterThan(0);
     });
 
     it("--fix updates drifted hashes in-place", () => {
@@ -237,43 +190,43 @@ nodes:
       const wrongHash = "0000000000000000";
       writeGraphWithSources(dir, wrongHash);
 
-      validate(dir, { checkSources: true, fix: true, basePath: dir });
+      expect(() => validate(dir, { checkSources: true, fix: true, basePath: dir })).toThrow(
+        "process.exit",
+      );
+      expect(exitSpy).toHaveBeenCalledWith(0);
 
-      // File should have been updated
       const updatedContent = fs.readFileSync(path.join(dir, "source-test.workflow.yaml"), "utf-8");
       const correctHash = hashContent(docContent);
       expect(updatedContent).toContain(correctHash);
       expect(updatedContent).not.toContain(wrongHash);
 
-      const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-      expect(stderr).toContain("FIXED");
+      const result = stdoutJson() as { fixed?: number };
+      expect(result.fixed).toBeGreaterThan(0);
     });
 
     it("--fix skips FILE_NOT_FOUND sources", () => {
       const dir = tmpDir();
-      // No doc.md file exists
       writeGraphWithSources(dir, "0000000000000000");
 
       expect(() => validate(dir, { checkSources: true, fix: true, basePath: dir })).toThrow(
         "process.exit",
       );
-      // Should still report drift since it couldn't fix
-      const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-      expect(stderr).toContain("DRIFT");
+      expect(exitSpy).toHaveBeenCalledWith(3);
+      const result = stdoutJson() as { sourceDrift: unknown[] };
+      expect(result.sourceDrift.length).toBeGreaterThan(0);
     });
 
-    it("reports drift in JSON mode", () => {
+    it("reports drift in JSON output", () => {
       const dir = tmpDir();
       fs.writeFileSync(path.join(dir, "doc.md"), "# Doc\n");
       writeGraphWithSources(dir, "0000000000000000");
-      setCli({ json: true });
 
       expect(() => validate(dir, { checkSources: true, basePath: dir })).toThrow("process.exit");
-      const stdout = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-      const result = JSON.parse(stdout);
+      const result = stdoutJson() as {
+        valid: boolean;
+        sourceDrift: Array<{ drifted: Array<{ expected: string; actual: string }> }>;
+      };
       expect(result.valid).toBe(false);
-      expect(result.sourceDrift).toBeDefined();
-      expect(result.sourceDrift.length).toBeGreaterThan(0);
       expect(result.sourceDrift[0].drifted[0].expected).toBe("0000000000000000");
       expect(result.sourceDrift[0].drifted[0].actual).toBeTruthy();
     });

--- a/test/cli-visualize.test.ts
+++ b/test/cli-visualize.test.ts
@@ -1,15 +1,8 @@
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setCli } from "../src/cli/output.js";
 import { visualize } from "../src/cli/visualize.js";
-
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  return { ...actual, execFileSync: vi.fn() };
-});
 
 const FIXTURES_DIR = path.resolve(import.meta.dirname, "fixtures");
 
@@ -17,9 +10,12 @@ function fixturePath(name: string): string {
   return path.join(FIXTURES_DIR, name);
 }
 
+// CLI visualize is JSON-only per docs/decisions.md § CLI-primary. The
+// response shape is { graphId, format, [format]: <diagram> } or
+// { graphId, format, written } when --output is passed.
+
 describe("CLI visualize", () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
-  let stderrSpy: ReturnType<typeof vi.spyOn>;
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
   const createdTmpDirs: string[] = [];
 
@@ -29,13 +25,17 @@ describe("CLI visualize", () => {
     return dir;
   }
 
+  function stdoutJson(): unknown {
+    const out = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+    return JSON.parse(out);
+  }
+
   beforeEach(() => {
     exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
       throw new Error("process.exit");
     }) as never);
-    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    setCli({ json: false, quiet: false, verbose: false, noColor: false });
   });
 
   afterEach(() => {
@@ -46,42 +46,42 @@ describe("CLI visualize", () => {
     }
   });
 
-  it("outputs Mermaid diagram to stdout", () => {
+  it("emits JSON with Mermaid diagram", () => {
     visualize(fixturePath("valid-simple.workflow.yaml"), { format: "mermaid" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    expect(output).toContain("graph TD");
-    expect(output).toContain("start");
-    expect(output).toContain("done");
+    const result = stdoutJson() as { graphId: string; format: string; mermaid: string };
+    expect(result.graphId).toBe("valid-simple");
+    expect(result.format).toBe("mermaid");
+    expect(result.mermaid).toContain("graph TD");
+    expect(result.mermaid).toContain("start");
+    expect(result.mermaid).toContain("done");
   });
 
-  it("outputs DOT diagram to stdout", () => {
+  it("emits JSON with DOT diagram", () => {
     visualize(fixturePath("valid-simple.workflow.yaml"), { format: "dot" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    expect(output).toContain("digraph");
-    expect(output).toContain("rankdir=TD");
-    expect(output).toContain("->");
+    const result = stdoutJson() as { graphId: string; format: string; dot: string };
+    expect(result.format).toBe("dot");
+    expect(result.dot).toContain("digraph");
+    expect(result.dot).toContain("rankdir=TD");
+    expect(result.dot).toContain("->");
   });
 
   it("Mermaid uses correct node shapes", () => {
     visualize(fixturePath("valid-branching.workflow.yaml"), { format: "mermaid" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    // decision nodes get diamond braces
-    expect(output).toMatch(/choose-path\{choose-path\}/);
-    // terminal nodes get double parens
-    expect(output).toMatch(/done\(\(done\)\)/);
-    // action nodes get square brackets
-    expect(output).toMatch(/left-work\[left-work\]/);
+    const result = stdoutJson() as { mermaid: string };
+    expect(result.mermaid).toMatch(/choose-path\{choose-path\}/);
+    expect(result.mermaid).toMatch(/done\(\(done\)\)/);
+    expect(result.mermaid).toMatch(/left-work\[left-work\]/);
   });
 
   it("DOT uses correct node shapes", () => {
     visualize(fixturePath("valid-branching.workflow.yaml"), { format: "dot" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    expect(output).toContain("shape=diamond");
-    expect(output).toContain("shape=doublecircle");
-    expect(output).toContain("shape=box");
+    const result = stdoutJson() as { dot: string };
+    expect(result.dot).toContain("shape=diamond");
+    expect(result.dot).toContain("shape=doublecircle");
+    expect(result.dot).toContain("shape=box");
   });
 
-  it("writes to file with --output", () => {
+  it("writes diagram to file with --output, JSON response includes written path", () => {
     const outFile = path.join(makeTmpDir(), "out.mmd");
     visualize(fixturePath("valid-simple.workflow.yaml"), {
       format: "mermaid",
@@ -90,72 +90,56 @@ describe("CLI visualize", () => {
     expect(fs.existsSync(outFile)).toBe(true);
     const content = fs.readFileSync(outFile, "utf-8");
     expect(content).toContain("graph TD");
+    const result = stdoutJson() as { written: string; format: string };
+    expect(result.written).toBe(outFile);
+    expect(result.format).toBe("mermaid");
   });
 
-  it("exits with GRAPH_ERROR for nonexistent file", () => {
+  it("exits with NOT_FOUND (4) for nonexistent file", () => {
     expect(() => visualize("/nonexistent/file.workflow.yaml", { format: "mermaid" })).toThrow(
       "process.exit",
     );
-    expect(exitSpy).toHaveBeenCalledWith(3);
+    expect(exitSpy).toHaveBeenCalledWith(4);
   });
 
-  it("exits with INVALID_USAGE for wrong extension", () => {
+  it("exits with INVALID_INPUT (5) for wrong extension", () => {
     const tmpFile = path.join(makeTmpDir(), "bad.yaml");
     fs.writeFileSync(tmpFile, "id: test\n");
     expect(() => visualize(tmpFile, { format: "mermaid" })).toThrow("process.exit");
-    expect(exitSpy).toHaveBeenCalledWith(2);
-  });
-
-  it("produces JSON output when --json is set", () => {
-    setCli({ json: true });
-    visualize(fixturePath("valid-simple.workflow.yaml"), { format: "mermaid" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(output);
-    expect(result.graphId).toBe("valid-simple");
-    expect(result.mermaid).toContain("graph TD");
-  });
-
-  it("JSON output for DOT includes dot key", () => {
-    setCli({ json: true });
-    visualize(fixturePath("valid-simple.workflow.yaml"), { format: "dot" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    const result = JSON.parse(output);
-    expect(result.dot).toContain("digraph");
+    expect(exitSpy).toHaveBeenCalledWith(5);
   });
 
   it("Mermaid includes edge labels", () => {
     visualize(fixturePath("valid-simple.workflow.yaml"), { format: "mermaid" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    expect(output).toMatch(/-->\|.+\|/);
+    const result = stdoutJson() as { mermaid: string };
+    expect(result.mermaid).toMatch(/-->\|.+\|/);
   });
 
   it("DOT includes edge labels", () => {
     visualize(fixturePath("valid-simple.workflow.yaml"), { format: "dot" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    expect(output).toMatch(/label="/);
+    const result = stdoutJson() as { dot: string };
+    expect(result.dot).toMatch(/label="/);
   });
 
   it("Mermaid renders wait nodes with stadium shape", () => {
     visualize(fixturePath("valid-wait-simple.workflow.yaml"), { format: "mermaid" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    // wait nodes use ([...]) stadium shape
-    expect(output).toMatch(/wait-approval\(\[wait-approval\]\)/);
+    const result = stdoutJson() as { mermaid: string };
+    expect(result.mermaid).toMatch(/wait-approval\(\[wait-approval\]\)/);
   });
 
   it("DOT renders wait nodes with dashed style", () => {
     visualize(fixturePath("valid-wait-simple.workflow.yaml"), { format: "dot" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    expect(output).toContain('style="dashed"');
+    const result = stdoutJson() as { dot: string };
+    expect(result.dot).toContain('style="dashed"');
   });
 
   it("DOT renders gate nodes with bold style", () => {
     visualize(fixturePath("valid-branching.workflow.yaml"), { format: "dot" });
-    const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
-    // quality-check is a gate node — should have style="bold"
-    expect(output).toContain('style="bold"');
+    const result = stdoutJson() as { dot: string };
+    expect(result.dot).toContain('style="bold"');
   });
 
-  it("exits with GRAPH_ERROR for valid extension but invalid content", () => {
+  it("exits with VALIDATION (3) for valid extension but invalid content", () => {
     const tmpFile = path.join(makeTmpDir(), "broken.workflow.yaml");
     fs.writeFileSync(tmpFile, "this is not valid graph yaml at all");
     expect(() => visualize(tmpFile, { format: "mermaid" })).toThrow("process.exit");
@@ -171,56 +155,5 @@ describe("CLI visualize", () => {
     expect(fs.existsSync(outFile)).toBe(true);
     const content = fs.readFileSync(outFile, "utf-8");
     expect(content).toContain("digraph");
-  });
-
-  it("--open generates HTML file with mermaid content", () => {
-    vi.mocked(execFileSync).mockReturnValue(Buffer.from(""));
-
-    visualize(fixturePath("valid-simple.workflow.yaml"), {
-      format: "mermaid",
-      open: true,
-    });
-
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("Opened in browser:");
-
-    // Verify the HTML file was written
-    const htmlPathMatch = stderr.match(/Opened in browser: (.+)/);
-    expect(htmlPathMatch).not.toBeNull();
-    const htmlPath = htmlPathMatch![1].trim();
-    const html = fs.readFileSync(htmlPath, "utf-8");
-    expect(html).toContain("<!DOCTYPE html>");
-    expect(html).toContain("mermaid");
-    expect(html).toContain("graph TD");
-  });
-
-  it("--open with DOT format converts to mermaid for HTML", () => {
-    vi.mocked(execFileSync).mockReturnValue(Buffer.from(""));
-
-    visualize(fixturePath("valid-simple.workflow.yaml"), {
-      format: "dot",
-      open: true,
-    });
-
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    const htmlPathMatch = stderr.match(/Opened in browser: (.+)/);
-    expect(htmlPathMatch).not.toBeNull();
-    const html = fs.readFileSync(htmlPathMatch![1].trim(), "utf-8");
-    // Even though format is DOT, HTML should contain mermaid
-    expect(html).toContain("graph TD");
-  });
-
-  it("--open handles browser open failure gracefully", () => {
-    vi.mocked(execFileSync).mockImplementation(() => {
-      throw new Error("no browser");
-    });
-
-    visualize(fixturePath("valid-simple.workflow.yaml"), {
-      format: "mermaid",
-      open: true,
-    });
-
-    const stderr = stderrSpy.mock.calls.map((c) => c[0]).join("");
-    expect(stderr).toContain("Could not open browser automatically");
   });
 });

--- a/test/context-caps.test.ts
+++ b/test/context-caps.test.ts
@@ -186,30 +186,33 @@ describe("GraphEngine cap enforcement", () => {
   });
 });
 
-describe("MCP error response surfaces EngineError code", () => {
-  it("includes structured code alongside the error message", () => {
+describe("MCP error response uses canonical { error: { code, message } } shape", () => {
+  // Canonical error shape is shared with the CLI surface — see
+  // src/cli/output.ts:outputError. Tests here lock the MCP side of that
+  // contract so the two surfaces can't drift.
+  it("wraps EngineError in { error: { code, message } }", () => {
     const err = new EngineError('Context value "x" is too big.', "CONTEXT_VALUE_TOO_LARGE");
     const resp = handleError(err);
     expect(resp.isError).toBe(true);
     const payload = JSON.parse(resp.content[0].text);
     expect(payload).toEqual({
-      error: 'Context value "x" is too big.',
-      code: "CONTEXT_VALUE_TOO_LARGE",
+      error: { code: "CONTEXT_VALUE_TOO_LARGE", message: 'Context value "x" is too big.' },
     });
   });
 
-  it("surfaces CONTEXT_TOTAL_TOO_LARGE code the same way", () => {
+  it("uses the same shape for CONTEXT_TOTAL_TOO_LARGE", () => {
     const err = new EngineError("Total too large.", "CONTEXT_TOTAL_TOO_LARGE");
     const resp = handleError(err);
     const payload = JSON.parse(resp.content[0].text);
-    expect(payload.code).toBe("CONTEXT_TOTAL_TOO_LARGE");
+    expect(payload.error.code).toBe("CONTEXT_TOTAL_TOO_LARGE");
+    expect(payload.error.message).toBe("Total too large.");
   });
 
-  it("non-EngineError throws still surface as a plain error (no code field)", () => {
+  it("non-EngineError throws become { error: { code: 'INTERNAL', message } }", () => {
     const resp = handleError(new Error("something unrelated"));
     const payload = JSON.parse(resp.content[0].text);
-    expect(payload.error).toContain("Internal error");
-    expect(payload.code).toBeUndefined();
+    expect(payload.error.code).toBe("INTERNAL");
+    expect(payload.error.message).toContain("Internal error");
   });
 });
 


### PR DESCRIPTION
Part of #99 (Phase 1 — CLI enabling work for the skill).

## Framing

Every CLI verb — runtime (`status`, `start`, `advance`, `context set`, `meta set`, `inspect`, `reset`, `memory *`) and authoring (`init`, `validate`, `visualize`, `config`, `sources *`, `guide`, `distill`) — is agent-driven per `docs/decisions.md` § "CLI is the execution surface for agents". The dual-mode (`--json` vs human-readable) branching is dead weight: no human is driving this API. This PR strips it.

## Exit codes

| Code | Meaning | Example |
|---|---|---|
| 0 | success | advance succeeded |
| 1 | internal | unexpected throw, hook script failed |
| 2 | blocked | in-band AdvanceErrorResult (edge condition false, validation failed, wait not ready) |
| 3 | validation | graph structural validation failure |
| 4 | not found | TRAVERSAL_NOT_FOUND / GRAPH_NOT_FOUND / EDGE_NOT_FOUND / NO_TRAVERSAL / TEMPLATE_NOT_FOUND |
| 5 | invalid input | STRICT_CONTEXT_VIOLATION / CONTEXT_VALUE_TOO_LARGE / REQUIRED_META_MISSING / CONFIRM_REQUIRED / UNKNOWN_CONFIG_KEY / missing --confirm |

`mapEngineErrorToExit(code)` in `src/cli/output.ts` is the mapping table. Unknown EngineError codes fall back to INTERNAL so a novel error never masquerades as caller-fixable.

## Canonical error shape

Both CLI stdout and MCP tool-response payloads now use the same shape:

```json
{ "isError": true, "error": { "code": "CONTEXT_VALUE_TOO_LARGE", "message": "..." } }
```

Prior to this PR, MCP emitted a flat `{ error, code }` while CLI emitted nested `{ error: { code, message } }`. A skill consuming either surface sees one contract.

## What changed

**Source**:
- `src/cli/output.ts` — new exit codes, `mapEngineErrorToExit`, `outputError`, `handleRuntimeError` (shared try/catch tail), and structured `fatal(msg, exitCode, code)`. `CliState` drops dead `json` and `noColor` fields.
- `src/cli/traversals.ts`, `src/cli/memory.ts`, `src/cli/stateless.ts` — runtime handlers always `outputJson` on success and route errors through `handleRuntimeError`. In-band advance errors use `EXIT.BLOCKED`.
- `src/cli/config.ts`, `src/cli/validate.ts`, `src/cli/visualize.ts`, `src/cli/init.ts` — authoring handlers flipped to JSON-only. `visualize --open` removed; diagram ships inline or via `--output`. `init`'s manual-client path embeds the MCP snippet in the JSON response rather than printing it separately.
- `src/cli/program.ts` — `--json` / `--no-color` flags deleted; `fatal()` call sites updated to semantic exit codes + error codes.
- `src/mcp-helpers.ts` — MCP `handleError()` migrated to the canonical `{ error: { code, message } }` shape.

**Tests**:
- `cli-traversals`, `cli-config`, `cli-validate`, `cli-visualize`, `cli-init`, `cli-index` rewritten / updated to assert stdout JSON + specific exit codes / error codes.
- `context-caps` MCP shape tests updated for the new nested shape.
- `setCli()` calls drop the removed `json` / `noColor` fields.
- 772/772 pass.

## Review passes

Three review agents (reuse, quality, efficiency) were run after the first commit; their findings were folded into the follow-up commit:

- MCP / CLI error-shape drift → aligned to the canonical nested shape
- `handleError` duplicated across three handler files → consolidated to `handleRuntimeError` in `output.ts`
- Dead `CliState.json`, `CliState.noColor`, `--json`, `--no-color` → removed
- Stale `EXIT.GENERAL_ERROR` / `EXIT.INVALID_USAGE` in `program.ts` and `init.ts` fatal calls → switched to semantic names + passed the missing `code` param
- No efficiency issues flagged

Deferred: canonical error-code constant table (substantial refactor, separate PR).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 772/772 pass
- [x] `npx biome check src/ test/` — no new violations (1 pre-existing warning on `prune.ts`)
- [x] Smoke-tested `freelance status`, `guide`, `validate`, `advance` against actual binary — JSON out, exit codes correct

## Follow-up

- Phase 2 — add `skills/freelance/SKILL.md` to the plugin distribution and wire the skill body against the CLI.
- Open question — the existing MCP server / tool handlers in `src/server.ts` and `src/tools/*` are no longer a first-class surface under the committed architecture. Their fate (deprecation, removal, or narrower niche) is a separate follow-up to scope.
- Canonical error-code table (Agent 2 finding #5) — would improve cohesion but is substantial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
