### PR TITLE
test(engine): lock in #134 unified error envelope under minimal mode

### DIFF
--- a/test/engine-minimal-response.test.ts
+++ b/test/engine-minimal-response.test.ts
@@ -123,6 +123,27 @@ describe("advance({ responseMode: 'minimal' }) — gate-blocked shape", () => {
     expect(r).not.toHaveProperty("graphSources");
   });
 
+  // Locks in the #134 unified envelope (`error.kind`) under minimal mode.
+  // Without this assertion, the minimal-mode error type could drop the
+  // envelope silently and skills relying on `error.kind` would break.
+  it("carries the unified error envelope with kind: 'blocked'", async () => {
+    const engine = makeEngine("valid-simple.workflow.yaml");
+    await engine.start("valid-simple");
+    await engine.advance("work-done");
+
+    const r = await engine.advance("approved", undefined, { responseMode: "minimal" });
+    expect(r.isError).toBe(true);
+    if (!r.isError) return;
+
+    expect(r.error).toEqual({
+      code: "VALIDATION_FAILED",
+      message: expect.stringContaining("Task must be started"),
+      kind: "blocked",
+    });
+    // reason is retained as a back-compat mirror of error.message.
+    expect(r.reason).toBe(r.error.message);
+  });
+
   it("blocked minimal with no caller writes has empty contextDelta", async () => {
     const engine = makeEngine("valid-simple.workflow.yaml");
     await engine.start("valid-simple");


### PR DESCRIPTION
Follow-up to #130. The rebase-cleanup-agent added `error: { code, message, kind: \"blocked\" }` to \`AdvanceErrorMinimalResult\` in \`src/types.ts\` so minimal-mode gate blocks share #134's unified envelope. That addition was structurally required (typecheck would fail otherwise) but no test asserted it — a future refactor could drop the field silently.

This PR adds a focused assertion to \`test/engine-minimal-response.test.ts\`: a gate-blocked advance in minimal mode carries the full envelope with \`kind: \"blocked\"\`, code \`VALIDATION_FAILED\`, and \`reason\` mirroring \`error.message\` for back-compat.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test -- test/engine-minimal-response.test.ts\` — 14/14 pass (13 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)