### PR TITLE
docs(decisions): config is CLI-invocation-scoped, not runtime-reloaded (#91)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -48,3 +48,11 @@ The residual concern the issue captures — a user starts a traversal, edits/ren
 **What would break if reversed:** reintroducing a watcher without an explicit orphan-handling policy re-opens #90. Any future hot-reload surface must decide up front whether it (a) refuses to reload when active traversals reference the departing graph, (b) marks orphans but continues serving, or (c) auto-resets orphans loudly.
 
 See issue [#90](https://github.com/duct-tape-and-markdown/freelance/issues/90).
+
+### Config changes take effect on the next CLI invocation
+
+Freelance config (`.freelance/config.yml`, `.freelance/config.local.yml`) is read at CLI startup and flows into `composeRuntime` → `HookRunner` / `GraphEngine` / `MemoryStore` for the duration of that invocation. There is no long-running process to hot-patch — each `freelance advance` / `freelance status` / etc. reloads config from disk before wiring the runtime. "Config reload" is therefore not a runtime concern; it's "run the next verb."
+
+Historical note (closed by #121 and #90): an MCP-server era `onConfigChange` handler in `src/server.ts` logged `"Freelance: config reloaded"` on `config.yml` / `config.local.yml` edits but never re-threaded the new values into the live `HookRunner` or `GraphEngine` — edits looked like they applied and didn't. #91 called that out. The handler was deleted with the MCP server (#121); the watcher that would have invoked it was deleted with #90. A future re-introduction of any long-running surface must either (a) plumb the new config through every downstream that consumed it (hook timeouts, maxDepth, memory dir — with the caveat that some fields can't hot-swap, e.g. memory db path reopening) or (b) log `"Freelance: config changed on disk — restart to apply"` and leave the mutation out. Silent reload-without-apply is the specific trap to avoid.
+
+See issue [#91](https://github.com/duct-tape-and-markdown/freelance/issues/91).


### PR DESCRIPTION
## Summary

#91 flagged that the `onConfigChange` handler in `src/server.ts` logged `\"Freelance: config reloaded\"` but never re-threaded the new values into the live `HookRunner` / `GraphEngine`. The handler was deleted when MCP went away (#121); the watcher that would have invoked it is being deleted in #90. Both call sites are already gone on main.

Rather than rebuild a handler to re-thread config into a runtime that no longer exists, this PR locks in the design consequence: in the CLI-primary world, config is read fresh on every invocation via `composeRuntime` and scoped to that process. \"Config reload\" is not a runtime concept; it is \"run the next verb.\"

The new decisions-log entry also names the trap a future reviver of any long-running surface must avoid: silent reload-without-apply. Options if hot-reload is ever needed again: plumb changes through every downstream that consumed them (with the caveat that some fields — memory db path — can't hot-swap without reopening), or log `\"config changed on disk — restart to apply\"` and leave the mutation out.

## Why no code changes

- `src/server.ts` (where the empty handler lived) — deleted in #121.
- `src/watcher.ts` (where `onConfigChange` was dispatched) — deleted in #90 (PR #127).
- `src/cli/*` — loads config fresh on every invocation; no reload logic exists.
- Nothing in the current tree mentions config reload outside the vestigial watcher comment that goes with the watcher deletion.

## Relationship to #90 / #127

Strictly a sibling of #90 rather than a dependency — this PR stands on its own whether or not #127 merges first. If #127 merges first, the decisions-log entry is a preemptive guardrail for future hot-reload work. If this lands first, it documents the architectural choice that makes both issues moot. Either order is fine.

Closes #91

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 703/703 pass (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)