### PR TITLE
refactor(memory): use temp table for stale-proposition exclusion

### DIFF
--- a/src/memory/enrichment.ts
+++ b/src/memory/enrichment.ts
@@ -8,7 +8,16 @@
  */
 
 import type { Db } from "./db.js";
+import { STALE_PROP_IDS_TABLE } from "./staleness.js";
 import type { NeighborEntity, StatusResult } from "./types.js";
+
+// Every query below assumes `materializeStalePropIds` has been called
+// on this db handle earlier in the same public read — the store does
+// this once per call right after `getStalePropositionIds`. The filter
+// joins against a shared TEMP TABLE instead of spreading ids inline as
+// parameters, which keeps us clear of SQLite's `SQLITE_MAX_VARIABLE_NUMBER`
+// ceiling and lets the prepared-statement cache reuse one SQL string.
+const NOT_STALE_EXISTS_FILTER = `NOT EXISTS (SELECT 1 FROM ${STALE_PROP_IDS_TABLE} _s WHERE _s.proposition_id = a1.proposition_id)`;
 
 /**
  * Co-occurring entities for a given entity. Ranks by count of shared
@@ -20,16 +29,9 @@ import type { NeighborEntity, StatusResult } from "./types.js";
 export function getNeighbors(
   db: Db,
   entityId: string,
-  stalePropIds: Set<string>,
   options?: { withSample?: boolean; limit?: number; offset?: number },
 ): Array<NeighborEntity & { sample?: string | null }> {
   const withSample = options?.withSample ?? false;
-
-  const staleParams = [...stalePropIds];
-  const staleFilter =
-    staleParams.length > 0
-      ? `a1.proposition_id NOT IN (${staleParams.map(() => "?").join(",")})`
-      : "1";
 
   const sampleCol = withSample
     ? `, (SELECT p2.content FROM propositions p2
@@ -48,7 +50,7 @@ export function getNeighbors(
     .prepare(
       `SELECT e2.id, e2.name, e2.kind,
             COUNT(DISTINCT a1.proposition_id) as shared_propositions,
-            COUNT(DISTINCT CASE WHEN ${staleFilter} THEN a1.proposition_id END) as valid_shared_propositions${sampleCol}
+            COUNT(DISTINCT CASE WHEN ${NOT_STALE_EXISTS_FILTER} THEN a1.proposition_id END) as valid_shared_propositions${sampleCol}
      FROM about a1
      JOIN about a2 ON a1.proposition_id = a2.proposition_id
      JOIN entities e2 ON a2.entity_id = e2.id
@@ -57,7 +59,7 @@ export function getNeighbors(
      ORDER BY valid_shared_propositions DESC
      ${pageClause}`,
     )
-    .all(...staleParams, ...sampleParams, entityId, ...pageParams) as Array<
+    .all(...sampleParams, entityId, ...pageParams) as Array<
     NeighborEntity & { sample?: string | null }
   >;
 }
@@ -83,25 +85,14 @@ export function countNeighbors(db: Db, entityId: string): number {
 }
 
 /** Count propositions about an entity that are currently valid. */
-export function countValidForEntity(db: Db, entityId: string, stalePropIds: Set<string>): number {
-  // Fast path: no stale props — skip the exclusion filter
-  if (stalePropIds.size === 0) {
-    return (
-      db.prepare("SELECT COUNT(*) as c FROM about WHERE entity_id = ?").get(entityId) as {
-        c: number;
-      }
-    ).c;
-  }
-
-  const staleParams = [...stalePropIds];
-  const placeholders = staleParams.map(() => "?").join(",");
+export function countValidForEntity(db: Db, entityId: string): number {
   return (
     db
       .prepare(
-        `SELECT COUNT(*) as c FROM about
-     WHERE entity_id = ? AND proposition_id NOT IN (${placeholders})`,
+        `SELECT COUNT(*) as c FROM about a1
+         WHERE a1.entity_id = ? AND ${NOT_STALE_EXISTS_FILTER}`,
       )
-      .get(entityId, ...staleParams) as { c: number }
+      .get(entityId) as { c: number }
   ).c;
 }
 

--- a/src/memory/staleness.ts
+++ b/src/memory/staleness.ts
@@ -56,9 +56,35 @@ export function isFileChanged(
 }
 
 /**
+ * Name of the TEMP TABLE populated by `getStalePropositionIds`. The
+ * read-side queries in `enrichment.ts` + `store.ts` join against it
+ * (`NOT EXISTS (SELECT 1 FROM _stale_prop_ids ...)`) instead of
+ * spreading ids into a dynamically-sized `NOT IN (?, ?, ?, …)` clause,
+ * which would hit SQLite's `SQLITE_MAX_VARIABLE_NUMBER` ceiling on
+ * large stale sets and churn the prepared-statement cache across
+ * differently-sized stale sets.
+ *
+ * Population is coupled into `getStalePropositionIds` so downstream
+ * readers can't forget to materialize. An empty table means "no stale
+ * props" — `NOT EXISTS` returns TRUE for every row, which correctly
+ * counts all propositions as valid.
+ */
+export const STALE_PROP_IDS_TABLE = "_stale_prop_ids";
+
+// Bulk-insert batch size — well under SQLite's default variable limit
+// (32766) so materialization never hits the very ceiling it's meant to
+// sidestep, regardless of stale-set cardinality.
+const STALE_PROP_BATCH_SIZE = 500;
+
+/**
  * Scan proposition_sources and return the set of propositions that have
  * at least one drifted source file. Uses the cache to avoid re-stating
  * files that multiple propositions share.
+ *
+ * Side effect: materializes the stale set into `STALE_PROP_IDS_TABLE`
+ * on the same connection so read queries can reference it. Every public
+ * read on MemoryStore calls this once per operation, which keeps the
+ * temp-table contents consistent with the Set returned here.
  */
 export function getStalePropositionIds(
   db: Db,
@@ -80,5 +106,23 @@ export function getStalePropositionIds(
       stale.add(proposition_id);
     }
   }
+  materializeStalePropIds(db, stale);
   return stale;
+}
+
+function materializeStalePropIds(db: Db, stalePropIds: Set<string>): void {
+  db.exec(
+    `CREATE TEMP TABLE IF NOT EXISTS ${STALE_PROP_IDS_TABLE} (proposition_id TEXT PRIMARY KEY) WITHOUT ROWID`,
+  );
+  db.exec(`DELETE FROM ${STALE_PROP_IDS_TABLE}`);
+  if (stalePropIds.size === 0) return;
+
+  const ids = [...stalePropIds];
+  for (let i = 0; i < ids.length; i += STALE_PROP_BATCH_SIZE) {
+    const batch = ids.slice(i, i + STALE_PROP_BATCH_SIZE);
+    const placeholders = batch.map(() => "(?)").join(",");
+    db.prepare(`INSERT INTO ${STALE_PROP_IDS_TABLE} (proposition_id) VALUES ${placeholders}`).run(
+      ...batch,
+    );
+  }
 }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -20,6 +20,7 @@ import {
   createStalenessCache,
   getStalePropositionIds,
   isFileChanged,
+  STALE_PROP_IDS_TABLE,
   type StalenessCache,
 } from "./staleness.js";
 import type {
@@ -389,12 +390,10 @@ export class MemoryStore {
       whereParams.push(options.kind);
     }
 
-    const stalePropIds = getStalePropositionIds(this.db, this.sourceRoot, cache);
-    const staleParams = [...stalePropIds];
-    const notStale =
-      staleParams.length > 0
-        ? `a.proposition_id NOT IN (${staleParams.map(() => "?").join(",")})`
-        : "1";
+    // getStalePropositionIds also materializes the set into STALE_PROP_IDS_TABLE
+    // for the NOT EXISTS join below.
+    getStalePropositionIds(this.db, this.sourceRoot, cache);
+    const notStale = `NOT EXISTS (SELECT 1 FROM ${STALE_PROP_IDS_TABLE} _s WHERE _s.proposition_id = a.proposition_id)`;
     const having = includeOrphans ? "" : "HAVING valid_count > 0";
 
     const selectExpr = `
@@ -408,14 +407,14 @@ export class MemoryStore {
       ${having}`;
 
     const total = (
-      this.db
-        .prepare(`SELECT COUNT(*) as total FROM (${selectExpr})`)
-        .get(...staleParams, ...whereParams) as { total: number }
+      this.db.prepare(`SELECT COUNT(*) as total FROM (${selectExpr})`).get(...whereParams) as {
+        total: number;
+      }
     ).total;
 
     const rows = this.db
       .prepare(`${selectExpr} ORDER BY e.created_at DESC LIMIT ? OFFSET ?`)
-      .all(...staleParams, ...whereParams, limit, offset) as Array<
+      .all(...whereParams, limit, offset) as Array<
       EntityRow & { proposition_count: number; valid_count: number }
     >;
 
@@ -463,9 +462,9 @@ export class MemoryStore {
     // `valid_proposition_count` on the entity header reports the
     // entity-wide valid total (across the full, unpaginated set); the
     // paginated `propositions` list is just the current page.
-    const stalePropIds = getStalePropositionIds(this.db, this.sourceRoot, cache);
-    const validCount = countValidForEntity(this.db, entity.id, stalePropIds);
-    const neighbors = getNeighbors(this.db, entity.id, stalePropIds);
+    getStalePropositionIds(this.db, this.sourceRoot, cache);
+    const validCount = countValidForEntity(this.db, entity.id);
+    const neighbors = getNeighbors(this.db, entity.id);
 
     if (shape === "minimal") {
       return {
@@ -600,8 +599,8 @@ export class MemoryStore {
     const limit = clampLimit(options?.limit);
     const offset = clampOffset(options?.offset);
 
-    const stalePropIds = getStalePropositionIds(this.db, this.sourceRoot, cache);
-    const validCount = countValidForEntity(this.db, entity.id, stalePropIds);
+    getStalePropositionIds(this.db, this.sourceRoot, cache);
+    const validCount = countValidForEntity(this.db, entity.id);
     const totalCount = (
       this.db.prepare("SELECT COUNT(*) as c FROM about WHERE entity_id = ?").get(entity.id) as {
         c: number;
@@ -609,7 +608,7 @@ export class MemoryStore {
     ).c;
 
     const total = countNeighbors(this.db, entity.id);
-    const rows = getNeighbors(this.db, entity.id, stalePropIds, {
+    const rows = getNeighbors(this.db, entity.id, {
       withSample: true,
       limit,
       offset,

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -568,6 +568,30 @@ describe("MemoryStore", () => {
     });
   });
 
+  describe("stale filter at scale", () => {
+    // Regression guard: the old `NOT IN (?, …)` pattern bound one param
+    // per stale id, which would hit SQLITE_MAX_VARIABLE_NUMBER on a
+    // large-enough stale set. The temp-table materialization keeps the
+    // param count bounded regardless.
+    it("browse/inspect/related work when every proposition is stale", () => {
+      writeFile(tmpDir, "heavy.ts", "v1");
+      const N = 150;
+      const batch = Array.from({ length: N }, (_, i) => ({
+        content: `Heavy claim number ${i} about the system.`,
+        entities: [`Hub${i}`, "Shared"],
+        sources: ["heavy.ts"],
+      }));
+      store.emit(batch);
+      writeFile(tmpDir, "heavy.ts", "v2-drifted");
+
+      expect(() => store.browse({ includeOrphans: true })).not.toThrow();
+      expect(() => store.inspect("Shared")).not.toThrow();
+      expect(() => store.related("Shared")).not.toThrow();
+
+      expect(store.status().stale_propositions).toBe(N);
+    });
+  });
+
   describe("cross-session knowledge", () => {
     it("accumulates knowledge across sessions", () => {
       writeFile(tmpDir, "auth.ts", "class Auth {}");


### PR DESCRIPTION
## Summary

- Three read-side queries (`browse`, `getNeighbors`, `countValidForEntity`) built a dynamic `NOT IN (?, ?, ?, …)` clause with one param per stale proposition id. This would hit SQLite's `SQLITE_MAX_VARIABLE_NUMBER` ceiling on large stale sets (e.g. after a major refactor or a rebase that touched many sourced files) and churn the prepared-statement cache across differently-sized stale sets.
- `getStalePropositionIds` now materializes the set into a connection-scoped TEMP TABLE (`_stale_prop_ids`). Read queries join via `NOT EXISTS (SELECT 1 FROM _stale_prop_ids …)` instead of inlining parameters. One fixed SQL string, zero stale-id parameters bound, regardless of stale-set cardinality.
- Materialization is coupled into `getStalePropositionIds` (not a separate helper) because every read that needs the stale filter already calls it first — separating them would let a new caller silently get "no props stale" (NOT EXISTS over an empty table is TRUE) instead of crashing.
- Inserts are batched at 500 ids per call to stay clear of the same variable limit on the insert side.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 704 pass (703 baseline + 1 new "browse/inspect/related work when every proposition is stale" test exercising the three rewritten sites)

## Out of scope

- `prune.ts`'s `hardDeletedPropIds` placeholder-expansion is a similar idiom but bounded by how many propositions are deleted in one prune call (small). The issue explicitly called it out as "different"; leaving it alone.

Closes #106

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>