### PR TITLE
feat(hooks): name the trust model; add FREELANCE_HOOKS_ALLOW_SCRIPTS opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ nodes:
 
 **onEnter hooks** — Any node can declare `onEnter: [{ call, args }]` hooks that run before the agent sees the node. `call` resolves to either a built-in hook (`memory_status`, `memory_browse`) or a local script path (`./scripts/fetch-context.js`). Hooks receive resolved args, live context, and the memory store, and return a plain object of context updates. Strict-context enforcement still applies. Per-hook timeout defaults to 5000ms, configurable via `hooks.timeoutMs` in `config.yml`.
 
-> **Trust model for hook scripts.** Local script hooks execute with full Node privileges in the host process on graph load and node arrival — treat a workflow file that references a local script like a `package.json` scripts block: trust it at the same level you trust the rest of the repo. Do not load workflow graphs from untrusted sources.
+> **Trust model for hook scripts.** Hook execution sits on an explicit line between two tiers:
+>
+> - **Built-in hooks** (`memory_status`, `memory_browse`, `meta_set`, …) are curated and ship inside the package. They run against a narrow read interface over memory + a meta collector. Always safe to reference.
+> - **Local script hooks** (`./scripts/foo.js`) execute with full Node privileges in the host process — same filesystem, same network, same subprocess spawn, same env vars. There is no sandbox. Treat a workflow file that references a local script like a `package.json` scripts block: trust it at the same level you trust the rest of the repo. Do not load workflow graphs from untrusted sources.
+>
+> A deployment that can't vet every workflow (shared graph registry, untrusted contributors) can set `FREELANCE_HOOKS_ALLOW_SCRIPTS=0` in the environment; graph load then rejects any `onEnter` entry that points at a local script, leaving built-ins as the only runnable hook surface. Unset or set to any other value means scripts are allowed (default). See `docs/decisions.md` for the architectural rationale and the sandboxing milestone.
 
 ## Memory
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -56,3 +56,22 @@ Freelance config (`.freelance/config.yml`, `.freelance/config.local.yml`) is rea
 Historical note (closed by #121 and #90): an MCP-server era `onConfigChange` handler in `src/server.ts` logged `"Freelance: config reloaded"` on `config.yml` / `config.local.yml` edits but never re-threaded the new values into the live `HookRunner` or `GraphEngine` — edits looked like they applied and didn't. #91 called that out. The handler was deleted with the MCP server (#121); the watcher that would have invoked it was deleted with #90. A future re-introduction of any long-running surface must either (a) plumb the new config through every downstream that consumed it (hook timeouts, maxDepth, memory dir — with the caveat that some fields can't hot-swap, e.g. memory db path reopening) or (b) log `"Freelance: config changed on disk — restart to apply"` and leave the mutation out. Silent reload-without-apply is the specific trap to avoid.
 
 See issue [#91](https://github.com/duct-tape-and-markdown/freelance/issues/91).
+
+### Hook trust model: built-ins curated, script hooks full-privilege, sandbox deferred
+
+`onEnter` hooks have two tiers with deliberately different trust postures:
+
+- **Built-in hooks** (`src/engine/builtin-hooks.ts`) are part of the package surface. They run against a narrow read interface over memory (`HookMemoryAccess`) plus an explicit meta collector — not the whole `MemoryStore` — so a built-in can't reach write methods, the SQLite handle, or process globals. They're reviewed at every release.
+- **Local script hooks** (`./scripts/foo.js`) are user code loaded via `import()` into the same Node process. They get filesystem, network, subprocess, and environment at full privilege. The 5-second `hooks.timeoutMs` only bounds the promise race; side effects initiated before the timeout still run to completion.
+
+This asymmetry is intentional. Collapsing the tiers either way is worse: sandboxing built-ins adds indirection with no security win (they're curated), and sandboxing user scripts requires real isolation (`isolated-vm`, subprocess with `--permission`, or a WASM runtime) — that's architecture work, not a patch, and doesn't fit in a P2 issue.
+
+What ships today is the assertion surface, not the sandbox:
+
+- `FREELANCE_HOOKS_ALLOW_SCRIPTS=0` at the environment makes `resolveGraphHooks` reject every `kind: "script"` entry at graph load with a clear error. Operators that can't vet every contributed workflow (shared graph registry, multi-agent marketplace scenarios from #45) set the flag and get a built-ins-only runtime. Default is allowed — the flag is an opt-in to stricter handling, not a default-deny, because the dominant single-user case is a trusted repo.
+- The README's "Trust model for hook scripts" paragraph names the line explicitly so a graph author can't claim they didn't know.
+- A real sandbox (isolate scripts in a subprocess or VM with no ambient authority) is the right answer for the marketplace scenario. Tracking as a milestone feature, not a patch on this PR.
+
+**What would break if reversed:** Making user scripts sandboxed-by-default would require picking a sandbox technology now — each option has real tradeoffs (vm2 is unmaintained, isolated-vm is a native dep, subprocess adds IPC overhead to every hook) and picking wrong is worse than the honest "no sandbox, don't load untrusted graphs" stance.
+
+See issue [#89](https://github.com/duct-tape-and-markdown/freelance/issues/89).

--- a/src/hook-resolution.ts
+++ b/src/hook-resolution.ts
@@ -20,6 +20,26 @@ import { pathToFileURL } from "node:url";
 import { BUILTIN_HOOK_NAMES } from "./engine/builtin-hooks.js";
 import type { GraphDefinition } from "./schema/graph-schema.js";
 
+/**
+ * Trust gate for user-authored script hooks. Read from the environment
+ * on every resolution call (not cached) so tests and operators can flip
+ * the flag without restarting the host.
+ *
+ * Scripts run with full Node privileges in the host process — see
+ * README.md "Trust model for hook scripts" and the decision entry in
+ * `docs/decisions.md`. A deployment that can't vet every workflow
+ * (shared graph registry, untrusted contributors) sets
+ * `FREELANCE_HOOKS_ALLOW_SCRIPTS=0` and gets a built-ins-only runtime.
+ *
+ * Defaults to allowed; the flag is an opt-in to stricter handling, not
+ * a default-deny.
+ */
+function scriptsAllowed(): boolean {
+  const raw = process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS?.trim().toLowerCase();
+  if (raw === undefined || raw === "") return true;
+  return raw !== "0" && raw !== "false" && raw !== "no";
+}
+
 export type ResolvedHook =
   | { readonly kind: "builtin"; readonly call: string; readonly name: string }
   | { readonly kind: "script"; readonly call: string; readonly absolutePath: string };
@@ -149,6 +169,13 @@ function resolveOneHook(call: string, graphDir: string): ResolvedHook | string {
     return (
       `script path "${call}" must be relative (start with "./" or "../"). ` +
       `Absolute paths are rejected to keep graphs portable.`
+    );
+  }
+
+  if (!scriptsAllowed()) {
+    return (
+      `script hook "${call}" rejected: FREELANCE_HOOKS_ALLOW_SCRIPTS is disabled. ` +
+      `This deployment runs built-in hooks only. Remove the hook or unset the env var.`
     );
   }
 

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { BUILTIN_HOOKS } from "../src/engine/builtin-hooks.js";
 import type { HookFn } from "../src/engine/hooks.js";
 import { HookRunner, resolveHookArgs } from "../src/engine/hooks.js";
@@ -139,6 +139,58 @@ describe("hook resolution — loader", () => {
       },
     };
     expect(() => resolveGraphHooks(def, "/tmp/bad.workflow.yaml")).toThrow(/must be relative/);
+  });
+
+  describe("FREELANCE_HOOKS_ALLOW_SCRIPTS opt-in hardening", () => {
+    // Env var is read on every resolution call — not cached — so we can
+    // flip it per-test without restart. Restore after each case so later
+    // suites that rely on the default (allowed) don't see stale state.
+    const originalEnv = process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS;
+    afterEach(() => {
+      if (originalEnv === undefined) delete process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS;
+      else process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS = originalEnv;
+    });
+
+    it("rejects script hooks when set to 0", () => {
+      process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS = "0";
+      expect(() => stageFixture("hook-simple.workflow.yaml", ["set-count.js"])).toThrow(
+        /FREELANCE_HOOKS_ALLOW_SCRIPTS is disabled/,
+      );
+    });
+
+    it.each(["false", "no", "FALSE", "No"])("rejects script hooks when set to %s", (value) => {
+      process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS = value;
+      expect(() => stageFixture("hook-simple.workflow.yaml", ["set-count.js"])).toThrow(
+        /FREELANCE_HOOKS_ALLOW_SCRIPTS is disabled/,
+      );
+    });
+
+    it("still resolves built-in hooks when scripts are disabled", () => {
+      process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS = "0";
+      const def = {
+        id: "ok",
+        version: "1.0.0",
+        name: "ok",
+        description: "",
+        startNode: "start",
+        nodes: {
+          start: {
+            type: "action" as const,
+            description: "",
+            onEnter: [{ call: "memory_status" }],
+            edges: [{ target: "done", label: "next" }],
+          },
+          done: { type: "terminal" as const, description: "" },
+        },
+      };
+      expect(() => resolveGraphHooks(def, "/tmp/ok.workflow.yaml")).not.toThrow();
+    });
+
+    it.each(["1", "true", "yes", "", undefined])("allows scripts when env is %s", (value) => {
+      if (value === undefined) delete process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS;
+      else process.env.FREELANCE_HOOKS_ALLOW_SCRIPTS = value;
+      expect(() => stageFixture("hook-simple.workflow.yaml", ["set-count.js"])).not.toThrow();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Expand README's "Trust model for hook scripts" paragraph into an explicit two-tier line: curated built-ins (narrow read interface, no process access) vs full-privilege user scripts (import() into the host process, no sandbox).
- Record the decision in `docs/decisions.md` — why the tiers differ intentionally, why sandboxing is a milestone rather than a patch, and what would break if picked prematurely.
- Add `FREELANCE_HOOKS_ALLOW_SCRIPTS=0` runtime assertion. `resolveGraphHooks` rejects every `kind: "script"` entry at load time when the env var is set to `0`/`false`/`no`; built-ins still resolve. Default is allowed — opt-in to stricter handling, not default-deny — because the dominant case is a single-user trusted repo.

Closes #89

## Test plan

- [x] `npm run build`
- [x] `npm test` (714 pass)
- [x] New tests cover: rejection with `0`/`false`/`no`/`FALSE`/`No`, built-in hooks still resolving when scripts are disabled, allowed values (`1`/`true`/`yes`/empty/unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)