### PR TITLE
feat(hooks): eager-validate hook-script imports at validate time

### DIFF
--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { validateHookImports } from "../hook-resolution.js";
 import { findGraphFiles, loadSingleGraph, validateCrossGraphRefs } from "../loader.js";
 import { SEALED_GRAPH_IDS } from "../memory/sealed.js";
 import { extractSection } from "../section-resolver.js";
@@ -36,7 +37,7 @@ interface ValidateOptions {
   basePath?: string;
 }
 
-export function validate(graphsDir: string, options?: ValidateOptions): void {
+export async function validate(graphsDir: string, options?: ValidateOptions): Promise<void> {
   const resolvedDir = path.resolve(graphsDir);
 
   if (!fs.existsSync(resolvedDir)) {
@@ -67,8 +68,8 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
   for (const filePath of files) {
     const relFile = path.relative(resolvedDir, filePath);
     try {
-      const { id, definition, graph } = loadSingleGraph(filePath);
-      parsed.set(id, { definition, graph });
+      const { id, definition, graph, hookResolutions } = loadSingleGraph(filePath);
+      parsed.set(id, { definition, graph, hookResolutions });
       graphFilePaths.set(id, filePath);
       result.graphs.push({
         id,
@@ -92,6 +93,27 @@ export function validate(graphsDir: string, options?: ValidateOptions): void {
       const msg = err instanceof Error ? err.message : String(err);
       result.errors.push({ file: resolvedDir, message: msg });
       result.valid = false;
+    }
+  }
+
+  // Phase 2.5: eager hook-script import check. Catches syntax errors,
+  // missing relative deps, and non-function default exports at validate
+  // time instead of deep into a traversal. Only runs if schema + cross-
+  // graph checks passed — a graph that didn't parse has no resolutions
+  // to import anyway.
+  if (result.errors.length === 0) {
+    for (const [graphId, { hookResolutions }] of parsed) {
+      if (!hookResolutions) continue;
+      const hookErrors = await validateHookImports(hookResolutions);
+      if (hookErrors.length === 0) continue;
+      const relFile = path.relative(resolvedDir, graphFilePaths.get(graphId)!);
+      for (const hookErr of hookErrors) {
+        result.errors.push({
+          file: relFile,
+          message: `Node "${hookErr.nodeId}", onEnter[${hookErr.index}] "${hookErr.call}": ${hookErr.message}`,
+        });
+        result.valid = false;
+      }
     }
   }
 

--- a/src/engine/hooks.ts
+++ b/src/engine/hooks.ts
@@ -204,9 +204,13 @@ export class HookRunner {
    * on the same absolute path is a Module-map lookup, no re-parse and
    * no re-execute. We don't layer our own cache on top.
    *
-   * Import failure and bad-shape are both hard errors surfaced at the
-   * first invocation attempt, not at engine construction, so graphs
-   * with script hooks only fail when those nodes are actually reached.
+   * Runtime is the second line of defense: `freelance validate` runs
+   * `validateHookImports` (hook-resolution.ts) eagerly over every
+   * script so authors see syntax errors and bad-shape exports at
+   * validate time. Callers that skip validate (direct engine
+   * construction in tests, programmatic use) still hit the same import
+   * + typeof-default checks here on first invocation, surfacing the
+   * same error codes.
    */
   private async loadHookFn(resolved: ResolvedHook, nodeId: string): Promise<HookFn> {
     if (resolved.kind === "builtin") {

--- a/src/hook-resolution.ts
+++ b/src/hook-resolution.ts
@@ -16,6 +16,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { BUILTIN_HOOK_NAMES } from "./engine/builtin-hooks.js";
 import type { GraphDefinition } from "./schema/graph-schema.js";
 
@@ -24,6 +25,14 @@ export type ResolvedHook =
   | { readonly kind: "script"; readonly call: string; readonly absolutePath: string };
 
 export type HookResolutionMap = ReadonlyMap<string, readonly ResolvedHook[]>;
+
+export interface HookImportError {
+  readonly nodeId: string;
+  readonly index: number;
+  readonly call: string;
+  readonly absolutePath: string;
+  readonly message: string;
+}
 
 /**
  * Walk every node's `onEnter` list and resolve each hook reference.
@@ -155,4 +164,59 @@ function resolveOneHook(call: string, graphDir: string): ResolvedHook | string {
   }
 
   return { kind: "script", call, absolutePath };
+}
+
+/**
+ * Attempt to import every script hook in `resolutions` and verify it
+ * exposes a default-exported function. Does NOT invoke the hook — we're
+ * only catching module-level syntax errors, missing dependencies, and
+ * obviously-wrong exports. Runtime-only failures (throws inside the
+ * hook body, argument misuse) still surface on first invocation.
+ *
+ * Returns one entry per broken script. An empty array means every
+ * script loaded cleanly. Node's import cache is keyed by URL, so a
+ * subsequent runtime call won't re-parse or re-execute — this pass is
+ * a cheap pre-flight, not a duplicate load.
+ *
+ * Kept async + off the sync `loadSingleGraph` path so graph loading
+ * stays synchronous. Callers that want fail-fast authoring feedback
+ * (CLI `validate`) invoke this explicitly after load.
+ */
+export async function validateHookImports(
+  resolutions: HookResolutionMap,
+): Promise<HookImportError[]> {
+  const errors: HookImportError[] = [];
+  for (const [nodeId, nodeResolutions] of resolutions) {
+    for (let i = 0; i < nodeResolutions.length; i++) {
+      const resolved = nodeResolutions[i];
+      if (resolved.kind !== "script") continue;
+
+      let mod: Record<string, unknown>;
+      try {
+        mod = (await import(pathToFileURL(resolved.absolutePath).href)) as Record<string, unknown>;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        errors.push({
+          nodeId,
+          index: i,
+          call: resolved.call,
+          absolutePath: resolved.absolutePath,
+          message: `Failed to import hook script: ${message}`,
+        });
+        continue;
+      }
+
+      const fn = mod.default;
+      if (typeof fn !== "function") {
+        errors.push({
+          nodeId,
+          index: i,
+          call: resolved.call,
+          absolutePath: resolved.absolutePath,
+          message: `Hook script must export a default function (got ${typeof fn})`,
+        });
+      }
+    }
+  }
+  return errors;
 }

--- a/test/cli-validate.test.ts
+++ b/test/cli-validate.test.ts
@@ -41,46 +41,46 @@ describe("CLI validate", () => {
     vi.restoreAllMocks();
   });
 
-  it("succeeds with valid graph files (exit 0)", () => {
+  it("succeeds with valid graph files (exit 0)", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "valid-simple.workflow.yaml", "valid-branching.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
     const result = stdoutJson() as { valid: boolean; graphs: Array<{ id: string }> };
     expect(result.valid).toBe(true);
     expect(result.graphs).toHaveLength(2);
   });
 
-  it("exits with VALIDATION (3) for nonexistent directory", () => {
-    expect(() => validate("/nonexistent/path")).toThrow("process.exit");
+  it("exits with VALIDATION (3) for nonexistent directory", async () => {
+    await expect(validate("/nonexistent/path")).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
     const result = stdoutJson() as { valid: boolean; errors: Array<{ message: string }> };
     expect(result.valid).toBe(false);
     expect(result.errors[0].message).toContain("does not exist");
   });
 
-  it("exits with VALIDATION (3) for empty directory", () => {
+  it("exits with VALIDATION (3) for empty directory", async () => {
     const dir = tmpDir();
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
     const result = stdoutJson() as { valid: boolean; errors: Array<{ message: string }> };
     expect(result.errors[0].message).toContain("No *.workflow.yaml");
   });
 
-  it("exits with VALIDATION (3) for invalid graph", () => {
+  it("exits with VALIDATION (3) for invalid graph", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "invalid-orphan.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
     const result = stdoutJson() as { valid: boolean; errors: unknown[] };
     expect(result.valid).toBe(false);
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
-  it("reports per-file errors in the JSON response", () => {
+  it("reports per-file errors in the JSON response", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "valid-simple.workflow.yaml", "invalid-orphan.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
     const result = stdoutJson() as {
       valid: boolean;
@@ -94,39 +94,39 @@ describe("CLI validate", () => {
     expect(result.errors.some((e) => e.file.includes("invalid-orphan"))).toBe(true);
   });
 
-  it("validates cross-graph subgraph references (success path)", () => {
+  it("validates cross-graph subgraph references (success path)", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "parent-with-subgraph.workflow.yaml", "child-review.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("fails on broken cross-graph subgraph reference", () => {
+  it("fails on broken cross-graph subgraph reference", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "parent-with-subgraph.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
   });
 
-  it("accepts subgraph references to sealed memory:* workflows", () => {
+  it("accepts subgraph references to sealed memory:* workflows", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "parent-with-sealed-subgraph.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("treats directory with non-graph files as empty", () => {
+  it("treats directory with non-graph files as empty", async () => {
     const dir = tmpDir();
     fs.writeFileSync(path.join(dir, "readme.txt"), "not a graph");
     fs.writeFileSync(path.join(dir, "data.yaml"), "id: test");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(3);
   });
 
-  it("JSON output includes graph metadata fields", () => {
+  it("JSON output includes graph metadata fields", async () => {
     const dir = tmpDir();
     copyFixtures(dir, "valid-simple.workflow.yaml");
-    expect(() => validate(dir)).toThrow("process.exit");
+    await expect(validate(dir)).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
     const result = stdoutJson() as {
       graphs: Array<{ id: string; name: string; version: string; nodeCount: number }>;
@@ -161,36 +161,40 @@ nodes:
       fs.writeFileSync(path.join(dir, "source-test.workflow.yaml"), graphContent);
     }
 
-    it("passes when source hashes match", () => {
+    it("passes when source hashes match", async () => {
       const dir = tmpDir();
       const docContent = "# Doc\n\nContent here.\n";
       fs.writeFileSync(path.join(dir, "doc.md"), docContent);
       const correctHash = hashContent(docContent);
       writeGraphWithSources(dir, correctHash);
 
-      expect(() => validate(dir, { checkSources: true, basePath: dir })).toThrow("process.exit");
+      await expect(validate(dir, { checkSources: true, basePath: dir })).rejects.toThrow(
+        "process.exit",
+      );
       expect(exitSpy).toHaveBeenCalledWith(0);
     });
 
-    it("detects drift when source hash is wrong", () => {
+    it("detects drift when source hash is wrong", async () => {
       const dir = tmpDir();
       fs.writeFileSync(path.join(dir, "doc.md"), "# Doc\n");
       writeGraphWithSources(dir, "0000000000000000");
 
-      expect(() => validate(dir, { checkSources: true, basePath: dir })).toThrow("process.exit");
+      await expect(validate(dir, { checkSources: true, basePath: dir })).rejects.toThrow(
+        "process.exit",
+      );
       expect(exitSpy).toHaveBeenCalledWith(3);
       const result = stdoutJson() as { sourceDrift: unknown[] };
       expect(result.sourceDrift.length).toBeGreaterThan(0);
     });
 
-    it("--fix updates drifted hashes in-place", () => {
+    it("--fix updates drifted hashes in-place", async () => {
       const dir = tmpDir();
       const docContent = "# Doc\n\nFixed content.\n";
       fs.writeFileSync(path.join(dir, "doc.md"), docContent);
       const wrongHash = "0000000000000000";
       writeGraphWithSources(dir, wrongHash);
 
-      expect(() => validate(dir, { checkSources: true, fix: true, basePath: dir })).toThrow(
+      await expect(validate(dir, { checkSources: true, fix: true, basePath: dir })).rejects.toThrow(
         "process.exit",
       );
       expect(exitSpy).toHaveBeenCalledWith(0);
@@ -204,11 +208,11 @@ nodes:
       expect(result.fixed).toBeGreaterThan(0);
     });
 
-    it("--fix skips FILE_NOT_FOUND sources", () => {
+    it("--fix skips FILE_NOT_FOUND sources", async () => {
       const dir = tmpDir();
       writeGraphWithSources(dir, "0000000000000000");
 
-      expect(() => validate(dir, { checkSources: true, fix: true, basePath: dir })).toThrow(
+      await expect(validate(dir, { checkSources: true, fix: true, basePath: dir })).rejects.toThrow(
         "process.exit",
       );
       expect(exitSpy).toHaveBeenCalledWith(3);
@@ -216,12 +220,14 @@ nodes:
       expect(result.sourceDrift.length).toBeGreaterThan(0);
     });
 
-    it("reports drift in JSON output", () => {
+    it("reports drift in JSON output", async () => {
       const dir = tmpDir();
       fs.writeFileSync(path.join(dir, "doc.md"), "# Doc\n");
       writeGraphWithSources(dir, "0000000000000000");
 
-      expect(() => validate(dir, { checkSources: true, basePath: dir })).toThrow("process.exit");
+      await expect(validate(dir, { checkSources: true, basePath: dir })).rejects.toThrow(
+        "process.exit",
+      );
       const result = stdoutJson() as {
         valid: boolean;
         sourceDrift: Array<{ drifted: Array<{ expected: string; actual: string }> }>;
@@ -229,6 +235,99 @@ nodes:
       expect(result.valid).toBe(false);
       expect(result.sourceDrift[0].drifted[0].expected).toBe("0000000000000000");
       expect(result.sourceDrift[0].drifted[0].actual).toBeTruthy();
+    });
+  });
+
+  describe("hook-script import check", () => {
+    // File-existence of `./scripts/foo.js` is checked synchronously in
+    // `resolveGraphHooks` (loader path). The cases here exercise errors
+    // that can only be caught by actually importing the module — syntax
+    // errors, missing default export, non-function default. Without the
+    // eager check these would only surface at first hook invocation
+    // inside a live traversal.
+    function writeGraphWithHook(dir: string, scriptName: string): void {
+      const graphContent = `id: hook-validate
+version: "1.0.0"
+name: "Hook Validate"
+description: "Graph with a local hook script"
+startNode: start
+nodes:
+  start:
+    type: action
+    description: "Start"
+    onEnter:
+      - call: ./scripts/${scriptName}
+    edges:
+      - target: done
+        label: done
+  done:
+    type: terminal
+    description: "Done"
+`;
+      fs.writeFileSync(path.join(dir, "hook-validate.workflow.yaml"), graphContent);
+    }
+
+    it("passes with a syntactically-valid default-function-exporting script", async () => {
+      const dir = tmpDir();
+      fs.mkdirSync(path.join(dir, "scripts"));
+      fs.writeFileSync(
+        path.join(dir, "scripts", "ok.js"),
+        "export default async function () { return {}; }\n",
+      );
+      writeGraphWithHook(dir, "ok.js");
+
+      await expect(validate(dir)).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it("reports syntax errors in hook scripts", async () => {
+      const dir = tmpDir();
+      fs.mkdirSync(path.join(dir, "scripts"));
+      // Unterminated string literal
+      fs.writeFileSync(path.join(dir, "scripts", "broken.js"), 'export default "\n');
+      writeGraphWithHook(dir, "broken.js");
+
+      await expect(validate(dir)).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(3);
+      const result = stdoutJson() as {
+        valid: boolean;
+        errors: Array<{ file: string; message: string }>;
+      };
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.message.includes("Failed to import hook script"))).toBe(
+        true,
+      );
+    });
+
+    it("reports missing default export", async () => {
+      const dir = tmpDir();
+      fs.mkdirSync(path.join(dir, "scripts"));
+      fs.writeFileSync(
+        path.join(dir, "scripts", "nodefault.js"),
+        "export const notTheDefault = 1;\n",
+      );
+      writeGraphWithHook(dir, "nodefault.js");
+
+      await expect(validate(dir)).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(3);
+      const result = stdoutJson() as { errors: Array<{ message: string }> };
+      expect(result.errors.some((e) => e.message.includes("must export a default function"))).toBe(
+        true,
+      );
+    });
+
+    it("reports non-function default export", async () => {
+      const dir = tmpDir();
+      fs.mkdirSync(path.join(dir, "scripts"));
+      fs.writeFileSync(path.join(dir, "scripts", "notfn.js"), "export default 42;\n");
+      writeGraphWithHook(dir, "notfn.js");
+
+      await expect(validate(dir)).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(3);
+      const result = stdoutJson() as { errors: Array<{ message: string }> };
+      expect(result.errors.some((e) => e.message.includes("must export a default function"))).toBe(
+        true,
+      );
     });
   });
 });

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -6,7 +6,8 @@ import { BUILTIN_HOOKS } from "../src/engine/builtin-hooks.js";
 import type { HookFn } from "../src/engine/hooks.js";
 import { HookRunner, resolveHookArgs } from "../src/engine/hooks.js";
 import { GraphEngine } from "../src/engine/index.js";
-import { resolveGraphHooks } from "../src/hook-resolution.js";
+import type { HookResolutionMap } from "../src/hook-resolution.js";
+import { resolveGraphHooks, validateHookImports } from "../src/hook-resolution.js";
 import { loadGraphs, loadSingleGraph } from "../src/loader.js";
 import type { ValidatedGraph } from "../src/types.js";
 
@@ -304,5 +305,70 @@ describe("hook runner — end-to-end via engine", () => {
     const graphs = loadGraphs(tmpDir);
     const engine = new GraphEngine(graphs, { hookRunner: makeRunner() });
     await expect(engine.start("bad-return")).rejects.toThrow(/must return a plain object/);
+  });
+});
+
+describe("validateHookImports — load-time eager check", () => {
+  // resolveGraphHooks already stats the script path; the cases here
+  // only materialize when the file exists but fails to import or
+  // exports the wrong thing. Runtime's lazy check still covers the
+  // same surface, but authors want the failure at validate time.
+
+  function stageScript(contents: string): { resolutions: HookResolutionMap } {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hook-validate-test-"));
+    fs.mkdirSync(path.join(tmpDir, "scripts"));
+    const abs = path.join(tmpDir, "scripts", "hook.js");
+    fs.writeFileSync(abs, contents);
+    const resolutions: HookResolutionMap = new Map([
+      ["start", [{ kind: "script", call: "./scripts/hook.js", absolutePath: abs }]],
+    ]);
+    return { resolutions };
+  }
+
+  it("returns no errors for a valid default-exporting script", async () => {
+    const { resolutions } = stageScript("export default async function () { return {}; }\n");
+    const errors = await validateHookImports(resolutions);
+    expect(errors).toEqual([]);
+  });
+
+  it("flags syntax errors as import failures", async () => {
+    // Unterminated string — parse fails during import()
+    const { resolutions } = stageScript('export default "\n');
+    const errors = await validateHookImports(resolutions);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/Failed to import hook script/);
+    expect(errors[0].nodeId).toBe("start");
+    expect(errors[0].index).toBe(0);
+  });
+
+  it("flags missing default export", async () => {
+    const { resolutions } = stageScript("export const other = 1;\n");
+    const errors = await validateHookImports(resolutions);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/must export a default function/);
+  });
+
+  it("flags non-function default exports", async () => {
+    const { resolutions } = stageScript("export default 42;\n");
+    const errors = await validateHookImports(resolutions);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/must export a default function \(got number\)/);
+  });
+
+  it("ignores built-in resolutions", async () => {
+    const resolutions: HookResolutionMap = new Map([
+      ["start", [{ kind: "builtin", call: "memory_status", name: "memory_status" }]],
+    ]);
+    const errors = await validateHookImports(resolutions);
+    expect(errors).toEqual([]);
+  });
+
+  it("does NOT invoke the hook body (module-level side effects stay quiet)", async () => {
+    // If we called fn(), this would throw. The check is import-only.
+    const { resolutions } = stageScript(
+      "export default async function () { throw new Error('SHOULD-NOT-RUN'); }\n",
+    );
+    const errors = await validateHookImports(resolutions);
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Add async `validateHookImports(resolutions)` in `src/hook-resolution.ts` that walks every script hook, imports it, and verifies the default export is a function. Returns per-hook `HookImportError[]`; does NOT invoke the hook body.
- Wire into `freelance validate` as a new phase (2.5) so authors catch syntax errors, missing deps, and non-function default exports at validate time instead of deep inside a traversal.
- Runtime kept as a second line of defense for callers that bypass validate (direct engine construction, programmatic use); Node's import cache keys by URL so the eager pre-flight is free on the subsequent runtime load.

Closes #97

## Test plan

- [x] `npm run build`
- [x] `npm test` (713 pass)
- [x] New unit tests for `validateHookImports` cover valid script, syntax error, missing default, non-function default, built-in passthrough, and confirm the hook body is never invoked.
- [x] New `cli-validate.test.ts` cases exercise the same matrix end-to-end through `freelance validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)