### PR TITLE
refactor(memory): dedupe hashFile + resolveEntity kind-reconcile

### DIFF
--- a/docs/debt.md
+++ b/docs/debt.md
@@ -14,6 +14,6 @@ Flat list. No categories, no status column, no prioritization. Delete entries wh
 
 ## Entries
 
-- `src/memory/staleness.ts:~32` / `src/memory/prune.ts:~60,~153` — `readFileSync(path, "utf-8")` and `bytes.toString("utf-8")` coerce non-UTF-8 bytes to U+FFFD before hashing, making hashes meaningless for binary source files. Inherited across the whole memory system (emit, staleness, prune); fixing only one site would create inconsistency. Needs a coordinated switch to raw-byte hashing end-to-end.
+- `src/sources.ts` (`hashSourceFile`) / `src/memory/prune.ts:~150` (`bytes.toString("utf-8")`) — the UTF-8 coercion corrupts non-UTF-8 bytes to U+FFFD before hashing, so hashes on binary source files are meaningless. The on-disk hashing is now one helper; the binary-safe fix is switching it + the `cat-file` bytes-to-hash bridge in prune.ts to raw-byte hashing end-to-end.
 - `src/memory/git.ts:~80-120` — hand-rolled parser for `git cat-file --batch` output. Format is stable and we only ever request blobs, so safe today; if we ever ask for trees/commits or git adds header fields, silent mis-threading. Swap to per-spec `git show` (simpler, slower) or a library if this becomes a liability.
 - `src/config.ts:~120` — `memory.prune.keep` concatenates across config files without dedup, so `[main]` in project + `[main]` in local yields `[main, main]`. Harmless (duplicates resolve to the same SHA) but ugly in `freelance config show`. Dedup with a `Set`.

--- a/src/memory/prune.ts
+++ b/src/memory/prune.ts
@@ -29,9 +29,8 @@
  *     hard error (prune is a git-scoped operation).
  */
 
-import fs from "node:fs";
 import path from "node:path";
-import { hashContent } from "../sources.js";
+import { hashContent, hashSourceFile } from "../sources.js";
 import { readBlobsAtRefs, resolveGitTopLevel, resolveRef } from "./git.js";
 import type { MemoryStore } from "./store.js";
 
@@ -55,14 +54,6 @@ interface RowMeta {
   proposition_id: string;
   file_path: string;
   content_hash: string;
-}
-
-function hashFileOnDisk(absPath: string): string | null {
-  try {
-    return hashContent(fs.readFileSync(absPath, "utf-8"));
-  } catch {
-    return null;
-  }
 }
 
 /** `"?, ?, ?"` for `n=3`. Used when binding variadic `IN (...)` clauses. */
@@ -127,7 +118,7 @@ export function prune(store: MemoryStore, options: PruneOptions): PruneResult {
   const liveHashes = new Map<string, Set<string>>();
   for (const fp of distinctPaths) {
     const set = new Set<string>();
-    const diskHash = hashFileOnDisk(path.resolve(sourceRoot, fp));
+    const diskHash = hashSourceFile(path.resolve(sourceRoot, fp));
     if (diskHash !== null) set.add(diskHash);
     liveHashes.set(fp, set);
   }

--- a/src/memory/staleness.ts
+++ b/src/memory/staleness.ts
@@ -15,9 +15,8 @@
  * lets it garbage-collect when the call returns.
  */
 
-import fs from "node:fs";
 import path from "node:path";
-import { hashContent } from "../sources.js";
+import { hashSourceFile } from "../sources.js";
 import type { Db } from "./db.js";
 
 export interface StalenessCache {
@@ -28,14 +27,6 @@ export function createStalenessCache(): StalenessCache {
   return { hashes: new Map() };
 }
 
-function hashFile(filePath: string): string | null {
-  try {
-    return hashContent(fs.readFileSync(filePath, "utf-8"));
-  } catch {
-    return null;
-  }
-}
-
 function getCurrentFileHash(
   sourceRoot: string,
   cache: StalenessCache,
@@ -44,7 +35,7 @@ function getCurrentFileHash(
   const cached = cache.hashes.get(filePath);
   if (cache.hashes.has(filePath)) return cached ?? null;
   const resolvedPath = path.resolve(sourceRoot, filePath);
-  const hash = hashFile(resolvedPath);
+  const hash = hashSourceFile(resolvedPath);
   cache.hashes.set(filePath, hash);
   return hash;
 }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -12,9 +12,8 @@
  */
 
 import crypto from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
-import { hashContent } from "../sources.js";
+import { hashSourceFile } from "../sources.js";
 import type { Db } from "./db.js";
 import { computeStatus, countValidForEntity, getNeighbors } from "./enrichment.js";
 import {
@@ -45,14 +44,6 @@ function generateId(): string {
 
 function now(): string {
   return new Date().toISOString();
-}
-
-function hashFile(filePath: string): string | null {
-  try {
-    return hashContent(fs.readFileSync(filePath, "utf-8"));
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -219,7 +210,7 @@ export class MemoryStore {
       // at emit time; if the file can't be read, the emit fails for this prop.
       for (const sourcePath of prop.sources) {
         const { storedPath, resolvedPath } = this.prepareSourcePath(sourcePath);
-        const hash = hashFile(resolvedPath);
+        const hash = hashSourceFile(resolvedPath);
         if (hash === null) {
           throw new Error(`Cannot read source file "${sourcePath}" during emit.`);
         }
@@ -270,16 +261,7 @@ export class MemoryStore {
       | EntityRow
       | undefined;
     if (exact) {
-      if (kind && exact.kind && exact.kind !== kind) {
-        warnings.push({
-          type: "entity_kind_conflict",
-          entity: exact.name,
-          existingKind: exact.kind,
-          providedKind: kind,
-        });
-      } else if (kind && !exact.kind) {
-        this.db.prepare("UPDATE entities SET kind = ? WHERE id = ?").run(kind, exact.id);
-      }
+      this.reconcileKind(exact, kind, warnings);
       return { id: exact.id, name: exact.name, resolution: "exact" };
     }
 
@@ -288,16 +270,7 @@ export class MemoryStore {
       .prepare("SELECT id, name, kind FROM entities WHERE LOWER(TRIM(name)) = ?")
       .get(normalized) as EntityRow | undefined;
     if (normMatch) {
-      if (kind && normMatch.kind && normMatch.kind !== kind) {
-        warnings.push({
-          type: "entity_kind_conflict",
-          entity: normMatch.name,
-          existingKind: normMatch.kind,
-          providedKind: kind,
-        });
-      } else if (kind && !normMatch.kind) {
-        this.db.prepare("UPDATE entities SET kind = ? WHERE id = ?").run(kind, normMatch.id);
-      }
+      this.reconcileKind(normMatch, kind, warnings);
       return { id: normMatch.id, name: normMatch.name, resolution: "normalized" };
     }
 
@@ -307,6 +280,33 @@ export class MemoryStore {
       .run(id, name, kind ?? null, now());
 
     return { id, name, resolution: "created" };
+  }
+
+  /**
+   * First-wins kind policy: if the existing entity has a kind that
+   * disagrees with the provided one, surface a warning but keep the
+   * stored kind. If the existing entity has no kind and one is
+   * provided, backfill. Either branch is a no-op when the caller
+   * didn't specify `kind`.
+   */
+  private reconcileKind(
+    existing: EntityRow,
+    kind: string | undefined,
+    warnings: EmitWarning[],
+  ): void {
+    if (!kind) return;
+    if (existing.kind && existing.kind !== kind) {
+      warnings.push({
+        type: "entity_kind_conflict",
+        entity: existing.name,
+        existingKind: existing.kind,
+        providedKind: kind,
+      });
+      return;
+    }
+    if (!existing.kind) {
+      this.db.prepare("UPDATE entities SET kind = ? WHERE id = ?").run(kind, existing.id);
+    }
   }
 
   // --- Entity lookup ---

--- a/src/sources.ts
+++ b/src/sources.ts
@@ -32,6 +32,21 @@ export function hashContent(content: string): string {
     .substring(0, 16);
 }
 
+/**
+ * Hash an on-disk source file by absolute path. Returns null when the
+ * file is missing or unreadable — every memory-side caller (emit,
+ * staleness, prune) treats "can't read the file" as "no live hash for
+ * this path right now", not as an error. Read known-UTF-8 today; the
+ * binary-safe switch is tracked in docs/debt.md.
+ */
+export function hashSourceFile(absPath: string): string | null {
+  try {
+    return hashContent(fs.readFileSync(absPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
 // --- Types ---
 
 interface SourceRef {


### PR DESCRIPTION
## Summary

Two small consolidation passes in the memory module.

- **#103 (hashFile dedup):** The "read file, hash content, swallow errors as null" helper existed three times — identical bodies in `store.ts`, `staleness.ts`, and `prune.ts`. Now one `hashSourceFile` in `src/sources.ts` next to `hashContent`. This clears the prerequisite that the debt entry on binary-safe hashing was blocked on; the debt entry is updated to point at the new single site.
- **#104 (resolveEntity dedup):** The kind-reconcile logic (conflict-warning vs backfill) was inlined in both the exact-name and normalized-name match branches of `resolveEntity`. Extracted to a private `reconcileKind(row, kind, warnings)` helper — each branch now calls it and returns.

Both are pure refactors; no behavior change.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 703 pass; existing `entityKinds` test suite covers the reconcile paths (no new tests needed, the extraction doesn't change branches)

Closes #103
Closes #104

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>