### PR TITLE
fix(memory): wrap resetAll in a transaction

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -118,8 +118,20 @@ export class MemoryStore {
     ).c;
     const entCount = (this.db.prepare("SELECT COUNT(*) as c FROM entities").get() as { c: number })
       .c;
-    this.db.exec("DELETE FROM propositions");
-    this.db.exec("DELETE FROM entities");
+    // Atomically — partial reset (propositions gone but entities left
+    // orphaned) is worse than no reset, since the user now has stranded
+    // entity rows the normal flow can't reach. Mirrors the prune BEGIN/
+    // COMMIT/ROLLBACK pattern. `about` and `proposition_sources` cascade
+    // via FK on proposition delete; FTS via the `propositions_ad` trigger.
+    this.db.exec("BEGIN");
+    try {
+      this.db.exec("DELETE FROM propositions");
+      this.db.exec("DELETE FROM entities");
+      this.db.exec("COMMIT");
+    } catch (e) {
+      this.db.exec("ROLLBACK");
+      throw e;
+    }
     return { deleted_propositions: propCount, deleted_entities: entCount };
   }
 

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -442,6 +442,55 @@ describe("MemoryStore", () => {
     });
   });
 
+  describe("resetAll", () => {
+    it("wipes propositions and entities together", () => {
+      writeFile(tmpDir, "a.ts", "x");
+      store.emit([
+        { content: "Auth validates.", entities: ["Auth"], sources: ["a.ts"] },
+        { content: "DB stores.", entities: ["Database"], sources: ["a.ts"] },
+      ]);
+
+      const result = store.resetAll();
+      expect(result.deleted_propositions).toBe(2);
+      expect(result.deleted_entities).toBe(2);
+
+      const status = store.status();
+      expect(status.total_propositions).toBe(0);
+      expect(status.total_entities).toBe(0);
+    });
+
+    it("rolls back on failure — no partial-delete window", () => {
+      // Force the second DELETE to throw by stubbing exec; the first
+      // DELETE (propositions) must be rolled back so the store isn't
+      // left with stranded entity rows.
+      writeFile(tmpDir, "a.ts", "x");
+      store.emit([{ content: "Auth validates.", entities: ["Auth"], sources: ["a.ts"] }]);
+
+      const db = (store as unknown as { db: { exec: (sql: string) => void } }).db;
+      const origExec = db.exec.bind(db);
+      let seen = 0;
+      db.exec = (sql: string) => {
+        // Let BEGIN + first DELETE succeed; fail the second DELETE to
+        // exercise the rollback path. ROLLBACK itself must pass through.
+        if (sql.includes("DELETE FROM entities")) {
+          seen++;
+          throw new Error("simulated failure on second delete");
+        }
+        return origExec(sql);
+      };
+
+      expect(() => store.resetAll()).toThrow("simulated failure");
+      expect(seen).toBe(1);
+
+      // Restore before asserting so status() can run.
+      db.exec = origExec;
+
+      const status = store.status();
+      expect(status.total_propositions).toBe(1);
+      expect(status.total_entities).toBe(1);
+    });
+  });
+
   describe("cross-session knowledge", () => {
     it("accumulates knowledge across sessions", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");


### PR DESCRIPTION
## Summary

- Two back-to-back `exec("DELETE ...")` calls in `MemoryStore.resetAll` had a partial-state window: if the second delete failed (process killed, disk pressure, FK trigger fault), the store would be left with zero propositions but the full entity set — all of which are now unreachable since `about.proposition_id` cascade-deleted with the propositions. Reset was meant to be the recovery tool; leaving it non-atomic meant the recovery tool itself was unreliable.
- Wraps both DELETEs in BEGIN/COMMIT/ROLLBACK, mirroring the existing pattern in `prune()`.
- `about` and `proposition_sources` continue to cascade via FK; FTS via the `propositions_ad` trigger — no change there.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 705 pass (added 2: happy-path and rollback via stubbed `db.exec`)

Closes #107

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>