### PR TITLE
fix(state): atomic read-modify-write on traversal JSON (#88)

### DIFF
--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -22,6 +22,13 @@ export const ENGINE_ERROR_CODES = {
     "REQUIRED_META_MISSING",
     "AMBIGUOUS_TRAVERSAL",
     "TRAVERSAL_ACTIVE",
+    // Optimistic-concurrency conflict: another writer updated the
+    // record between our load and save. Transient — caller should
+    // re-read the traversal and retry. Classified as INVALID_INPUT
+    // because the caller's implicit precondition ("state hasn't
+    // changed since I read it") was violated; semantically retriable
+    // without operator intervention.
+    "TRAVERSAL_CONFLICT",
     "INVALID_KEY_VALUE_PAIR",
     "INVALID_CONTEXT_JSON",
     "INVALID_EMIT_JSON",
@@ -61,6 +68,7 @@ export const EC = {
   REQUIRED_META_MISSING: "REQUIRED_META_MISSING",
   AMBIGUOUS_TRAVERSAL: "AMBIGUOUS_TRAVERSAL",
   TRAVERSAL_ACTIVE: "TRAVERSAL_ACTIVE",
+  TRAVERSAL_CONFLICT: "TRAVERSAL_CONFLICT",
   INVALID_KEY_VALUE_PAIR: "INVALID_KEY_VALUE_PAIR",
   INVALID_CONTEXT_JSON: "INVALID_CONTEXT_JSON",
   INVALID_EMIT_JSON: "INVALID_EMIT_JSON",

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -5,6 +5,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { EC, EngineError } from "../errors.js";
 import type { SessionState } from "../types.js";
 
 export interface TraversalRecord {
@@ -15,6 +16,12 @@ export interface TraversalRecord {
   stackDepth: number;
   createdAt: string;
   updatedAt: string;
+  // Monotonic revision counter. Bumped on every successful put. Callers
+  // that read-then-write use this for optimistic-concurrency conflict
+  // detection via `putIfVersion`. Optional on the type for backward
+  // compatibility with pre-1.4 records on disk; read paths synthesize
+  // `version: 0` when absent.
+  version?: number;
   // Caller-supplied opaque tags set at createTraversal time and mutable
   // thereafter via setMeta. Freelance never interprets the keys or values —
   // they exist purely so external systems can find a traversal by their own
@@ -28,9 +35,33 @@ export interface StateStore {
   /** Load all records. Each record requires a full read + parse, so prefer `listIds` for count/presence checks. */
   list(): TraversalRecord[];
   get(id: string): TraversalRecord | undefined;
+  /** Unconditional write. Use for first-time creation; prefer `putIfVersion` for updates. */
   put(record: TraversalRecord): void;
+  /**
+   * Optimistic-concurrency write. Writes `record` iff the on-disk
+   * version still matches `expectedVersion`. Throws
+   * `EngineError(TRAVERSAL_CONFLICT)` otherwise. The caller passes the
+   * version it observed at load time; a mismatch means another writer
+   * raced between the caller's get() and this put().
+   *
+   * The supplied `record.version` is ignored on input — the store
+   * always writes `expectedVersion + 1`. Returns the record actually
+   * written (with the bumped version) so callers have an accurate
+   * view of what's on disk without a follow-up read.
+   */
+  putIfVersion(record: TraversalRecord, expectedVersion: number): TraversalRecord;
   delete(id: string): void;
   close(): void;
+}
+
+class TraversalConflictError extends EngineError {
+  constructor(id: string, expected: number, actual: number) {
+    super(
+      `Traversal "${id}" was modified concurrently (expected version ${expected}, found ${actual}). ` +
+        `Re-read the traversal and retry.`,
+      EC.TRAVERSAL_CONFLICT,
+    );
+  }
 }
 
 function sortByUpdatedDesc(records: TraversalRecord[]): TraversalRecord[] {
@@ -50,7 +81,17 @@ class InMemoryStateStore implements StateStore {
     return this.records.get(id);
   }
   put(record: TraversalRecord): void {
-    this.records.set(record.id, record);
+    this.records.set(record.id, { ...record, version: (record.version ?? 0) + 1 });
+  }
+  putIfVersion(record: TraversalRecord, expectedVersion: number): TraversalRecord {
+    const current = this.records.get(record.id);
+    const currentVersion = current?.version ?? 0;
+    if (current && currentVersion !== expectedVersion) {
+      throw new TraversalConflictError(record.id, expectedVersion, currentVersion);
+    }
+    const next = { ...record, version: expectedVersion + 1 };
+    this.records.set(record.id, next);
+    return next;
   }
   delete(id: string): void {
     this.records.delete(id);
@@ -111,6 +152,29 @@ class JsonDirectoryStateStore implements StateStore {
   }
 
   put(record: TraversalRecord): void {
+    const next = { ...record, version: (record.version ?? 0) + 1 };
+    this.writeAtomic(next);
+  }
+
+  putIfVersion(record: TraversalRecord, expectedVersion: number): TraversalRecord {
+    // Within a single Node process the read-check-write here is
+    // effectively atomic — the event loop can't interleave synchronous
+    // fs calls. Across processes it's still racy (classic TOCTOU on
+    // the version field), but the per-file rename is atomic, so the
+    // worst case is two writers both think they won. For Freelance's
+    // workload (per-checkout tool, rare cross-process concurrency)
+    // detection via TRAVERSAL_CONFLICT beats silent loss.
+    const existing = this.get(record.id);
+    const current = existing?.version ?? 0;
+    if (existing && current !== expectedVersion) {
+      throw new TraversalConflictError(record.id, expectedVersion, current);
+    }
+    const next = { ...record, version: expectedVersion + 1 };
+    this.writeAtomic(next);
+    return next;
+  }
+
+  private writeAtomic(record: TraversalRecord): void {
     const final = this.fileFor(record.id);
     const tmp = `${final}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(record));

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -48,6 +48,8 @@ export class TraversalStore {
   private maxDepth: number;
   private hookRunner: HookRunner;
   private contextCaps?: ContextCaps;
+  // Per-id async mutex tails, keyed by traversal id. See `withLock`.
+  private locks = new Map<string, Promise<unknown>>();
 
   constructor(
     state: StateStore,
@@ -59,6 +61,34 @@ export class TraversalStore {
     this.maxDepth = options.maxDepth ?? 5;
     this.hookRunner = options.hookRunner;
     this.contextCaps = options.contextCaps;
+  }
+
+  /**
+   * Run `fn` under the per-id lock. Subsequent calls for the same id
+   * queue behind the current one. The map entry is cleared when the
+   * last waiter settles so an idle id carries no memory cost.
+   *
+   * The tail-marker stored in `this.locks` is a rejection-swallowing
+   * derivative of the result promise — a failure in `fn` doesn't
+   * poison subsequent operations on the same id. The rejection still
+   * propagates to the immediate caller via the awaited result.
+   */
+  private async withLock<T>(id: string, fn: () => Promise<T> | T): Promise<T> {
+    // Stored tails already swallow rejections, so `prior` always
+    // resolves; chaining with a single continuation is enough.
+    const prior = this.locks.get(id) ?? Promise.resolve();
+    const result = prior.then(fn);
+    const tail = result.catch(() => {});
+    this.locks.set(id, tail);
+    try {
+      return await result;
+    } finally {
+      // Only evict if we're still the tail — another caller may have
+      // appended behind us while we awaited.
+      if (this.locks.get(id) === tail) {
+        this.locks.delete(id);
+      }
+    }
   }
 
   close(): void {
@@ -166,20 +196,28 @@ export class TraversalStore {
     edge: string,
     contextUpdates?: Record<string, unknown>,
   ): Promise<{ traversalId: string; meta: Record<string, string> } & AdvanceResult> {
-    const { engine, record } = this.loadEngine(traversalId);
-    const hookMeta: Record<string, string> = {};
-    const result = await engine.advance(edge, contextUpdates, {
-      metaCollector: (updates) => Object.assign(hookMeta, updates),
+    // advance() is the only traversal-mutating path that awaits (hooks
+    // run mid-call), so two concurrent invocations on the same id can
+    // interleave their load → mutate → save sequences within one
+    // process. The mutex gives them clean sequential semantics; the
+    // sync methods (contextSet/setMeta) can't interleave within a
+    // process and rely on putIfVersion alone for cross-process races.
+    return this.withLock(traversalId, async () => {
+      const { engine, record } = this.loadEngine(traversalId);
+      const hookMeta: Record<string, string> = {};
+      const result = await engine.advance(edge, contextUpdates, {
+        metaCollector: (updates) => Object.assign(hookMeta, updates),
+      });
+      // Merge collected hook updates into the in-memory record before save —
+      // saveEngine carries record.meta forward verbatim, so this is the
+      // single point of integration. Avoids a separate setMeta + extra disk
+      // write per advance.
+      if (Object.keys(hookMeta).length > 0) {
+        record.meta = { ...record.meta, ...hookMeta };
+      }
+      this.saveEngine(record, engine);
+      return { traversalId, meta: record.meta ?? EMPTY_META, ...result };
     });
-    // Merge collected hook updates into the in-memory record before save —
-    // saveEngine carries record.meta forward verbatim, so this is the
-    // single point of integration. Avoids a separate setMeta + extra disk
-    // write per advance.
-    if (Object.keys(hookMeta).length > 0) {
-      record.meta = { ...record.meta, ...hookMeta };
-    }
-    this.saveEngine(record, engine);
-    return { traversalId, meta: record.meta ?? EMPTY_META, ...result };
   }
 
   contextSet(
@@ -210,7 +248,10 @@ export class TraversalStore {
       throw new EngineError(`Traversal "${traversalId}" not found`, EC.TRAVERSAL_NOT_FOUND);
     }
     const meta = { ...record.meta, ...updates };
-    this.state.put({ ...record, meta, updatedAt: new Date().toISOString() });
+    this.state.putIfVersion(
+      { ...record, meta, updatedAt: new Date().toISOString() },
+      record.version ?? 0,
+    );
     return { traversalId, meta };
   }
 
@@ -301,6 +342,10 @@ export class TraversalStore {
     // meta_set onEnter hook) mutate record.meta *before* calling saveEngine,
     // so reading from `record` here picks up their writes.
     if (record.meta) next.meta = record.meta;
-    this.state.put(next);
+    // `record.version` is what we observed at loadEngine() time —
+    // putIfVersion throws TRAVERSAL_CONFLICT if another writer bumped
+    // the version meanwhile. `version ?? 0` handles legacy records
+    // written before the field existed.
+    this.state.putIfVersion(next, record.version ?? 0);
   }
 }

--- a/test/traversal-store.test.ts
+++ b/test/traversal-store.test.ts
@@ -450,4 +450,121 @@ describe("TraversalStore — stateless JSON", () => {
       expect(store.hasActiveTraversalForGraph()).toBe(false);
     });
   });
+
+  describe("concurrent writers (#88)", () => {
+    it("serializes two in-process advances on the same id (no lost update)", async () => {
+      const t = await store.createTraversal("valid-simple");
+      store.contextSet(t.traversalId, { taskStarted: true });
+
+      // Without the in-process lock, both advances would load at the
+      // same version; the later putIfVersion would throw
+      // TRAVERSAL_CONFLICT. With the lock, they serialize: the first
+      // moves start → review, the second runs against the post-first
+      // state and fails cleanly (no matching edge at `review`).
+      // Either way, no silent lost update.
+      const results = await Promise.allSettled([
+        store.advance(t.traversalId, "work-done"),
+        store.advance(t.traversalId, "work-done"),
+      ]);
+
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      const rejected = results.filter((r) => r.status === "rejected");
+
+      // The first advance succeeds (moves start → review). The second
+      // runs against the post-first state and fails cleanly — but
+      // crucially, not with TRAVERSAL_CONFLICT: the mutex already
+      // serialized them, so the second call sees a coherent world.
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      for (const r of rejected) {
+        const err = (r as PromiseRejectedResult).reason;
+        expect(err).toBeInstanceOf(EngineError);
+        expect((err as EngineError).code).not.toBe("TRAVERSAL_CONFLICT");
+      }
+
+      // Persisted state reflects the first advance, not a half-applied
+      // or overwritten result.
+      const list = store.listTraversals();
+      expect(list).toHaveLength(1);
+      expect(list[0].currentNode).toBe("review");
+    });
+
+    it("version monotonically increases on each successful write", async () => {
+      const dir = path.join(tmpDir, "traversals");
+      const t = await store.createTraversal("valid-simple");
+
+      // Reach into the raw store to observe the on-disk version.
+      // The record's version is an implementation detail of the
+      // optimistic-concurrency scheme; we're verifying it behaves as
+      // described rather than exposing it on the public API.
+      const raw = () => {
+        const file = fs.readFileSync(path.join(dir, `${t.traversalId}.json`), "utf-8");
+        return JSON.parse(file) as { version?: number };
+      };
+
+      // createTraversal's first put goes through `put`, so version = 1.
+      expect(raw().version).toBe(1);
+
+      store.contextSet(t.traversalId, { taskStarted: true });
+      expect(raw().version).toBe(2);
+
+      store.setMeta(t.traversalId, { owner: "alice" });
+      expect(raw().version).toBe(3);
+
+      await store.advance(t.traversalId, "work-done");
+      expect(raw().version).toBe(4);
+    });
+
+    it("detects cross-process writer races via TRAVERSAL_CONFLICT", async () => {
+      // Simulates the two-process CLI-vs-hook scenario from #88:
+      // writer A captures a record at version N, writer B lands a
+      // write at N+1, writer A's save must throw instead of silently
+      // clobbering. TraversalStore's own methods re-read on every
+      // call, so we drop to the raw backend to capture a stale view.
+      const dir = path.join(tmpDir, "traversals");
+      const store2 = new TraversalStore(openStateStore(dir), graphs, {
+        hookRunner: new HookRunner(),
+      });
+
+      try {
+        const t = await store.createTraversal("valid-simple");
+        const backend = openStateStore(dir);
+        const staleView = backend.get(t.traversalId);
+        if (!staleView) throw new Error("unreachable");
+
+        // Another writer bumps the on-disk version past staleView's.
+        store2.contextSet(t.traversalId, { taskStarted: true });
+
+        expect(() =>
+          backend.putIfVersion(
+            { ...staleView, updatedAt: new Date().toISOString() },
+            staleView.version ?? 0,
+          ),
+        ).toThrow(EngineError);
+        try {
+          backend.putIfVersion(
+            { ...staleView, updatedAt: new Date().toISOString() },
+            staleView.version ?? 0,
+          );
+        } catch (e) {
+          expect((e as EngineError).code).toBe("TRAVERSAL_CONFLICT");
+        }
+        backend.close();
+      } finally {
+        store2.close();
+      }
+    });
+
+    it("rejection in one advance doesn't poison subsequent calls on the same id", async () => {
+      const t = await store.createTraversal("valid-simple");
+      // First advance fails (no matching edge, no contextSet first).
+      await expect(store.advance(t.traversalId, "nonexistent-edge")).rejects.toThrow(EngineError);
+
+      // Second advance on the same id must still proceed — the lock
+      // tail-marker swallows the prior rejection.
+      store.contextSet(t.traversalId, { taskStarted: true });
+      const adv = await store.advance(t.traversalId, "work-done");
+      expect(adv.isError).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the silent data-loss risk when two writers race against the same traversal JSON file:
- CLI invocation + a hook that shells out to `freelance`
- Two CLI invocations from different shells pointed at the same `.freelance/`
- Any future programmatic user with concurrent `TraversalStore` callers

Until now the per-file rename inside `put` was atomic but the `load → mutate → save` window wasn't, so a race dropped one writer's update. Now:

- Every `TraversalRecord` carries a monotonic `version` bumped on each `put`.
- New `StateStore.putIfVersion(record, expectedVersion)` check-and-writes — throws `EngineError(TRAVERSAL_CONFLICT)` when the observed version is stale. `TraversalStore.saveEngine` and `setMeta` now use it.
- Per-id async mutex (`withLock`) for `advance` — the only mutating path that awaits mid-call, where two same-process callers could genuinely interleave. `contextSet` / `setMeta` / `resetTraversal` stay synchronous; Node's event loop already serializes them within a process, so `putIfVersion` alone covers their cross-process case.

Legacy on-disk records without `version` read as version 0; first write bumps to 1.

`TRAVERSAL_CONFLICT` is classified under `INVALID_INPUT` (exit 5) — transient, caller can re-read and retry.

Closes #88

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 707/707 pass (4 new concurrency tests)
  - two in-process advances on same id: mutex serializes, no `TRAVERSAL_CONFLICT`
  - version monotonically increases across put/contextSet/setMeta/advance
  - cross-process stale writer gets `TRAVERSAL_CONFLICT` (via raw backend)
  - rejection doesn't poison subsequent lock acquisitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)