### PR TITLE
feat(skills): ship single driving skill; freelance init installs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Single driving skill + `freelance init` wires it up.** Ships
+  `plugins/freelance/skills/freelance/SKILL.md` with the plugin and
+  `templates/skills/freelance/SKILL.md` for CLI users. The skill teaches
+  the invariant protocol for driving any Freelance workflow via the
+  `freelance` CLI — discover, start, loop, recover, exit — and branches
+  on the semantic exit codes shipped in the previous CHANGELOG entry.
+  `freelance init --client claude-code` now copies the skill into
+  `.claude/skills/freelance/SKILL.md` (project scope) or
+  `~/.claude/skills/freelance/SKILL.md` (user scope), so agents can
+  drive workflows without per-turn MCP tool-definition weight. Other
+  clients (Cursor / Windsurf / Cline) skip skill installation — they
+  don't consume Claude Agent Skills. See issue #115.
 - **Byte caps on context writes.** Every write to session context —
   `freelance_context_set`, `contextUpdates` on `freelance_advance`,
   `initialContext` on `freelance_start`, and onEnter hook return

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ cd /path/to/your/project
 freelance init
 ```
 
+## Driving workflows via skill + CLI
+
+For Claude Code, Freelance ships a single [Claude Agent Skill](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) that teaches the agent how to drive any workflow through the `freelance` CLI. The skill activates from its description match — when the user mentions a workflow to run, describes a task matching a loaded workflow, or wants to continue an in-flight traversal.
+
+`freelance init --client claude-code` installs `SKILL.md` at `.claude/skills/freelance/` (project scope) or `~/.claude/skills/freelance/` (user scope) alongside scaffolding the workflows directory and MCP config. The plugin install path (`/plugin install freelance@freelance-plugins`) ships the same skill.
+
+The agent drives workflows through shell-out calls — `freelance status`, `freelance start <graphId>`, `freelance advance <edge>`, `freelance context set k=v`, `freelance inspect` — and branches on semantic exit codes (0 success, 1 internal, 2 blocked, 3 validation, 4 not found, 5 invalid input). Every runtime verb emits a structured JSON response on stdout; breadcrumbs go to stderr. See [`plugins/freelance/skills/freelance/SKILL.md`](plugins/freelance/skills/freelance/SKILL.md) for the driving protocol.
+
 ## Workflows
 
 Workflows are directed graphs defined in YAML. The agent calls MCP tools to traverse them — `freelance_start` to begin, `freelance_advance` to move between nodes. Gate nodes block advancement until conditions are met. State lives server-side, so it survives context compaction.

--- a/plugins/freelance/skills/freelance/SKILL.md
+++ b/plugins/freelance/skills/freelance/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: Freelance
+description: Drive a Freelance workflow — graph-based gated traversals for structured multi-step work. Activate when the user names a workflow to run, describes a task matching a loaded workflow, asks to compile or recall knowledge into Freelance memory, or wants to continue an in-flight traversal.
+allowed-tools: Bash
+version: 1.0.0
+---
+
+# Driving Freelance workflows
+
+Freelance is graph-based workflow enforcement for AI agents. The **workflow graph** carries the domain knowledge (what to do at each step, when to gate, which edges to take). This skill carries the **invariant protocol** for driving any workflow via the `freelance` CLI.
+
+**Key idea:** the workflow is the teacher. Every `advance` response returns the new node's full teaching surface — `instructions`, `suggestedTools`, valid edges with descriptions, sources. Read the response, follow the instructions, pick the edge, advance. You don't need prior knowledge of any specific workflow.
+
+## Discover loaded workflows
+
+```bash
+freelance status
+```
+
+Returns `{ graphs: [...], activeTraversals: [...] }`. Each graph has `id`, `name`, `description`, `version`. Active traversals carry `traversalId`, `graphId`, `currentNode`, `meta`.
+
+## Start a traversal
+
+```bash
+freelance start <graphId> \
+  [--context '<json object>'] \
+  [--meta key=value [--meta key=value]...]
+```
+
+Response shape:
+
+```json
+{
+  "traversalId": "tr_xxxxx",
+  "status": "started",
+  "currentNode": "<node id>",
+  "node": { "instructions": "...", "suggestedTools": [...], "sources": [...] },
+  "validTransitions": [
+    { "label": "...", "target": "...", "condition": "...", "conditionMet": true, "description": "..." }
+  ],
+  "context": { ... },
+  "meta": { ... }
+}
+```
+
+Record the `traversalId`. If the graph declares `requiredMeta`, start rejects calls missing those keys with exit code 5 — pass them via `--meta`.
+
+## The driving loop
+
+Every `advance`, `context set`, and `inspect` response has the same shape as `start` above. The loop:
+
+1. **Read `node.instructions`.** This is what the workflow wants you to do at this step.
+2. **Do the work.** Use whatever tools (`Read`, `Grep`, `Edit`, etc.) the instructions call for.
+3. **Record outcomes in context.** Values that gates or edge conditions will check:
+   ```bash
+   freelance context set testsPass=true coverage=0.92
+   ```
+   Values are JSON-coerced: `true`/`false` become booleans, numerics become numbers, anything else stays a string.
+4. **Pick an edge.** From `validTransitions`, find the one whose `conditionMet: true` matches your outcome. Consult `condition` and `description` to disambiguate.
+5. **Advance.**
+   ```bash
+   freelance advance <edge-label>
+   ```
+6. **Parse the new response.** Return to step 1 with the new `node.instructions`.
+
+Repeat until you reach a terminal node (`status: "complete"`).
+
+To preview the current node's edges without advancing, call `freelance advance` with no edge — the response returns `{ traversalId, validTransitions }` only.
+
+## Output conventions
+
+- **stdout** — every runtime verb emits a JSON object. Always parseable; shape is verb-specific.
+- **stderr** — breadcrumbs (memory enabled, graphs loaded). Ignore unless debugging.
+- **Exit codes** — branch on these before parsing stdout:
+  - `0` success
+  - `1` internal error — report to the user, don't retry
+  - `2` blocked — an edge condition, wait condition, validation, or return schema blocked the advance. Fix context (see `validTransitions[i].condition` and the error message), retry the same edge.
+  - `3` validation failed — graph structural validation (authoring-time, rare during a live traversal)
+  - `4` not found — traversal id, graph id, or edge doesn't exist. Usually means a stale id or a typo; don't retry.
+  - `5` invalid input — the call was malformed (bad JSON, missing `=` in key=value, unknown shell for completion). Fix the call, retry.
+
+## Error shape on stdout
+
+On failure, stdout carries `{ "isError": true, "error": { "code": "...", "message": "..." } }`. Common codes:
+
+- `EDGE_NOT_FOUND` — the edge label doesn't exist on the current node. Exit 4. Check `validTransitions`.
+- `NO_EDGES` — the current node is terminal. Exit 2.
+- `TRAVERSAL_NOT_FOUND` / `NO_TRAVERSAL` / `AMBIGUOUS_TRAVERSAL` — traversal id issue. Exit 4 or 5.
+- `STRICT_CONTEXT_VIOLATION` — tried to write a key the graph's context schema doesn't declare. Exit 5.
+- `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` — write exceeds the byte cap. Exit 5. Shrink the value or split it across calls.
+- `REQUIRED_META_MISSING` — `start` without required meta keys. Exit 5. Rerun with `--meta k=v`.
+- `HOOK_FAILED` / `HOOK_IMPORT_FAILED` / `HOOK_BAD_SHAPE` — an `onEnter` hook is broken. Exit 1. Surface to the user; don't loop.
+
+A **blocked advance** (exit 2) returns a normal response shape with `isError: true` and `status: "error"`, carrying `validTransitions` so you can see what's still possible. Distinct from the structured-error shape above.
+
+## Recovery from context compaction
+
+If you lose track of where a traversal is:
+
+```bash
+freelance inspect [<traversalId>]                # current node + validTransitions
+freelance inspect [<traversalId>] --detail history   # step history + context writes
+```
+
+`--active` lists every active traversal with its current node. `--waits` filters that list to traversals sitting on a wait node.
+
+## Subgraphs
+
+Some workflows push subgraph calls. Responses include:
+
+- `subgraphPushed: { graphId, startNode, stackDepth }` when a subgraph begins.
+- `status: "subgraph_complete"` with `completedGraph` and `returnedContext` when a subgraph's terminal is reached and values flow back to the parent.
+- `stackDepth` shows nesting depth.
+
+You drive the same way regardless of depth — read the new node's instructions, advance.
+
+## Meta tags
+
+Meta is opaque key/value tagging for external lookup (PR urls, ticket ids, branch names). Freelance never interprets meta; it's purely for the agent or external tools to find a traversal by a known key later. Set at start or mid-traversal:
+
+```bash
+freelance meta set prUrl=https://... branch=feature/x
+```
+
+## Memory operations
+
+When a workflow involves memory (`memory:compile`, `memory:recall`, or user workflows that use memory), the node instructions will tell you to emit or query. Propositions come from a JSON file or stdin:
+
+```bash
+freelance memory emit /tmp/props.json
+freelance memory emit -     # read from stdin
+```
+
+Read operations (available any time):
+
+```bash
+freelance memory status
+freelance memory browse [--name X] [--kind Y] [--limit N] [--offset N]
+freelance memory search "<query>" [--limit N]
+freelance memory inspect <entityIdOrName>
+freelance memory related <entityIdOrName>
+freelance memory by-source <filePath>
+```
+
+Maintenance:
+
+- `freelance memory prune --keep <ref> [--keep <ref>]... [--dry-run | --yes]` — remove source rows whose content no longer matches either the working tree or any `--keep` ref. Always preview with `--dry-run` before running with `--yes`.
+- `freelance memory reset --confirm` — delete the db + WAL/SHM sidecars. Recovery path for schema-mismatch after an upgrade. Destroys all memory; the user should be aware.
+
+`memory emit` is gated server-side on "must be inside an active traversal". Skill activation implies one; nothing further to do.
+
+## Exit
+
+Reach a terminal node — the response has `status: "complete"` and carries a `traversalHistory` summary. Traversal is done; nothing to clean up.
+
+Avoid `freelance reset --confirm` except to abandon a traversal that's genuinely stuck. Reset destroys context; it's not the normal exit.
+
+## Authoring and refinement (meta-operations)
+
+If the user asks to *author* a workflow or *refine* one after running:
+
+```bash
+freelance guide [topic]              # authoring help; no topic for TOC
+freelance distill --mode distill     # prompt for distilling an ad-hoc task into a workflow
+freelance distill --mode refine      # prompt for improving a workflow after running it
+```
+
+These return Markdown prompts. Read them, follow the instructions, edit `.workflow.yaml` files accordingly.
+
+## The only thing to remember
+
+The workflow leads. Read each response's `node.instructions`, follow them, record outcomes, advance. This skill is just the protocol for talking to the engine; the engine's responses carry the domain knowledge JIT.

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -106,6 +106,18 @@ function getConfigPath(client: Client, scope: Scope): string {
   }
 }
 
+/**
+ * Resolve where to install the driving SKILL.md, or `null` when the
+ * client doesn't consume Claude Skills (cursor / windsurf / cline /
+ * manual). Claude Code reads from `.claude/skills/<name>/SKILL.md`
+ * (project) or `~/.claude/skills/<name>/SKILL.md` (user).
+ */
+function resolveSkillInstallPath(client: Client, scope: Scope): string | null {
+  if (client !== "claude-code") return null;
+  const base = scope === "user" ? homeDir() : process.cwd();
+  return path.join(base, ".claude", "skills", "freelance", "SKILL.md");
+}
+
 function writeClientConfig(client: Client, scope: Scope): string | null {
   if (client === "manual") return null;
 
@@ -351,6 +363,18 @@ export async function init(options: InitOptions): Promise<void> {
     }
   }
 
+  // 6. Driving skill — Claude Code only. Installs `SKILL.md` so the
+  // agent can drive workflows via the CLI without per-turn MCP weight.
+  // Cursor / Windsurf / Cline don't consume Claude Skills; skip for them.
+  const skillPath = resolveSkillInstallPath(client, scope);
+  if (skillPath) {
+    if (fs.existsSync(skillPath)) {
+      actions.push({ verb: "skip", target: displayPath(skillPath), detail: "already exists" });
+    } else {
+      actions.push({ verb: "create", target: displayPath(skillPath) });
+    }
+  }
+
   // --- Dry run ---
   if (dryRun) {
     outputJson({ dryRun: true, scope, client, starter, actions });
@@ -375,9 +399,10 @@ export async function init(options: InitOptions): Promise<void> {
     filesCreated.push(ignorePath);
   }
 
+  const templatesDir = getTemplatesDir();
+
   // 2. Copy starter graph
   if (starter !== "none") {
-    const templatesDir = getTemplatesDir();
     const templateFile = path.join(templatesDir, `${starter}.workflow.yaml`);
 
     if (!fs.existsSync(templateFile)) {
@@ -393,7 +418,6 @@ export async function init(options: InitOptions): Promise<void> {
 
   // 2b. Copy starter config.yml
   {
-    const templatesDir = getTemplatesDir();
     const configTemplate = path.join(templatesDir, "config.yml");
     const configDest = path.join(graphsDir, "config.yml");
     if (!fs.existsSync(configDest) && fs.existsSync(configTemplate)) {
@@ -428,6 +452,18 @@ export async function init(options: InitOptions): Promise<void> {
     if (hookResult) {
       filesCreated.push(hookResult.path);
     }
+  }
+
+  // 6. Install the driving skill. Skip if the target exists to preserve
+  // local edits on re-init.
+  if (skillPath && !fs.existsSync(skillPath)) {
+    const skillTemplate = path.join(templatesDir, "skills", "freelance", "SKILL.md");
+    if (!fs.existsSync(skillTemplate)) {
+      fatal(`Skill template not found: ${skillTemplate}`, EXIT.NOT_FOUND, "TEMPLATE_NOT_FOUND");
+    }
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.copyFileSync(skillTemplate, skillPath);
+    filesCreated.push(skillPath);
   }
 
   outputJson({

--- a/templates/skills/freelance/SKILL.md
+++ b/templates/skills/freelance/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: Freelance
+description: Drive a Freelance workflow — graph-based gated traversals for structured multi-step work. Activate when the user names a workflow to run, describes a task matching a loaded workflow, asks to compile or recall knowledge into Freelance memory, or wants to continue an in-flight traversal.
+allowed-tools: Bash
+version: 1.0.0
+---
+
+# Driving Freelance workflows
+
+Freelance is graph-based workflow enforcement for AI agents. The **workflow graph** carries the domain knowledge (what to do at each step, when to gate, which edges to take). This skill carries the **invariant protocol** for driving any workflow via the `freelance` CLI.
+
+**Key idea:** the workflow is the teacher. Every `advance` response returns the new node's full teaching surface — `instructions`, `suggestedTools`, valid edges with descriptions, sources. Read the response, follow the instructions, pick the edge, advance. You don't need prior knowledge of any specific workflow.
+
+## Discover loaded workflows
+
+```bash
+freelance status
+```
+
+Returns `{ graphs: [...], activeTraversals: [...] }`. Each graph has `id`, `name`, `description`, `version`. Active traversals carry `traversalId`, `graphId`, `currentNode`, `meta`.
+
+## Start a traversal
+
+```bash
+freelance start <graphId> \
+  [--context '<json object>'] \
+  [--meta key=value [--meta key=value]...]
+```
+
+Response shape:
+
+```json
+{
+  "traversalId": "tr_xxxxx",
+  "status": "started",
+  "currentNode": "<node id>",
+  "node": { "instructions": "...", "suggestedTools": [...], "sources": [...] },
+  "validTransitions": [
+    { "label": "...", "target": "...", "condition": "...", "conditionMet": true, "description": "..." }
+  ],
+  "context": { ... },
+  "meta": { ... }
+}
+```
+
+Record the `traversalId`. If the graph declares `requiredMeta`, start rejects calls missing those keys with exit code 5 — pass them via `--meta`.
+
+## The driving loop
+
+Every `advance`, `context set`, and `inspect` response has the same shape as `start` above. The loop:
+
+1. **Read `node.instructions`.** This is what the workflow wants you to do at this step.
+2. **Do the work.** Use whatever tools (`Read`, `Grep`, `Edit`, etc.) the instructions call for.
+3. **Record outcomes in context.** Values that gates or edge conditions will check:
+   ```bash
+   freelance context set testsPass=true coverage=0.92
+   ```
+   Values are JSON-coerced: `true`/`false` become booleans, numerics become numbers, anything else stays a string.
+4. **Pick an edge.** From `validTransitions`, find the one whose `conditionMet: true` matches your outcome. Consult `condition` and `description` to disambiguate.
+5. **Advance.**
+   ```bash
+   freelance advance <edge-label>
+   ```
+6. **Parse the new response.** Return to step 1 with the new `node.instructions`.
+
+Repeat until you reach a terminal node (`status: "complete"`).
+
+To preview the current node's edges without advancing, call `freelance advance` with no edge — the response returns `{ traversalId, validTransitions }` only.
+
+## Output conventions
+
+- **stdout** — every runtime verb emits a JSON object. Always parseable; shape is verb-specific.
+- **stderr** — breadcrumbs (memory enabled, graphs loaded). Ignore unless debugging.
+- **Exit codes** — branch on these before parsing stdout:
+  - `0` success
+  - `1` internal error — report to the user, don't retry
+  - `2` blocked — an edge condition, wait condition, validation, or return schema blocked the advance. Fix context (see `validTransitions[i].condition` and the error message), retry the same edge.
+  - `3` validation failed — graph structural validation (authoring-time, rare during a live traversal)
+  - `4` not found — traversal id, graph id, or edge doesn't exist. Usually means a stale id or a typo; don't retry.
+  - `5` invalid input — the call was malformed (bad JSON, missing `=` in key=value, unknown shell for completion). Fix the call, retry.
+
+## Error shape on stdout
+
+On failure, stdout carries `{ "isError": true, "error": { "code": "...", "message": "..." } }`. Common codes:
+
+- `EDGE_NOT_FOUND` — the edge label doesn't exist on the current node. Exit 4. Check `validTransitions`.
+- `NO_EDGES` — the current node is terminal. Exit 2.
+- `TRAVERSAL_NOT_FOUND` / `NO_TRAVERSAL` / `AMBIGUOUS_TRAVERSAL` — traversal id issue. Exit 4 or 5.
+- `STRICT_CONTEXT_VIOLATION` — tried to write a key the graph's context schema doesn't declare. Exit 5.
+- `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` — write exceeds the byte cap. Exit 5. Shrink the value or split it across calls.
+- `REQUIRED_META_MISSING` — `start` without required meta keys. Exit 5. Rerun with `--meta k=v`.
+- `HOOK_FAILED` / `HOOK_IMPORT_FAILED` / `HOOK_BAD_SHAPE` — an `onEnter` hook is broken. Exit 1. Surface to the user; don't loop.
+
+A **blocked advance** (exit 2) returns a normal response shape with `isError: true` and `status: "error"`, carrying `validTransitions` so you can see what's still possible. Distinct from the structured-error shape above.
+
+## Recovery from context compaction
+
+If you lose track of where a traversal is:
+
+```bash
+freelance inspect [<traversalId>]                # current node + validTransitions
+freelance inspect [<traversalId>] --detail history   # step history + context writes
+```
+
+`--active` lists every active traversal with its current node. `--waits` filters that list to traversals sitting on a wait node.
+
+## Subgraphs
+
+Some workflows push subgraph calls. Responses include:
+
+- `subgraphPushed: { graphId, startNode, stackDepth }` when a subgraph begins.
+- `status: "subgraph_complete"` with `completedGraph` and `returnedContext` when a subgraph's terminal is reached and values flow back to the parent.
+- `stackDepth` shows nesting depth.
+
+You drive the same way regardless of depth — read the new node's instructions, advance.
+
+## Meta tags
+
+Meta is opaque key/value tagging for external lookup (PR urls, ticket ids, branch names). Freelance never interprets meta; it's purely for the agent or external tools to find a traversal by a known key later. Set at start or mid-traversal:
+
+```bash
+freelance meta set prUrl=https://... branch=feature/x
+```
+
+## Memory operations
+
+When a workflow involves memory (`memory:compile`, `memory:recall`, or user workflows that use memory), the node instructions will tell you to emit or query. Propositions come from a JSON file or stdin:
+
+```bash
+freelance memory emit /tmp/props.json
+freelance memory emit -     # read from stdin
+```
+
+Read operations (available any time):
+
+```bash
+freelance memory status
+freelance memory browse [--name X] [--kind Y] [--limit N] [--offset N]
+freelance memory search "<query>" [--limit N]
+freelance memory inspect <entityIdOrName>
+freelance memory related <entityIdOrName>
+freelance memory by-source <filePath>
+```
+
+Maintenance:
+
+- `freelance memory prune --keep <ref> [--keep <ref>]... [--dry-run | --yes]` — remove source rows whose content no longer matches either the working tree or any `--keep` ref. Always preview with `--dry-run` before running with `--yes`.
+- `freelance memory reset --confirm` — delete the db + WAL/SHM sidecars. Recovery path for schema-mismatch after an upgrade. Destroys all memory; the user should be aware.
+
+`memory emit` is gated server-side on "must be inside an active traversal". Skill activation implies one; nothing further to do.
+
+## Exit
+
+Reach a terminal node — the response has `status: "complete"` and carries a `traversalHistory` summary. Traversal is done; nothing to clean up.
+
+Avoid `freelance reset --confirm` except to abandon a traversal that's genuinely stuck. Reset destroys context; it's not the normal exit.
+
+## Authoring and refinement (meta-operations)
+
+If the user asks to *author* a workflow or *refine* one after running:
+
+```bash
+freelance guide [topic]              # authoring help; no topic for TOC
+freelance distill --mode distill     # prompt for distilling an ad-hoc task into a workflow
+freelance distill --mode refine      # prompt for improving a workflow after running it
+```
+
+These return Markdown prompts. Read them, follow the instructions, edit `.workflow.yaml` files accordingly.
+
+## The only thing to remember
+
+The workflow leads. Read each response's `node.instructions`, follow them, record outcomes, advance. This skill is just the protocol for talking to the engine; the engine's responses carry the domain knowledge JIT.

--- a/test/cli-init.test.ts
+++ b/test/cli-init.test.ts
@@ -398,6 +398,44 @@ describe("CLI init", () => {
     expect(parsed.actions.some((a) => a.verb === "append" && a.target === "CLAUDE.md")).toBe(true);
   });
 
+  it("claude-code project scope installs driving skill at .claude/skills/freelance/SKILL.md", async () => {
+    await init(defaults());
+    const skillPath = path.join(workDir, ".claude", "skills", "freelance", "SKILL.md");
+    expect(fs.existsSync(skillPath)).toBe(true);
+    const content = fs.readFileSync(skillPath, "utf-8");
+    expect(content).toContain("name: Freelance");
+    expect(content).toContain("freelance advance");
+  });
+
+  it("claude-code user scope installs driving skill at ~/.claude/skills/freelance/SKILL.md", async () => {
+    const fakeHome = tmpDir();
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      await init(defaults({ scope: "user", client: "claude-code" }));
+      const skillPath = path.join(fakeHome, ".claude", "skills", "freelance", "SKILL.md");
+      expect(fs.existsSync(skillPath)).toBe(true);
+    } finally {
+      process.env.HOME = origHome;
+    }
+  });
+
+  it("non-claude-code clients skip skill installation", async () => {
+    await init(defaults({ client: "cursor" }));
+    expect(fs.existsSync(path.join(workDir, ".claude", "skills", "freelance", "SKILL.md"))).toBe(
+      false,
+    );
+  });
+
+  it("existing SKILL.md is preserved on re-init", async () => {
+    const skillDir = path.join(workDir, ".claude", "skills", "freelance");
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, "SKILL.md"), "# locally customized\n");
+    await init(defaults());
+    const content = fs.readFileSync(path.join(skillDir, "SKILL.md"), "utf-8");
+    expect(content).toBe("# locally customized\n");
+  });
+
   it("missing template file calls fatal", async () => {
     // Use a starter name that has no template file
     // We can't easily make "blank" template missing, but we can test by

--- a/test/plugin-manifest.test.ts
+++ b/test/plugin-manifest.test.ts
@@ -76,6 +76,26 @@ describe("plugin .mcp.json launcher shape", () => {
   });
 });
 
+describe("driving skill ships with the plugin and the npm template tree", () => {
+  const pluginSkill = path.join(repoRoot, "plugins/freelance/skills/freelance/SKILL.md");
+  const templateSkill = path.join(repoRoot, "templates/skills/freelance/SKILL.md");
+
+  it("exists in the plugin distribution", () => {
+    expect(fs.existsSync(pluginSkill), `missing: ${pluginSkill}`).toBe(true);
+  });
+
+  it("exists in templates/ (npm CLI init reads from here)", () => {
+    expect(fs.existsSync(templateSkill), `missing: ${templateSkill}`).toBe(true);
+  });
+
+  // Plugin users load SKILL.md from the plugin dir; CLI-init users
+  // copy from templates/. Content identity prevents the plugin crowd
+  // and the CLI crowd from drifting apart at release time.
+  it("plugin and template copies are identical", () => {
+    expect(fs.readFileSync(templateSkill, "utf-8")).toBe(fs.readFileSync(pluginSkill, "utf-8"));
+  });
+});
+
 describe("plugin version metadata stays in sync with package.json", () => {
   it("plugin.json version matches package.json", () => {
     expect(plugin.version).toBe(pkg.version);


### PR DESCRIPTION
Closes #115.

## Summary

- \`plugins/freelance/skills/freelance/SKILL.md\` — the driving skill shipped with the Claude Code plugin. Teaches the invariant protocol for driving *any* Freelance workflow via the \`freelance\` CLI (discover → start → loop → recover → exit), including memory verbs and error branching.
- \`templates/skills/freelance/SKILL.md\` — identical copy (enforced by a new byte-identity test in \`plugin-manifest.test.ts\`) that npm-CLI users pick up via \`freelance init\`.
- \`freelance init --client claude-code\` copies the skill into \`.claude/skills/freelance/SKILL.md\` (project scope) or \`~/.claude/skills/freelance/SKILL.md\` (user scope). Idempotent — skipped if the target exists, so re-running init never clobbers local edits.
- Non-Claude-Code clients (cursor, windsurf, cline, manual) skip skill installation.
- README adds a "Driving Freelance via skill + CLI" section. MCP-centric prose stays for now; #116 will remove it.

## Drift from the prototype

Prototype lived on \`origin/claude/review-freelance-token-costs-YiYsD\` (commits \`be23d8a\`, \`7b18912\`). Updated for post-#114 CLI:

- Dropped all \`--json\` flags (JSON is the default now).
- Dropped \`--detail full\` from inspect docs (post-#111/#112, \`full\` coerces to \`position\`).
- Added \`memory prune\` and \`memory reset\` to the memory verbs list.
- Tightened exit-code branching to the canonical 0/1/2/3/4/5 set.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` — 782/782 passing (4 new init tests + 3 new plugin-manifest tests)
- [x] \`freelance init --client claude-code --scope project --yes\` creates \`.claude/skills/freelance/SKILL.md\` in a fresh dir
- [x] Re-running \`freelance init\` preserves a locally-edited SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)