### PR TITLE
refactor(memory): drop dead collection column + compound index

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -249,8 +249,8 @@ export async function init(options: InitOptions): Promise<void> {
     }
   }
 
-  // 2b. Starter config.yml — surfaces the memory.collections schema so
-  // users don't have to discover it by hitting "Unknown collection" errors.
+  // 2b. Starter config.yml — gives users a committed-default surface
+  // for memory + hooks + workflows settings instead of a blank slate.
   const configDest = path.join(graphsDir, "config.yml");
   if (!fs.existsSync(configDest)) {
     actions.push({ verb: "create", target: `${graphsDisplayPath}/config.yml` });

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,7 +125,7 @@ function resolvePaths(config: FreelanceConfigFile, baseDir: string): FreelanceCo
 }
 
 /**
- * Merge two config objects. Arrays (workflows, collections) concatenate so
+ * Merge two config objects. Arrays (e.g. workflows) concatenate so
  * plugin hooks can extend project-level values without clobbering them.
  * Scalars use the overlay value.
  */

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -61,11 +61,9 @@ CREATE TABLE IF NOT EXISTS propositions (
   id TEXT PRIMARY KEY,
   content TEXT NOT NULL,
   content_hash TEXT NOT NULL,
-  collection TEXT NOT NULL DEFAULT 'default',
   created_at TEXT NOT NULL
 );
-CREATE UNIQUE INDEX IF NOT EXISTS idx_prop_hash_coll ON propositions(content_hash, collection);
-CREATE INDEX IF NOT EXISTS idx_prop_collection ON propositions(collection);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_prop_hash ON propositions(content_hash);
 
 CREATE TABLE IF NOT EXISTS about (
   proposition_id TEXT NOT NULL REFERENCES propositions(id) ON DELETE CASCADE,
@@ -94,10 +92,10 @@ CREATE VIRTUAL TABLE IF NOT EXISTS propositions_fts USING fts5(
 
 -- Keep FTS in sync with propositions table. Only INSERT and DELETE
 -- triggers fire in practice: memory_emit uses ON CONFLICT DO NOTHING on
--- the (content_hash, collection) unique index, so an UPDATE path on the
--- propositions row never executes. The AFTER UPDATE trigger was present
--- in earlier schemas and never fired; removing it keeps the schema
--- honest about the real write path.
+-- the content_hash unique index, so an UPDATE path on the propositions
+-- row never executes. The AFTER UPDATE trigger was present in earlier
+-- schemas and never fired; removing it keeps the schema honest about
+-- the real write path.
 CREATE TRIGGER IF NOT EXISTS propositions_ai AFTER INSERT ON propositions BEGIN
   INSERT INTO propositions_fts(rowid, content) VALUES (new.rowid, new.content);
 END;
@@ -125,6 +123,31 @@ function checkSchemaCompatibility(db: Db): void {
   }
 }
 
+/**
+ * Transparent migration for the dead `collection` column on `propositions`.
+ *
+ * Memory's single-flat-namespace invariant (see `docs/memory-intent.md`)
+ * rules out collections as a feature, but the schema carried a
+ * `collection TEXT NOT NULL DEFAULT 'default'` column plus a compound
+ * UNIQUE(content_hash, collection) index from an earlier iteration.
+ * No write path ever set anything other than `'default'` and no read
+ * path filtered on it, so the column + compound index can be dropped
+ * in place: existing rows' `content_hash` is already unique on its
+ * own because every row's `collection` was `'default'`.
+ *
+ * Runs after `SCHEMA_SQL` so the new `idx_prop_hash` exists before the
+ * old compound index is removed — readers never see a window without a
+ * content_hash index.
+ */
+function migrateDropCollectionColumn(db: Db): void {
+  const cols = db.prepare("PRAGMA table_info(propositions)").all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === "collection")) return;
+
+  db.exec("DROP INDEX IF EXISTS idx_prop_hash_coll");
+  db.exec("DROP INDEX IF EXISTS idx_prop_collection");
+  db.exec("ALTER TABLE propositions DROP COLUMN collection");
+}
+
 export function openDatabase(dbPath: string): Db {
   const inner = new DatabaseSync(dbPath);
   inner.exec("PRAGMA journal_mode = WAL");
@@ -138,6 +161,7 @@ export function openDatabase(dbPath: string): Db {
   const db = wrap(inner);
   checkSchemaCompatibility(db);
   inner.exec(SCHEMA_SQL);
+  migrateDropCollectionColumn(db);
 
   // Converge older databases that were created with the propositions_au
   // AFTER UPDATE trigger. memory_emit's ON CONFLICT DO NOTHING means

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -157,7 +157,6 @@ export class MemoryStore {
   // --- Proposition emission ---
 
   emit(propositions: EmitProposition[]): EmitResult {
-    const collection = "default";
     const result: EmitResult = {
       created: 0,
       deduplicated: 0,
@@ -168,18 +167,18 @@ export class MemoryStore {
     const warnings: EmitWarning[] = [];
 
     // DO NOTHING (not DO UPDATE) — if an existing row matches on
-    // (content_hash, collection) the insert becomes a no-op and returns
-    // no row. We then SELECT the existing id separately. This keeps emit
-    // idempotent under retry and keeps the FTS index untouched on dedup
-    // hits (there's no AFTER UPDATE trigger to churn regardless).
+    // content_hash the insert becomes a no-op and returns no row. We
+    // then SELECT the existing id separately. This keeps emit idempotent
+    // under retry and keeps the FTS index untouched on dedup hits
+    // (there's no AFTER UPDATE trigger to churn regardless).
     const upsertProp = this.db.prepare(
-      `INSERT INTO propositions (id, content, content_hash, collection, created_at)
-       VALUES (?, ?, ?, ?, ?)
-       ON CONFLICT (content_hash, collection) DO NOTHING
+      `INSERT INTO propositions (id, content, content_hash, created_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT (content_hash) DO NOTHING
        RETURNING id`,
     );
     const selectExistingProp = this.db.prepare(
-      "SELECT id FROM propositions WHERE content_hash = ? AND collection = ?",
+      "SELECT id FROM propositions WHERE content_hash = ?",
     );
     const insertAbout = this.db.prepare(
       "INSERT OR IGNORE INTO about (proposition_id, entity_id) VALUES (?, ?)",
@@ -191,7 +190,7 @@ export class MemoryStore {
     for (const prop of propositions) {
       const contentHash = hashPropContent(prop.content);
       const newId = generateId();
-      const inserted = upsertProp.get(newId, prop.content, contentHash, collection, now()) as
+      const inserted = upsertProp.get(newId, prop.content, contentHash, now()) as
         | { id: string }
         | undefined;
 
@@ -208,7 +207,7 @@ export class MemoryStore {
         propResult.status = "created";
         result.created++;
       } else {
-        const existing = selectExistingProp.get(contentHash, collection) as { id: string };
+        const existing = selectExistingProp.get(contentHash) as { id: string };
         propId = existing.id;
         propResult.status = "deduplicated";
         result.deduplicated++;
@@ -538,7 +537,6 @@ export class MemoryStore {
       content: row.content,
       created_at: row.created_at,
       valid,
-      collection: row.collection,
       source_files: sourceFiles,
     };
   }

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -15,7 +15,6 @@ export interface PropositionRow {
   id: string;
   content: string;
   content_hash: string;
-  collection: string;
   created_at: string;
 }
 
@@ -74,7 +73,6 @@ export interface PropositionInfo {
   content: string;
   created_at: string;
   valid: boolean;
-  collection: string;
   source_files: Array<{ path: string; hash: string; current_match: boolean }>;
 }
 

--- a/templates/config.yml
+++ b/templates/config.yml
@@ -19,21 +19,3 @@
 memory:
   # Whether the memory store is enabled. Defaults to true when omitted.
   enabled: true
-
-  # Collections partition the knowledge graph. Each proposition is
-  # emitted into exactly one collection; queries can filter by
-  # collection or search across all.
-  #
-  # Custom collections MUST be declared here before a workflow can emit
-  # to them — referencing an unknown collection at emit time errors out
-  # with `Unknown collection "<name>". Available: ...`. Uncomment and
-  # edit the examples below to add your own.
-  collections:
-    - name: default
-      description: General project knowledge
-    # - name: architecture
-    #   description: High-level design decisions and constraints
-    #   paths: [docs/architecture/]
-    # - name: api
-    #   description: Public API surface and usage patterns
-    #   paths: [src/api/, docs/api/]

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { openDatabase } from "../src/memory/db.js";
 import { MemoryStore } from "../src/memory/store.js";
@@ -770,5 +771,84 @@ describe("MemoryStore", () => {
     it("throws for unknown entity", () => {
       expect(() => store.related("nonexistent")).toThrow("Entity not found");
     });
+  });
+});
+
+describe("MemoryStore schema migration", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Transparent migration for the dead `collection` column. Simulates a
+  // pre-migration DB by hand-installing the old schema + a seeded row,
+  // then opens it with the real `openDatabase` (which runs the migration)
+  // and confirms the column / old indexes are gone while the row survived.
+  it("drops collection column and compound index from a pre-migration db", () => {
+    const dbPath = path.join(tmpDir, "memory.db");
+    const raw = new DatabaseSync(dbPath);
+    raw.exec("PRAGMA journal_mode = WAL");
+    raw.exec(`
+      CREATE TABLE propositions (
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        collection TEXT NOT NULL DEFAULT 'default',
+        created_at TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX idx_prop_hash_coll ON propositions(content_hash, collection);
+      CREATE INDEX idx_prop_collection ON propositions(collection);
+    `);
+    raw.exec(
+      "INSERT INTO propositions (id, content, content_hash, collection, created_at) VALUES ('p1', 'foo', 'h1', 'default', '2024-01-01')",
+    );
+    raw.close();
+
+    // openDatabase runs SCHEMA_SQL + migrateDropCollectionColumn.
+    const db = openDatabase(dbPath);
+    try {
+      const cols = db.prepare("PRAGMA table_info(propositions)").all() as Array<{
+        name: string;
+      }>;
+      expect(cols.map((c) => c.name)).not.toContain("collection");
+
+      const indexes = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='propositions'")
+        .all() as Array<{ name: string }>;
+      const names = indexes.map((i) => i.name);
+      expect(names).not.toContain("idx_prop_hash_coll");
+      expect(names).not.toContain("idx_prop_collection");
+      expect(names).toContain("idx_prop_hash");
+
+      const row = db.prepare("SELECT id, content, content_hash FROM propositions").get() as {
+        id: string;
+        content: string;
+        content_hash: string;
+      };
+      expect(row).toEqual({ id: "p1", content: "foo", content_hash: "h1" });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("no-op on a fresh db (idempotent)", () => {
+    const dbPath = path.join(tmpDir, "memory.db");
+    // Opening twice exercises the "column already gone" branch.
+    const first = openDatabase(dbPath);
+    first.close();
+    const second = openDatabase(dbPath);
+    try {
+      const cols = second.prepare("PRAGMA table_info(propositions)").all() as Array<{
+        name: string;
+      }>;
+      expect(cols.map((c) => c.name)).not.toContain("collection");
+    } finally {
+      second.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

CLAUDE.md declares memory's shape explicitly: "Memory is a single flat namespace — no collections." But the schema, the store, and the wire shape all carried a `collection` column with no write path that ever set anything other than `'default'`, no read path that filtered on it, and no config surface that drove it. Per CLAUDE.md's design-iteration rule, the invariant forbade what the schema accommodated.

### Changes

- **Schema:** `propositions.collection` column removed; `idx_prop_hash_coll` (UNIQUE on `content_hash+collection`) replaced by `idx_prop_hash` (UNIQUE on `content_hash`); `idx_prop_collection` removed. Existing uniqueness is preserved because every row's collection was `'default'` — `content_hash` alone was already unique.
- **Transparent migration** in `openDatabase` for pre-migration DBs: detects the column via `PRAGMA table_info`, drops the compound index + column in place. Existing rows survive untouched.
- `MemoryStore.emit`: drops the `collection` local and the compound `ON CONFLICT` clause.
- **Types:** `PropositionRow.collection` and `PropositionInfo.collection` removed; every read stops surfacing the always-`'default'` string.
- **Starter `templates/config.yml`:** removes the stale `memory.collections:` block that referenced an "Unknown collection" error that no longer exists.
- Stale comments in `src/cli/init.ts` and `src/config.ts`.

### Wire-shape impact

`PropositionInfo` no longer includes `collection`. Any external consumer depending on that always-`'default'` field will break — but since the field was always the same literal, no useful information was being conveyed.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 705 pass (703 baseline + 2 migration tests: DROP COLUMN path on a hand-installed pre-migration db, and idempotent no-op on a fresh db)

Closes #102

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>