### PR TITLE
refactor(memory): drop getDb/getSourceRoot escape hatches

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -11,7 +11,6 @@
 import fs from "node:fs";
 import { EC, EngineError } from "../errors.js";
 import type { MemoryStore } from "../memory/index.js";
-import { prune } from "../memory/prune.js";
 import type { PropositionShape } from "../memory/types.js";
 import { EXIT, errorEnvelope, handleRuntimeError as handleError, outputJson } from "./output.js";
 
@@ -163,7 +162,7 @@ export function memoryPrune(
     // `--yes`. Return the plan + an explicit refusal when neither flag
     // is set, so the skill sees the blast radius before committing.
     const confirmed = opts.dryRun || opts.yes;
-    const result = prune(store, { keep: opts.keep, dryRun: !confirmed });
+    const result = store.prune({ keep: opts.keep, dryRun: !confirmed });
     if (confirmed) {
       outputJson(result);
     } else {

--- a/src/memory/prune.ts
+++ b/src/memory/prune.ts
@@ -31,8 +31,8 @@
 
 import path from "node:path";
 import { hashContent, hashSourceFile } from "../sources.js";
+import type { Db } from "./db.js";
 import { readBlobsAtRefs, resolveGitTopLevel, resolveRef } from "./git.js";
-import type { MemoryStore } from "./store.js";
 
 export interface PruneOptions {
   /** Preserve refs. Must be non-empty. Each must resolve via git rev-parse. */
@@ -61,16 +61,18 @@ function sqlPlaceholders(n: number): string {
   return Array(n).fill("?").join(",");
 }
 
-export function prune(store: MemoryStore, options: PruneOptions): PruneResult {
+// Takes `db` + `sourceRoot` directly instead of a `MemoryStore`. Prune
+// needs read-write SQL and filesystem access but nothing that lives on
+// the store's public API; threading the primitives keeps MemoryStore's
+// surface narrow (no `getDb`/`getSourceRoot` escape hatches). The CLI
+// caller already has both from the composition root.
+export function prune(db: Db, sourceRoot: string, options: PruneOptions): PruneResult {
   const { keep, dryRun = false } = options;
   if (!keep || keep.length === 0) {
     throw new Error(
       "memory prune requires at least one --keep <ref>. There is no default preserve set.",
     );
   }
-
-  const sourceRoot = store.getSourceRoot();
-  const db = store.getDb();
 
   const gitRoot = resolveGitTopLevel(sourceRoot);
   if (!gitRoot) {

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import { hashSourceFile } from "../sources.js";
 import type { Db } from "./db.js";
 import { computeStatus, countNeighbors, countValidForEntity, getNeighbors } from "./enrichment.js";
+import { type PruneOptions, type PruneResult, prune as pruneExternal } from "./prune.js";
 import {
   createStalenessCache,
   getStalePropositionIds,
@@ -107,15 +108,15 @@ export class MemoryStore {
     this.sourceRoot = sourceRoot;
   }
 
-  // `prune` lives outside this class (content-reachability needs git
-  // subprocesses; MemoryStore stays SQLite-only). The getters below
-  // are a deliberate narrow window for that caller — not a general
-  // "expose internals" pattern.
-  getDb(): Db {
-    return this.db;
-  }
-  getSourceRoot(): string {
-    return this.sourceRoot;
+  // Thin delegation to the standalone `prune` function. The prune
+  // implementation lives outside this class because content-reachability
+  // needs git subprocesses (MemoryStore stays SQLite-only), but the
+  // wrapper lets callers invoke it through the public surface so we
+  // don't have to expose `getDb` / `getSourceRoot` escape hatches on
+  // the class. Kept as a one-line method to keep the subprocess logic
+  // off the MemoryStore type.
+  prune(options: PruneOptions): PruneResult {
+    return pruneExternal(this.db, this.sourceRoot, options);
   }
 
   // Idempotent — CLI paths that `process.exit` mid-command want to

--- a/test/memory-prune.test.ts
+++ b/test/memory-prune.test.ts
@@ -4,8 +4,25 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { openDatabase } from "../src/memory/db.js";
-import { prune } from "../src/memory/prune.js";
 import { MemoryStore } from "../src/memory/store.js";
+
+/**
+ * Test-side read helper. The prior tests reached into `store.getDb()`
+ * to run verification SQL against `proposition_sources`; that escape
+ * hatch is gone, so we open a second short-lived db handle to the same
+ * file. WAL mode lets multiple readers coexist.
+ */
+function readPropSources(dbPath: string): Array<{ proposition_id: string; file_path: string }> {
+  const db = openDatabase(dbPath);
+  try {
+    return db.prepare("SELECT proposition_id, file_path FROM proposition_sources").all() as Array<{
+      proposition_id: string;
+      file_path: string;
+    }>;
+  } finally {
+    db.close();
+  }
+}
 
 function git(cwd: string, ...args: string[]): string {
   const res = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf-8" });
@@ -32,11 +49,13 @@ function commitAll(dir: string, msg: string): string {
 
 describe("memory prune (content-reachability)", () => {
   let dir: string;
+  let dbPath: string;
   let store: MemoryStore;
 
   beforeEach(() => {
     dir = createGitDir();
-    store = new MemoryStore(openDatabase(path.join(dir, "memory.db")), dir);
+    dbPath = path.join(dir, "memory.db");
+    store = new MemoryStore(openDatabase(dbPath), dir);
   });
 
   afterEach(() => {
@@ -46,27 +65,18 @@ describe("memory prune (content-reachability)", () => {
 
   describe("validation", () => {
     it("throws when keep list is empty", () => {
-      expect(() => prune(store, { keep: [] })).toThrow(/requires at least one --keep/i);
+      expect(() => store.prune({ keep: [] })).toThrow(/requires at least one --keep/i);
     });
 
     it("hard-errors on unresolvable keep ref without touching the db", () => {
       fs.writeFileSync(path.join(dir, "a.ts"), "x");
       commitAll(dir, "add a");
       store.emit([{ content: "a", entities: ["A"], sources: ["a.ts"] }]);
-      const before = (
-        store.getDb().prepare("SELECT COUNT(*) as c FROM proposition_sources").get() as {
-          c: number;
-        }
-      ).c;
+      const before = readPropSources(dbPath).length;
 
-      expect(() => prune(store, { keep: ["does-not-exist"] })).toThrow(/does-not-exist/);
+      expect(() => store.prune({ keep: ["does-not-exist"] })).toThrow(/does-not-exist/);
 
-      const after = (
-        store.getDb().prepare("SELECT COUNT(*) as c FROM proposition_sources").get() as {
-          c: number;
-        }
-      ).c;
-      expect(after).toBe(before);
+      expect(readPropSources(dbPath).length).toBe(before);
     });
 
     it("hard-errors when source root is outside a git checkout", () => {
@@ -74,7 +84,7 @@ describe("memory prune (content-reachability)", () => {
       fs.writeFileSync(path.join(nonGit, "a.ts"), "x");
       const s = new MemoryStore(openDatabase(path.join(nonGit, "memory.db")), nonGit);
       s.emit([{ content: "a", entities: ["A"], sources: ["a.ts"] }]);
-      expect(() => prune(s, { keep: ["main"] })).toThrow(/git checkout/i);
+      expect(() => s.prune({ keep: ["main"] })).toThrow(/git checkout/i);
       s.close();
       fs.rmSync(nonGit, { recursive: true, force: true });
     });
@@ -86,7 +96,7 @@ describe("memory prune (content-reachability)", () => {
       commitAll(dir, "v1");
       store.emit([{ content: "a is v1", entities: ["A"], sources: ["a.ts"] }]);
       // File still v1 on disk.
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(0);
     });
 
@@ -99,7 +109,7 @@ describe("memory prune (content-reachability)", () => {
       fs.writeFileSync(path.join(dir, "a.ts"), "v2");
       commitAll(dir, "v2");
       // Disk is now v2, but preserve-me still points at v1.
-      const result = prune(store, { keep: ["preserve-me"] });
+      const result = store.prune({ keep: ["preserve-me"] });
       expect(result.rows_pruned).toBe(0);
     });
 
@@ -114,13 +124,12 @@ describe("memory prune (content-reachability)", () => {
       git(dir, "add", "a.ts");
       git(dir, "-c", "commit.gpgsign=false", "commit", "-q", "--amend", "--no-edit");
 
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(1);
       expect(result.propositions_hard_deleted).toBe(1);
       expect(result.entities_orphaned).toBe(1);
 
-      const remaining = store.getDb().prepare("SELECT * FROM proposition_sources").all();
-      expect(remaining).toHaveLength(0);
+      expect(readPropSources(dbPath)).toHaveLength(0);
     });
 
     it("preserves rows across squash merge (rebase/squash-robust)", () => {
@@ -142,7 +151,7 @@ describe("memory prune (content-reachability)", () => {
       // Now on main with the feature content, but original feature
       // commit SHA is orphaned. Row's content_hash matches
       // main:a.ts content → preserved.
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(0);
     });
 
@@ -158,7 +167,7 @@ describe("memory prune (content-reachability)", () => {
       git(dir, "checkout", "-q", "main");
       git(dir, "branch", "-q", "-D", "experiment");
       // Content "abandoned-experiment" lives nowhere reachable from main.
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(1);
     });
 
@@ -172,7 +181,7 @@ describe("memory prune (content-reachability)", () => {
       git(dir, "rm", "-q", "scratch.ts");
       commitAll(dir, "remove scratch");
 
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(1);
     });
 
@@ -188,7 +197,7 @@ describe("memory prune (content-reachability)", () => {
       // triggers for paths stored relative to sourceRoot but outside
       // gitRoot when sourceRoot ≠ gitRoot. Covered implicitly by the
       // "disk matches → preserved" path above; no additional assert.
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(0);
     });
   });
@@ -208,15 +217,11 @@ describe("memory prune (content-reachability)", () => {
       git(dir, "branch", "-q", "-D", "side");
       // a.ts on main = "a-main"; row's hash for a.ts is "a-side-draft" → prune that row.
       // b.ts on main = "b-stable"; row's hash for b.ts is "b-stable" → preserve that row.
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(1);
       expect(result.propositions_hard_deleted).toBe(0);
 
-      const remaining = store
-        .getDb()
-        .prepare("SELECT file_path FROM proposition_sources")
-        .all() as Array<{ file_path: string }>;
-      expect(remaining.map((r) => r.file_path)).toEqual(["b.ts"]);
+      expect(readPropSources(dbPath).map((r) => r.file_path)).toEqual(["b.ts"]);
     });
   });
 
@@ -229,7 +234,7 @@ describe("memory prune (content-reachability)", () => {
 
       // Disk matches, so preserved regardless of ref. Exercises path
       // separator handling that would otherwise break on Windows.
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(0);
     });
   });
@@ -253,11 +258,10 @@ describe("memory prune (content-reachability)", () => {
       git(dir, "add", ".");
       git(dir, "-c", "commit.gpgsign=false", "commit", "-q", "--amend", "--no-edit");
 
-      const result = prune(store, { keep: ["main"] });
+      const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(2);
 
-      const rows = store.getDb().prepare("SELECT * FROM proposition_sources").all();
-      expect(rows).toHaveLength(0);
+      expect(readPropSources(dbPath)).toHaveLength(0);
     });
   });
 
@@ -270,12 +274,11 @@ describe("memory prune (content-reachability)", () => {
       git(dir, "add", "a.ts");
       git(dir, "-c", "commit.gpgsign=false", "commit", "-q", "--amend", "--no-edit");
 
-      const plan = prune(store, { keep: ["main"], dryRun: true });
+      const plan = store.prune({ keep: ["main"], dryRun: true });
       expect(plan.dry_run).toBe(true);
       expect(plan.rows_pruned).toBe(1);
 
-      const rows = store.getDb().prepare("SELECT * FROM proposition_sources").all();
-      expect(rows).toHaveLength(1);
+      expect(readPropSources(dbPath)).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- MemoryStore had two getters (`getDb` / `getSourceRoot`) that existed exclusively so the external `prune` function could reach past the class. The class comment conceded the tension ("deliberate narrow window for that caller — not a general 'expose internals' pattern") but the public API already said the opposite.
- `prune` now takes `(db, sourceRoot, options)` directly — a pure function over primitives, no MemoryStore coupling.
- `MemoryStore.prune(options)` is a one-line delegation so CLI callers (which hold the store but not the raw primitives) still invoke prune through the public surface. Subprocess logic stays external; only the wrapper lives on the class.
- `getDb()` / `getSourceRoot()` are removed.

Tests that used `store.getDb()` for direct SQL verification now use a short-lived second db handle via `openDatabase` (WAL mode allows multiple readers).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 703 pass (no net new tests; existing prune tests updated to `store.prune(...)` + the `readPropSources` helper)

Closes #105

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>