### PR TITLE
feat(cli): unify error envelope across in-band + thrown paths (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Unified CLI error envelope.** Every error — whether a gate-block
+  on `advance` (in-band) or a thrown `EngineError` (structural) —
+  now carries the same wire shape: `{ isError: true, error: { code,
+  message, kind } }` where `kind` is `"blocked"` (traversal is fine;
+  fix context and retry) or `"structural"` (stop and report). The
+  in-band gate-block response still carries `status: "error"`,
+  `currentNode`, `validTransitions`, and `context` on top of the
+  envelope so a skill can decide the next move without another
+  round-trip; `reason` stays populated (duplicates `error.message`)
+  for pre-#95 readers. Four new codes surface gate blocks with the
+  same stability promise as the others — `WAIT_BLOCKING`,
+  `RETURN_SCHEMA_VIOLATION`, `VALIDATION_FAILED`,
+  `EDGE_CONDITION_NOT_MET`, all grouped under the `BLOCKED`
+  category that maps to exit 2. Skills no longer branch on two
+  shapes; they read `error.kind` and the exit code. See issue #95.
 - **All CLI verbs are JSON-only (BREAKING).** Every handler —
   `status`, `start`, `advance`, `context set`, `meta set`, `inspect`,
   `reset`, `memory *`, `init`, `validate`, `visualize`, `config`,

--- a/plugins/freelance/skills/freelance/SKILL.md
+++ b/plugins/freelance/skills/freelance/SKILL.md
@@ -81,17 +81,30 @@ To preview the current node's edges without advancing, call `freelance advance` 
 
 ## Error shape on stdout
 
-On failure, stdout carries `{ "isError": true, "error": { "code": "...", "message": "..." } }`. Common codes:
+Every error — whether a gate-block on `advance` or a structural failure anywhere — carries the same envelope:
 
-- `EDGE_NOT_FOUND` — the edge label doesn't exist on the current node. Exit 4. Check `validTransitions`.
-- `NO_EDGES` — the current node is terminal. Exit 2.
-- `TRAVERSAL_NOT_FOUND` / `NO_TRAVERSAL` / `AMBIGUOUS_TRAVERSAL` — traversal id issue. Exit 4 or 5.
-- `STRICT_CONTEXT_VIOLATION` — tried to write a key the graph's context schema doesn't declare. Exit 5.
-- `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` — write exceeds the byte cap. Exit 5. Shrink the value or split it across calls.
-- `REQUIRED_META_MISSING` — `start` without required meta keys. Exit 5. Rerun with `--meta k=v`.
-- `HOOK_FAILED` / `HOOK_IMPORT_FAILED` / `HOOK_BAD_SHAPE` — an `onEnter` hook is broken. Exit 1. Surface to the user; don't loop.
+```json
+{
+  "isError": true,
+  "error": { "code": "...", "message": "...", "kind": "blocked" | "structural" }
+}
+```
 
-A **blocked advance** (exit 2) returns a normal response shape with `isError: true` and `status: "error"`, carrying `validTransitions` so you can see what's still possible. Distinct from the structured-error shape above.
+Branch on `error.kind` before anything else:
+
+- `"blocked"` — the traversal is fine; the last op can't proceed given current state. Fix context and retry. Exit 2. Response carries extra fields (`status: "error"`, `currentNode`, `validTransitions`, `context`) so you can pick a different edge or adjust context without another round-trip.
+- `"structural"` — something's wrong (bad graph id, unknown edge, malformed input, broken hook). Retrying won't help; report to the user.
+
+Common codes:
+
+- `WAIT_BLOCKING` / `RETURN_SCHEMA_VIOLATION` / `VALIDATION_FAILED` / `EDGE_CONDITION_NOT_MET` — gate blocks on `advance`. Kind `"blocked"`. Exit 2. Read the message and `validTransitions` to decide the next move.
+- `NO_EDGES` — the current node is terminal. Kind `"blocked"`. Exit 2.
+- `EDGE_NOT_FOUND` — the edge label doesn't exist on the current node. Kind `"structural"`. Exit 4. Check `validTransitions`.
+- `TRAVERSAL_NOT_FOUND` / `NO_TRAVERSAL` / `AMBIGUOUS_TRAVERSAL` — traversal id issue. Kind `"structural"`. Exit 4 or 5.
+- `STRICT_CONTEXT_VIOLATION` — tried to write a key the graph's context schema doesn't declare. Kind `"structural"`. Exit 5.
+- `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` — write exceeds the byte cap. Kind `"structural"`. Exit 5. Shrink the value or split across calls.
+- `REQUIRED_META_MISSING` — `start` without required meta keys. Kind `"structural"`. Exit 5. Rerun with `--meta k=v`.
+- `HOOK_FAILED` / `HOOK_IMPORT_FAILED` / `HOOK_BAD_SHAPE` — an `onEnter` hook is broken. Kind `"structural"`. Exit 1. Surface to the user; don't loop.
 
 ## Recovery from context compaction
 

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -13,7 +13,7 @@ import { EC, EngineError } from "../errors.js";
 import type { MemoryStore } from "../memory/index.js";
 import { prune } from "../memory/prune.js";
 import type { PropositionShape } from "../memory/types.js";
-import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js";
+import { EXIT, errorEnvelope, handleRuntimeError as handleError, outputJson } from "./output.js";
 
 export function memoryStatus(store: MemoryStore): void {
   try {
@@ -153,13 +153,7 @@ export function memoryPrune(
   // before every exit. MemoryStore.close is idempotent, so the
   // caller's finally is a harmless no-op after this.
   if (!opts.keep || opts.keep.length === 0) {
-    outputJson({
-      isError: true,
-      error: {
-        code: "MISSING_KEEP",
-        message: "memory prune requires --keep <ref> (repeatable).",
-      },
-    });
+    outputJson(errorEnvelope("MISSING_KEEP", "memory prune requires --keep <ref> (repeatable)."));
     store.close();
     process.exit(EXIT.INVALID_INPUT);
   }
@@ -175,11 +169,7 @@ export function memoryPrune(
     } else {
       outputJson({
         ...result,
-        isError: true,
-        error: {
-          code: "CONFIRM_REQUIRED",
-          message: "Refusing to delete without --yes or --dry-run.",
-        },
+        ...errorEnvelope("CONFIRM_REQUIRED", "Refusing to delete without --yes or --dry-run."),
       });
       store.close();
       process.exit(EXIT.INVALID_INPUT);
@@ -200,13 +190,12 @@ export function memoryPrune(
  */
 export function memoryReset(dbPath: string, opts: { confirm?: boolean }): void {
   if (!opts.confirm) {
-    outputJson({
-      isError: true,
-      error: {
-        code: "CONFIRM_REQUIRED",
-        message: "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
-      },
-    });
+    outputJson(
+      errorEnvelope(
+        "CONFIRM_REQUIRED",
+        "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
+      ),
+    );
     process.exit(EXIT.INVALID_INPUT);
   }
   const targets = [dbPath, `${dbPath}-shm`, `${dbPath}-wal`];

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -4,6 +4,7 @@ import {
   ENGINE_ERROR_CODES,
   type EngineErrorCategory,
   type EngineErrorCode,
+  errorKind,
 } from "../error-codes.js";
 import { EngineError } from "../errors.js";
 
@@ -57,23 +58,21 @@ export function mapEngineErrorToExit(code: EngineErrorCode): number {
 
 /**
  * Write a structured error to stdout and return the exit code. Payload is
- *   { isError: true, error: { code, message } }
- * — `isError` at the top level so a shell consumer can one-pass-parse
- * without checking exit codes, and `error.code` is what
- * `mapEngineErrorToExit` branches on. For unknown throws (non-EngineError),
- * `code` is `INTERNAL`.
+ *   { isError: true, error: { code, message, kind } }
+ * where `kind` is "blocked" or "structural" per `errorKind`. Top-level
+ * `isError` lets a shell consumer one-pass-parse without exit-code
+ * inspection, `error.code` is what `mapEngineErrorToExit` branches on,
+ * and `error.kind` is the wire-level recover-vs-stop discriminator
+ * unified with in-band gate-block responses (see #95). For unknown
+ * throws (non-EngineError), `code` is `INTERNAL`.
  */
 export function outputError(e: unknown): number {
   if (e instanceof EngineError) {
-    process.stdout.write(
-      `${JSON.stringify({ isError: true, error: { code: e.code, message: e.message } }, null, 2)}\n`,
-    );
+    outputJson(errorEnvelope(e.code, e.message));
     return mapEngineErrorToExit(e.code);
   }
   const message = e instanceof Error ? e.message : String(e);
-  process.stdout.write(
-    `${JSON.stringify({ isError: true, error: { code: "INTERNAL", message } }, null, 2)}\n`,
-  );
+  outputJson(errorEnvelope("INTERNAL", message));
   return EXIT.INTERNAL;
 }
 
@@ -92,6 +91,23 @@ export function outputError(e: unknown): number {
 export function handleRuntimeError(e: unknown): never {
   if (e instanceof Error && e.message === "process.exit") throw e;
   process.exit(outputError(e));
+}
+
+/**
+ * Build the unified error envelope as a plain object (no stdout write,
+ * no exit). Used by CLI handlers that need to `outputJson` a payload
+ * augmented with the envelope — e.g. `memory prune` returns the prune
+ * plan alongside `isError: true` so the caller sees the blast radius
+ * and the refusal in one response. `kind` is derived via `errorKind`.
+ */
+export function errorEnvelope(
+  code: string,
+  message: string,
+): {
+  isError: true;
+  error: { code: string; message: string; kind: ReturnType<typeof errorKind> };
+} {
+  return { isError: true, error: { code, message, kind: errorKind(code) } };
 }
 
 // Global CLI state — set via setCli() from program.ts before any
@@ -143,18 +159,20 @@ export function error(msg: string): void {
 
 /**
  * Emit a structured fatal error to stdout and exit with the given code.
- * Shape matches `outputError`: `{ isError: true, error: { code, message } }`.
- * Callers pass an exit code that categorizes the failure (see EXIT);
- * `code` defaults to "FATAL" and can be overridden for specificity.
+ * Shape matches `outputError`: `{ isError: true, error: { code,
+ * message, kind } }`. Callers pass an exit code that categorizes the
+ * failure (see EXIT); `code` defaults to "FATAL" and can be overridden
+ * for specificity. `kind` is derived via `errorKind` — any
+ * `fatal()`-produced error whose code isn't in `ENGINE_ERROR_CODES.BLOCKED`
+ * falls through to `"structural"`, which is the right default for
+ * authoring-time and setup failures.
  */
 export function fatal(
   msg: string,
   exitCode: number = EXIT.INTERNAL,
   code: string = "FATAL",
 ): never {
-  process.stdout.write(
-    `${JSON.stringify({ isError: true, error: { code, message: msg } }, null, 2)}\n`,
-  );
+  outputJson(errorEnvelope(code, msg));
   process.exit(exitCode);
 }
 

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -13,7 +13,7 @@
 import { EC, EngineError } from "../errors.js";
 import type { TraversalStore } from "../state/index.js";
 import type { InspectPositionResult } from "../types.js";
-import { EXIT, handleRuntimeError as handleError, outputJson } from "./output.js";
+import { EXIT, errorEnvelope, handleRuntimeError as handleError, outputJson } from "./output.js";
 
 /**
  * Shared primitive for CLI flags that accept `key=value` pairs. Splits on
@@ -234,10 +234,7 @@ export function traversalReset(
   opts?: { confirm?: boolean },
 ): void {
   if (!opts?.confirm) {
-    outputJson({
-      isError: true,
-      error: { code: "CONFIRM_REQUIRED", message: "must pass --confirm to reset a traversal." },
-    });
+    outputJson(errorEnvelope("CONFIRM_REQUIRED", "must pass --confirm to reset a traversal."));
     process.exit(EXIT.INVALID_INPUT);
   }
   try {

--- a/src/engine/gates.ts
+++ b/src/engine/gates.ts
@@ -1,3 +1,4 @@
+import type { GateBlockCode } from "../error-codes.js";
 import { evaluate } from "../evaluator.js";
 import type { AdvanceErrorResult, NodeDefinition, SessionState, SourceBinding } from "../types.js";
 import { cloneContext } from "./helpers.js";
@@ -5,9 +6,17 @@ import { validateReturnSchema } from "./returns.js";
 import { evaluateTransitions } from "./transitions.js";
 import { checkWaitTimeout, evaluateWaitConditions } from "./wait.js";
 
+/**
+ * Build the unified in-band gate-block envelope. Shape matches the
+ * thrown-error envelope (`isError: true` + `error: { code, message,
+ * kind }`) so the CLI writes one wire format for every advance
+ * failure — see issue #95. `reason` duplicates `error.message` for
+ * pre-#95 readers; new code should read `error.message`.
+ */
 function makeAdvanceError(
   currentNode: string,
-  reason: string,
+  code: GateBlockCode,
+  message: string,
   nodeDef: NodeDefinition,
   context: Record<string, unknown>,
   graphSources?: readonly SourceBinding[],
@@ -15,8 +24,9 @@ function makeAdvanceError(
   return {
     status: "error",
     isError: true,
+    error: { code, message, kind: "blocked" },
     currentNode,
-    reason,
+    reason: message,
     validTransitions: evaluateTransitions(nodeDef, context),
     context: cloneContext(context),
     ...(graphSources?.length ? { graphSources } : {}),
@@ -41,6 +51,7 @@ export function checkWaitBlocking(
   const unsatisfied = waitConditions.filter((w) => !w.satisfied);
   return makeAdvanceError(
     session.currentNode,
+    "WAIT_BLOCKING",
     `Waiting for external signals: ${unsatisfied.map((w) => `${w.key} (${w.type})`).join(", ")}`,
     nodeDef,
     session.context,
@@ -61,6 +72,7 @@ export function checkReturnSchema(
 
   return makeAdvanceError(
     session.currentNode,
+    "RETURN_SCHEMA_VIOLATION",
     `Return schema violation: ${violation}`,
     nodeDef,
     session.context,
@@ -86,6 +98,7 @@ export function checkValidations(
     if (!result) {
       return makeAdvanceError(
         session.currentNode,
+        "VALIDATION_FAILED",
         `Validation failed: ${v.message}`,
         nodeDef,
         session.context,
@@ -114,6 +127,7 @@ export function checkEdgeCondition(
 
   return makeAdvanceError(
     session.currentNode,
+    "EDGE_CONDITION_NOT_MET",
     `Edge "${edgeLabel}" condition not met: ${edgeCondition}`,
     nodeDef,
     session.context,

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -13,6 +13,24 @@
  * is always safe.
  */
 
+/**
+ * Codes emitted in-band from the engine's `advance` return (see
+ * `AdvanceErrorResult` in `types.ts` + `src/engine/gates.ts`) — not
+ * thrown. Exported as its own tuple so `AdvanceErrorResult.error.code`
+ * can be typed directly from the catalog instead of restating the
+ * union; all four are also merged into `ENGINE_ERROR_CODES.BLOCKED`
+ * below so they share exit mapping + `kind` classification with
+ * thrown BLOCKED-category codes (NO_EDGES, STACK_DEPTH_EXCEEDED).
+ */
+export const GATE_BLOCK_CODES = [
+  "WAIT_BLOCKING",
+  "RETURN_SCHEMA_VIOLATION",
+  "VALIDATION_FAILED",
+  "EDGE_CONDITION_NOT_MET",
+] as const;
+
+export type GateBlockCode = (typeof GATE_BLOCK_CODES)[number];
+
 export const ENGINE_ERROR_CODES = {
   NOT_FOUND: ["TRAVERSAL_NOT_FOUND", "GRAPH_NOT_FOUND", "EDGE_NOT_FOUND", "NO_TRAVERSAL"],
   INVALID_INPUT: [
@@ -35,7 +53,7 @@ export const ENGINE_ERROR_CODES = {
     "INVALID_META",
     "INVALID_SHAPE",
   ],
-  BLOCKED: ["NO_EDGES", "STACK_DEPTH_EXCEEDED"],
+  BLOCKED: ["NO_EDGES", "STACK_DEPTH_EXCEEDED", ...GATE_BLOCK_CODES],
   // Hook wiring failures (missing export, bad shape, import error,
   // timeout). Retrying with new context won't repair a broken hook
   // script — surface as INTERNAL so the skill reports instead of loops.
@@ -52,6 +70,37 @@ export const ENGINE_ERROR_CODES = {
 export type EngineErrorCategory = keyof typeof ENGINE_ERROR_CODES;
 
 export type EngineErrorCode = (typeof ENGINE_ERROR_CODES)[EngineErrorCategory][number];
+
+/**
+ * Wire-level discriminator carried on every CLI error envelope. A
+ * two-way split distinct from (and derived from) `EngineErrorCategory`:
+ *
+ *   - `"blocked"` — the traversal is fine; the caller's last
+ *     operation can't proceed given current state. Fix context and
+ *     retry the same edge.
+ *   - `"structural"` — something structural is wrong (missing graph,
+ *     unknown edge, strict-context violation, broken hook). Retry
+ *     won't help; report to the operator.
+ *
+ * BLOCKED-category codes map to `"blocked"`; every other category
+ * maps to `"structural"`. Exit codes still encode more fine-grained
+ * actionability (NOT_FOUND vs INVALID_INPUT vs BLOCKED vs INTERNAL);
+ * `errorKind` is the one the driving skill branches on before it
+ * picks recover-or-stop.
+ */
+export type ErrorKind = "blocked" | "structural";
+
+const BLOCKED_CODES: ReadonlySet<string> = new Set<string>(ENGINE_ERROR_CODES.BLOCKED);
+
+/**
+ * Classify an error code as `"blocked"` or `"structural"`. Unknown
+ * codes (e.g. CLI-surface codes like `INVALID_CONFIG_VALUE`,
+ * `CONFIRM_REQUIRED`, `TEMPLATE_NOT_FOUND`, or an uncatalogued throw)
+ * are treated as structural — the default "stop and report" stance.
+ */
+export function errorKind(code: string): ErrorKind {
+  return BLOCKED_CODES.has(code) ? "blocked" : "structural";
+}
 
 /**
  * Symbol aliases for every code — throw sites use `EC.FOO` so
@@ -77,6 +126,10 @@ export const EC = {
   INVALID_SHAPE: "INVALID_SHAPE",
   NO_EDGES: "NO_EDGES",
   STACK_DEPTH_EXCEEDED: "STACK_DEPTH_EXCEEDED",
+  WAIT_BLOCKING: "WAIT_BLOCKING",
+  RETURN_SCHEMA_VIOLATION: "RETURN_SCHEMA_VIOLATION",
+  VALIDATION_FAILED: "VALIDATION_FAILED",
+  EDGE_CONDITION_NOT_MET: "EDGE_CONDITION_NOT_MET",
   HOOK_FAILED: "HOOK_FAILED",
   HOOK_IMPORT_FAILED: "HOOK_IMPORT_FAILED",
   HOOK_BAD_SHAPE: "HOOK_BAD_SHAPE",

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type {
   WaitOnEntry,
 } from "./schema/graph-schema.js";
 
+import type { GateBlockCode } from "./error-codes.js";
 import type { HookResolutionMap } from "./hook-resolution.js";
 import type {
   GraphDefinition,
@@ -107,9 +108,25 @@ export interface AdvanceSuccessResult {
   readonly graphSources?: readonly SourceBinding[];
 }
 
+/**
+ * Gate-blocked advance result — carried in-band on the engine's advance
+ * return, not thrown. The wire envelope matches the thrown-error shape
+ * so a skill sees one unified error format: `{ isError: true, error: {
+ * code, message, kind } }`. Blocked responses add `status: "error"`,
+ * `currentNode`, `validTransitions`, and `context` so the caller can
+ * pick a different edge or fix context and retry. `reason` duplicates
+ * `error.message` for back-compat with pre-#95 readers; new code should
+ * read `error.message`. See `error-codes.ts` for the `kind`
+ * discriminator and issue #95 for the unification rationale.
+ */
 export interface AdvanceErrorResult {
   readonly status: "error";
   readonly isError: true;
+  readonly error: {
+    readonly code: GateBlockCode;
+    readonly message: string;
+    readonly kind: "blocked";
+  };
   readonly currentNode: string;
   readonly reason: string;
   readonly validTransitions: readonly TransitionInfo[];

--- a/templates/skills/freelance/SKILL.md
+++ b/templates/skills/freelance/SKILL.md
@@ -81,17 +81,30 @@ To preview the current node's edges without advancing, call `freelance advance` 
 
 ## Error shape on stdout
 
-On failure, stdout carries `{ "isError": true, "error": { "code": "...", "message": "..." } }`. Common codes:
+Every error — whether a gate-block on `advance` or a structural failure anywhere — carries the same envelope:
 
-- `EDGE_NOT_FOUND` — the edge label doesn't exist on the current node. Exit 4. Check `validTransitions`.
-- `NO_EDGES` — the current node is terminal. Exit 2.
-- `TRAVERSAL_NOT_FOUND` / `NO_TRAVERSAL` / `AMBIGUOUS_TRAVERSAL` — traversal id issue. Exit 4 or 5.
-- `STRICT_CONTEXT_VIOLATION` — tried to write a key the graph's context schema doesn't declare. Exit 5.
-- `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` — write exceeds the byte cap. Exit 5. Shrink the value or split it across calls.
-- `REQUIRED_META_MISSING` — `start` without required meta keys. Exit 5. Rerun with `--meta k=v`.
-- `HOOK_FAILED` / `HOOK_IMPORT_FAILED` / `HOOK_BAD_SHAPE` — an `onEnter` hook is broken. Exit 1. Surface to the user; don't loop.
+```json
+{
+  "isError": true,
+  "error": { "code": "...", "message": "...", "kind": "blocked" | "structural" }
+}
+```
 
-A **blocked advance** (exit 2) returns a normal response shape with `isError: true` and `status: "error"`, carrying `validTransitions` so you can see what's still possible. Distinct from the structured-error shape above.
+Branch on `error.kind` before anything else:
+
+- `"blocked"` — the traversal is fine; the last op can't proceed given current state. Fix context and retry. Exit 2. Response carries extra fields (`status: "error"`, `currentNode`, `validTransitions`, `context`) so you can pick a different edge or adjust context without another round-trip.
+- `"structural"` — something's wrong (bad graph id, unknown edge, malformed input, broken hook). Retrying won't help; report to the user.
+
+Common codes:
+
+- `WAIT_BLOCKING` / `RETURN_SCHEMA_VIOLATION` / `VALIDATION_FAILED` / `EDGE_CONDITION_NOT_MET` — gate blocks on `advance`. Kind `"blocked"`. Exit 2. Read the message and `validTransitions` to decide the next move.
+- `NO_EDGES` — the current node is terminal. Kind `"blocked"`. Exit 2.
+- `EDGE_NOT_FOUND` — the edge label doesn't exist on the current node. Kind `"structural"`. Exit 4. Check `validTransitions`.
+- `TRAVERSAL_NOT_FOUND` / `NO_TRAVERSAL` / `AMBIGUOUS_TRAVERSAL` — traversal id issue. Kind `"structural"`. Exit 4 or 5.
+- `STRICT_CONTEXT_VIOLATION` — tried to write a key the graph's context schema doesn't declare. Kind `"structural"`. Exit 5.
+- `CONTEXT_VALUE_TOO_LARGE` / `CONTEXT_TOTAL_TOO_LARGE` — write exceeds the byte cap. Kind `"structural"`. Exit 5. Shrink the value or split across calls.
+- `REQUIRED_META_MISSING` — `start` without required meta keys. Kind `"structural"`. Exit 5. Rerun with `--meta k=v`.
+- `HOOK_FAILED` / `HOOK_IMPORT_FAILED` / `HOOK_BAD_SHAPE` — an `onEnter` hook is broken. Kind `"structural"`. Exit 1. Surface to the user; don't loop.
 
 ## Recovery from context compaction
 

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setCli } from "../src/cli/output.js";
 import {
+  traversalAdvance,
   traversalContextSet,
   traversalInspect,
   traversalInspectActive,
@@ -86,10 +87,50 @@ describe("traversalStart", () => {
     const store = createTestStore();
     try {
       await expect(traversalStart(store, "nonexistent-graph")).rejects.toThrow("process.exit");
-      const parsed = stdoutJson() as { isError: true; error: { code: string } };
+      const parsed = stdoutJson() as {
+        isError: true;
+        error: { code: string; kind: string };
+      };
       expect(parsed.isError).toBe(true);
       expect(parsed.error.code).toBe("GRAPH_NOT_FOUND");
+      expect(parsed.error.kind).toBe("structural");
       expect(exitSpy).toHaveBeenCalledWith(4); // EXIT.NOT_FOUND
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("traversalAdvance — unified error envelope on gate-block", () => {
+  it("emits error.code + kind and exits BLOCKED on edge-condition failure", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      const { traversalId } = await store.createTraversal(graphId);
+      await traversalAdvance(store, "initialized", { traversal: traversalId });
+
+      // Reset stdout so we only capture the blocked response
+      stdoutSpy.mockClear();
+
+      await expect(traversalAdvance(store, "go-left", { traversal: traversalId })).rejects.toThrow(
+        "process.exit",
+      );
+
+      const parsed = stdoutJson() as {
+        isError: true;
+        status: string;
+        error: { code: string; kind: string; message: string };
+        reason: string;
+        validTransitions: unknown[];
+      };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.status).toBe("error");
+      expect(parsed.error.code).toBe("EDGE_CONDITION_NOT_MET");
+      expect(parsed.error.kind).toBe("blocked");
+      expect(parsed.error.message).toBe(parsed.reason);
+      expect(parsed.validTransitions).toBeDefined();
+      expect(exitSpy).toHaveBeenCalledWith(2); // EXIT.BLOCKED
     } finally {
       store.close();
     }
@@ -373,9 +414,13 @@ describe("traversalReset", () => {
     const store = createTestStore();
     try {
       expect(() => traversalReset(store, undefined, {})).toThrow("process.exit");
-      const parsed = stdoutJson() as { isError: true; error: { code: string } };
+      const parsed = stdoutJson() as {
+        isError: true;
+        error: { code: string; kind: string };
+      };
       expect(parsed.isError).toBe(true);
       expect(parsed.error.code).toBe("CONFIRM_REQUIRED");
+      expect(parsed.error.kind).toBe("structural");
       expect(exitSpy).toHaveBeenCalledWith(5); // EXIT.INVALID_INPUT
     } finally {
       store.close();

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -221,6 +221,36 @@ describe("advance() — conditional edges", () => {
   });
 });
 
+describe("advance() — unified error envelope", () => {
+  it("emits error.code + kind on gate-block (validation failure)", async () => {
+    const engine = makeEngine("valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    await engine.advance("work-done");
+
+    const result = await engine.advance("approved");
+    expect(result.isError).toBe(true);
+    if (result.isError) {
+      expect(result.error.code).toBe("VALIDATION_FAILED");
+      expect(result.error.kind).toBe("blocked");
+      expect(result.error.message).toBe(result.reason);
+    }
+  });
+
+  it("emits EDGE_CONDITION_NOT_MET on edge-condition block", async () => {
+    const engine = makeEngine("valid-branching.workflow.yaml");
+    await engine.start("valid-branching");
+    await engine.advance("initialized");
+    engine.contextSet({ path: "left" });
+
+    const result = await engine.advance("go-right");
+    expect(result.isError).toBe(true);
+    if (result.isError) {
+      expect(result.error.code).toBe("EDGE_CONDITION_NOT_MET");
+      expect(result.error.kind).toBe("blocked");
+    }
+  });
+});
+
 describe("advance() — default edges", () => {
   it("default edge conditionMet is true when no conditional edge matches", async () => {
     const engine = makeEngine("valid-default-edge.workflow.yaml");

--- a/test/returns.test.ts
+++ b/test/returns.test.ts
@@ -25,6 +25,8 @@ describe("return schema — engine validation", () => {
     if (result.isError) {
       expect(result.reason).toContain("Return schema violation");
       expect(result.reason).toContain("filesChanged");
+      expect(result.error.code).toBe("RETURN_SCHEMA_VIOLATION");
+      expect(result.error.kind).toBe("blocked");
     }
   });
 

--- a/test/wait.test.ts
+++ b/test/wait.test.ts
@@ -67,6 +67,8 @@ describe("wait nodes — blocking advance", () => {
     if (result.isError) {
       expect(result.reason).toContain("Waiting for external signals");
       expect(result.reason).toContain("approved");
+      expect(result.error.code).toBe("WAIT_BLOCKING");
+      expect(result.error.kind).toBe("blocked");
     }
   });
 


### PR DESCRIPTION
## Summary

- Every CLI error — whether a gate-block on `advance` (in-band) or a thrown `EngineError` (structural) — now emits the same wire shape `{ isError: true, error: { code, message, kind } }`. Skills branch on `error.kind` (`"blocked"` vs `"structural"`) instead of parsing two shapes and snooping exit codes to disambiguate them.
- In-band gate-block responses still carry `status: "error"`, `currentNode`, `validTransitions`, and `context` on top of the unified envelope so callers can adjust context and retry without another round-trip. `reason` stays populated (duplicates `error.message`) for pre-#95 readers so existing tests and consumers don't break.
- Four new codes expose gate blocks with the same stability promise as thrown codes — `WAIT_BLOCKING`, `RETURN_SCHEMA_VIOLATION`, `VALIDATION_FAILED`, `EDGE_CONDITION_NOT_MET` — exported as `GATE_BLOCK_CODES` / `GateBlockCode` in `src/error-codes.ts` and merged into `ENGINE_ERROR_CODES.BLOCKED`, so they share the `exit 2` mapping and `kind: "blocked"` classification with the existing thrown BLOCKED-category codes.
- `errorEnvelope(code, message)` in `src/cli/output.ts` is the single envelope builder; `outputError`, `fatal`, and the ad-hoc CLI-surface refusals (`CONFIRM_REQUIRED`, `MISSING_KEEP`) all route through it to keep one serializer and one shape.

## Design notes

The rescoping comment on #95 picked the "one wire shape, two exit codes" option. `error.kind` is that wire-level discriminator, derived from the code catalog (`BLOCKED` → `"blocked"`, everything else → `"structural"`) rather than hand-maintained alongside the throw sites.

Minimal-mode fit (#81, PR #130): the envelope lives at the top level, orthogonal to the projection mode. When PR #130 rebases on top of this, its `AdvanceErrorMinimalResult` picks up the same `error: { code, message, kind }` envelope automatically — nothing in #130's minimal projection conflicts with the new fields.

Closes #95.

## Test plan

- [x] `npm run build && npm test` — 706 tests pass (703 baseline + 3 new envelope assertions in `test/engine.test.ts`, `test/wait.test.ts`, `test/returns.test.ts`, and one new CLI-level test in `test/cli-traversals.test.ts` covering the gate-blocked advance exits with `EXIT.BLOCKED` and the unified envelope).
- [x] Updated `CONFIRM_REQUIRED` / `GRAPH_NOT_FOUND` CLI tests to assert the new `kind` field.
- [x] Skill docs (`templates/skills/freelance/SKILL.md` + `plugins/freelance/skills/freelance/SKILL.md`, kept identical per `test/plugin-manifest.test.ts`) rewritten to document the unified envelope and the `error.kind` branching contract.
- [x] Ran `/simplify`: collapsed `outputError` + `fatal` onto `errorEnvelope`; replaced the hardcoded string union on `AdvanceErrorResult.error.code` with the exported `GateBlockCode` so gate codes live in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)