### PR TITLE
feat(cli): ship #122 inspect flags + status loadErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`freelance inspect` flag parity restored (#122).** Threads the
+  engine-level inspect parameters through to the CLI surface, closing
+  the regression introduced when MCP was removed in #116:
+  - `--fields <name>` (repeatable; `currentNode | neighbors |
+    contextSchema | definition`) — additive projections on
+    position/history responses. Unknown values emit `INVALID_FLAG_VALUE`
+    (exit 5) via the unified envelope.
+  - `--limit <n>` / `--offset <n>` — pagination on
+    `--detail history`'s `traversalHistory` (default 50, max 200).
+    Parsed through the shared `parseIntArg` helper; typos surface as
+    `INVALID_FLAG_VALUE` exit 5 instead of silent `NaN`.
+  - `--include-snapshots` — opt-in inclusion of per-step
+    `contextSnapshot` in history entries (quadratic size; off by
+    default).
+  - `freelance status` surfaces `loadErrors: [{file, message}]` when
+    any workflow yaml in the graphs dir fails to parse or validate —
+    previously such files were silently dropped from the `graphs`
+    listing. The field is elided when empty, preserving the pre-#122
+    success shape.
 - **Lean response projection on the hot path (`--minimal`).** `freelance
   advance`, `freelance context set`, and `freelance inspect` now accept
   `--minimal`, which drops the full-context echo and the `node`

--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ Read (available anytime):
 
 | Command | Description |
 |---------|-------------|
-| `freelance status` | Discover available workflow graphs and active traversals (each with any `meta` tags) |
+| `freelance status` | Discover available workflow graphs and active traversals (each with any `meta` tags). Surfaces `loadErrors` when any workflow yaml failed to parse or validate |
 | `freelance start <graphId>` | Begin traversing a graph (optional opaque `--meta key=value` tags for later lookup) |
 | `freelance advance <edge>` | Move to the next node via a labeled edge. `--minimal` drops the full-context echo + `node` blob and returns `contextDelta` (keys written this turn) for lean hot-path responses |
 | `freelance context set <key=value>...` | Update session context without advancing. `--minimal` returns `contextDelta` only |
 | `freelance meta set <key=value>...` | Merge opaque `meta` tags onto a traversal (add or overwrite) |
-| `freelance inspect [id]` | Read-only introspection (`--detail position` or `--detail history`); includes `meta` tags. `--minimal` strips the `node` blob on position detail |
+| `freelance inspect [id]` | Read-only introspection. `--detail position\|history`, `--minimal` (strips `node` blob on position detail), `--fields <name>` (repeatable: `currentNode\|neighbors\|contextSchema\|definition`), and on history: `--limit <n>` / `--offset <n>` / `--include-snapshots`. Includes `meta` tags |
 | `freelance reset --confirm` | Clear traversal and start over |
 | `freelance guide [topic]` | Authoring guidance for writing graphs |
 | `freelance distill --mode distill\|refine` | Distill a task into a new workflow, or refine an existing one |

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "!plugins/**/skills",
       "!plugins/**/commands",
       "!plugins/**/agents",
-      "!experiments"
+      "!experiments",
+      "!.claude"
     ]
   },
   "formatter": {

--- a/plugins/freelance/skills/freelance/SKILL.md
+++ b/plugins/freelance/skills/freelance/SKILL.md
@@ -113,9 +113,18 @@ If you lose track of where a traversal is:
 ```bash
 freelance inspect [<traversalId>]                # current node + validTransitions
 freelance inspect [<traversalId>] --detail history   # step history + context writes
+freelance inspect [<traversalId>] --detail history --limit 10 --offset 0
+                                                 # paginate traversalHistory (default 50, max 200)
+freelance inspect [<traversalId>] --detail history --include-snapshots
+                                                 # include per-step contextSnapshot (opt-in: quadratic size)
+freelance inspect [<traversalId>] --fields currentNode --fields neighbors
+                                                 # additive projections (repeatable):
+                                                 # currentNode | neighbors | contextSchema | definition
 ```
 
 `--active` lists every active traversal with its current node. `--waits` filters that list to traversals sitting on a wait node.
+
+`freelance status` includes a `loadErrors: [{file, message}]` array if any workflow yaml in the graphs dir failed to parse or validate. The field is elided when empty — its presence means at least one file was silently dropped from the `graphs` listing.
 
 ## Lean responses (`--minimal`)
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,4 +1,13 @@
 #!/usr/bin/env node
+import { handleRuntimeError } from "./cli/output.js";
 import { program } from "./cli/program.js";
 
-program.parseAsync(process.argv);
+// Top-level catch: commander's `argParser` callbacks run *before* the
+// action handler's try/catch, so an EngineError thrown from an argParser
+// (e.g. INVALID_FLAG_VALUE on `--fields bogus`) would otherwise bubble
+// as an uncaught exception with exit 1. Route those through
+// `handleRuntimeError` so they surface as the unified JSON envelope +
+// the semantic exit code for their category.
+program.parseAsync(process.argv).catch((err) => {
+  handleRuntimeError(err);
+});

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -8,7 +8,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { Command, Option } from "commander";
 import { loadConfigFromDirs } from "../config.js";
+import { EC, EngineError } from "../errors.js";
 import { resolveGraphsDirs } from "../graph-resolution.js";
+import { INSPECT_FIELDS } from "../types.js";
 import { VERSION } from "../version.js";
 import { configSetLocal, configShow } from "./config.js";
 import {
@@ -271,14 +273,43 @@ addWorkflowsOpt(
     )
     .option("--active", "List every active traversal (ignores [traversalId])")
     .option("--waits", "With --active, include only traversals at a wait node")
-    .option("--minimal", "Lean response: drop NodeInfo + full context echo (position detail only)"),
+    .option("--minimal", "Lean response: drop NodeInfo + full context echo (position detail only)")
+    .option(
+      "--fields <name>",
+      `Additive projections (repeatable; choices: ${INSPECT_FIELDS.join(", ")}). Works with --detail position or history.`,
+      (value: string, previous?: string[]) => {
+        // Validate here — commander's .choices() is bypassed by a custom
+        // argParser, so enum validation has to live alongside the
+        // accumulator. INVALID_FLAG_VALUE keeps this on the same exit
+        // path as --limit/--offset typos.
+        if (!(INSPECT_FIELDS as readonly string[]).includes(value)) {
+          throw new EngineError(
+            `--fields must be one of ${INSPECT_FIELDS.join(", ")}; got "${value}".`,
+            EC.INVALID_FLAG_VALUE,
+          );
+        }
+        return previous ? [...previous, value] : [value];
+      },
+    )
+    .option("--limit <n>", "Max history entries (default 50, max 200). --detail history only.")
+    .option("--offset <n>", "Skip first N history entries. --detail history only.")
+    .option(
+      "--include-snapshots",
+      "Include per-step contextSnapshot in history entries (opt-in: quadratic size). --detail history only.",
+    ),
 ).action((traversalId, opts) => {
   const { store, runtime } = createTraversalStore({ workflows: opts.workflows });
   try {
     if (opts.active) {
       traversalInspectActive(store, { waitsOnly: opts.waits });
     } else {
-      traversalInspect(store, traversalId, opts.detail, { minimal: opts.minimal });
+      traversalInspect(store, traversalId, opts.detail, {
+        minimal: opts.minimal,
+        fields: opts.fields,
+        limit: opts.limit,
+        offset: opts.offset,
+        includeSnapshots: opts.includeSnapshots,
+      });
     }
   } finally {
     runtime.close();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -153,12 +153,14 @@ interface CliSetup {
   graphsDirs: string[];
   sourceRoot: string | undefined;
   sourceOpts: SourceOptions;
+  /** Non-fatal per-file load failures from graphsDirs; empty when all files parsed + validated. */
+  loadErrors: Array<{ file: string; message: string }>;
 }
 
 /** Load graphs and resolve directories for CLI commands. */
 export function loadGraphSetup(opts: CliSetupOptions): CliSetup {
   const graphsDirs = resolveGraphsDirs(opts.workflows);
-  const { graphs } = loadGraphsGraceful(graphsDirs);
+  const { graphs, errors: loadErrors } = loadGraphsGraceful(graphsDirs);
   const sourceRoot = resolveSourceRoot(graphsDirs, opts.sourceRoot);
   const sectionResolver = (filePath: string, section: string) => extractSection(filePath, section);
   return {
@@ -166,6 +168,7 @@ export function loadGraphSetup(opts: CliSetupOptions): CliSetup {
     graphsDirs,
     sourceRoot,
     sourceOpts: { resolver: sectionResolver, basePath: sourceRoot },
+    loadErrors,
   };
 }
 
@@ -196,6 +199,7 @@ export function createTraversalStore(opts: CliSetupOptions): {
     maxDepth: opts.maxDepth ?? fileConfig.maxDepth ?? 5,
     hookTimeoutMs: fileConfig.hooks.timeoutMs,
     contextCaps: resolveContextCaps(fileConfig.context),
+    loadErrors: setup.loadErrors,
   });
 
   return { store: runtime.store, setup, runtime };

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -17,7 +17,7 @@ import type { MemoryConfig, MemoryStore } from "../memory/index.js";
 import { extractSection } from "../section-resolver.js";
 import type { SourceOptions } from "../sources.js";
 import type { TraversalStore } from "../state/index.js";
-import type { ValidatedGraph } from "../types.js";
+import type { LoadError, ValidatedGraph } from "../types.js";
 
 // --- Layout helpers ---
 //
@@ -154,7 +154,7 @@ interface CliSetup {
   sourceRoot: string | undefined;
   sourceOpts: SourceOptions;
   /** Non-fatal per-file load failures from graphsDirs; empty when all files parsed + validated. */
-  loadErrors: Array<{ file: string; message: string }>;
+  loadErrors: readonly LoadError[];
 }
 
 /** Load graphs and resolve directories for CLI commands. */

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -10,10 +10,17 @@
  * relevant, never on the success path.
  */
 
+import type { InspectHistoryOptions } from "../engine/context.js";
 import { EC, EngineError } from "../errors.js";
 import type { TraversalStore } from "../state/index.js";
-import type { InspectPositionResult } from "../types.js";
-import { EXIT, errorEnvelope, handleRuntimeError as handleError, outputJson } from "./output.js";
+import type { InspectField, InspectPositionResult } from "../types.js";
+import {
+  EXIT,
+  errorEnvelope,
+  handleRuntimeError as handleError,
+  outputJson,
+  parseIntArg,
+} from "./output.js";
 
 /**
  * Shared primitive for CLI flags that accept `key=value` pairs. Splits on
@@ -184,11 +191,24 @@ export function traversalInspect(
   store: TraversalStore,
   traversalId?: string,
   detail?: "position" | "history",
-  opts?: { minimal?: boolean },
+  opts?: {
+    minimal?: boolean;
+    fields?: readonly InspectField[];
+    limit?: string;
+    offset?: string;
+    includeSnapshots?: boolean;
+  },
 ): void {
   try {
+    const limit = parseIntArg(opts?.limit, "--limit");
+    const offset = parseIntArg(opts?.offset, "--offset");
     const id = store.resolveTraversalId(traversalId);
-    const raw = store.inspect(id, detail ?? "position", undefined, undefined, {
+    const historyOpts: InspectHistoryOptions = {
+      ...(limit !== undefined && { limit }),
+      ...(offset !== undefined && { offset }),
+      ...(opts?.includeSnapshots && { includeSnapshots: true }),
+    };
+    const raw = store.inspect(id, detail ?? "position", opts?.fields, historyOpts, {
       ...(opts?.minimal ? { responseMode: "minimal" as const } : {}),
     });
     outputJson(raw);

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -21,7 +21,7 @@ import type { MemoryConfig } from "./memory/index.js";
 import { MemoryStore } from "./memory/index.js";
 import type { SectionResolver, SourceOptions } from "./sources.js";
 import { openStateStore, TraversalStore } from "./state/index.js";
-import type { ValidatedGraph } from "./types.js";
+import type { LoadError, ValidatedGraph } from "./types.js";
 
 /**
  * Build a MemoryStore from a MemoryConfig. Shared by `composeRuntime`
@@ -64,6 +64,12 @@ export interface ComposeConfig {
    * contextUpdates, contextSet). Omit to use `DEFAULT_CONTEXT_CAPS`.
    */
   readonly contextCaps?: ContextCaps;
+  /**
+   * Non-fatal graph-load errors carried through from the CLI setup so
+   * `status` can surface which files were dropped. See `LoadError` in
+   * `types.ts`.
+   */
+  readonly loadErrors?: readonly LoadError[];
 }
 
 export interface Runtime {
@@ -186,6 +192,7 @@ export function composeRuntime(config: ComposeConfig): Runtime {
     maxDepth: config.maxDepth,
     hookRunner,
     ...(config.contextCaps ? { contextCaps: config.contextCaps } : {}),
+    ...(config.loadErrors ? { loadErrors: config.loadErrors } : {}),
   });
 
   const sourceOpts: SourceOptions = {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -51,6 +51,7 @@ export type {
   InspectPositionMinimalResult,
   InspectPositionResult,
   InspectResult,
+  LoadError,
   NodeDefinition,
   NodeInfo,
   ResetResult,

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -52,7 +52,7 @@ export class TraversalStore {
   private maxDepth: number;
   private hookRunner: HookRunner;
   private contextCaps?: ContextCaps;
-  private loadErrors: readonly LoadError[];
+  private readonly loadErrors: readonly LoadError[];
   // Per-id async mutex tails, keyed by traversal id. See `withLock`.
   private locks = new Map<string, Promise<unknown>>();
 
@@ -72,16 +72,6 @@ export class TraversalStore {
     this.hookRunner = options.hookRunner;
     this.contextCaps = options.contextCaps;
     this.loadErrors = options.loadErrors ?? [];
-  }
-
-  /**
-   * Replace the snapshot of non-fatal load errors. The hot-reload watcher
-   * re-runs graph loading when source files change; callers update the
-   * store so `status` reflects the current file-set rather than the
-   * initial one.
-   */
-  setLoadErrors(errors: readonly LoadError[]): void {
-    this.loadErrors = errors;
   }
 
   /**

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -17,6 +17,7 @@ import type {
   InspectField,
   InspectMinimalResult,
   InspectResult,
+  LoadError,
   ResetResult,
   StartResult,
   TraversalInfo,
@@ -51,19 +52,36 @@ export class TraversalStore {
   private maxDepth: number;
   private hookRunner: HookRunner;
   private contextCaps?: ContextCaps;
+  private loadErrors: readonly LoadError[];
   // Per-id async mutex tails, keyed by traversal id. See `withLock`.
   private locks = new Map<string, Promise<unknown>>();
 
   constructor(
     state: StateStore,
     graphs: Map<string, ValidatedGraph>,
-    options: { maxDepth?: number; hookRunner: HookRunner; contextCaps?: ContextCaps },
+    options: {
+      maxDepth?: number;
+      hookRunner: HookRunner;
+      contextCaps?: ContextCaps;
+      loadErrors?: readonly LoadError[];
+    },
   ) {
     this.state = state;
     this.graphs = graphs;
     this.maxDepth = options.maxDepth ?? 5;
     this.hookRunner = options.hookRunner;
     this.contextCaps = options.contextCaps;
+    this.loadErrors = options.loadErrors ?? [];
+  }
+
+  /**
+   * Replace the snapshot of non-fatal load errors. The hot-reload watcher
+   * re-runs graph loading when source files change; callers update the
+   * store so `status` reflects the current file-set rather than the
+   * initial one.
+   */
+  setLoadErrors(errors: readonly LoadError[]): void {
+    this.loadErrors = errors;
   }
 
   /**
@@ -118,10 +136,13 @@ export class TraversalStore {
       });
     }
     graphList.sort((a, b) => a.id.localeCompare(b.id));
-    return {
+    const base: TraversalListResult = {
       graphs: graphList,
       activeTraversals: this.listTraversals(),
     };
+    // Elide loadErrors entirely when empty — the field is optional so a
+    // clean run still serializes to the pre-#122 shape.
+    return this.loadErrors.length > 0 ? { ...base, loadErrors: this.loadErrors } : base;
   }
 
   listTraversals(): TraversalInfo[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,7 +222,8 @@ export interface StackEntry {
  * position/history response. Each field is additive — the base shape
  * stays lean and the caller explicitly asks for the expansion.
  */
-export type InspectField = "currentNode" | "neighbors" | "contextSchema" | "definition";
+export const INSPECT_FIELDS = ["currentNode", "neighbors", "contextSchema", "definition"] as const;
+export type InspectField = (typeof INSPECT_FIELDS)[number];
 
 export interface InspectFieldProjections {
   /** Full `NodeDefinition` for the current node (edges, onEnter, validations, subgraph, timeout, etc.). Requested via fields: ["currentNode"]. */
@@ -366,7 +367,20 @@ export interface TraversalInfo {
   readonly meta: Readonly<Record<string, string>>;
 }
 
+/**
+ * One entry per graph file that failed to load (parse error, schema
+ * violation, or hook-resolution failure). Surfaced in `TraversalListResult`
+ * so CLI/skill callers can see which files were silently dropped from
+ * `graphs` — otherwise a broken yaml just disappears from `freelance status`.
+ */
+export interface LoadError {
+  readonly file: string;
+  readonly message: string;
+}
+
 export interface TraversalListResult {
   readonly graphs: GraphListResult["graphs"];
   readonly activeTraversals: readonly TraversalInfo[];
+  /** Only included when non-empty — keeps the success shape unchanged. */
+  readonly loadErrors?: readonly LoadError[];
 }

--- a/templates/skills/freelance/SKILL.md
+++ b/templates/skills/freelance/SKILL.md
@@ -113,9 +113,18 @@ If you lose track of where a traversal is:
 ```bash
 freelance inspect [<traversalId>]                # current node + validTransitions
 freelance inspect [<traversalId>] --detail history   # step history + context writes
+freelance inspect [<traversalId>] --detail history --limit 10 --offset 0
+                                                 # paginate traversalHistory (default 50, max 200)
+freelance inspect [<traversalId>] --detail history --include-snapshots
+                                                 # include per-step contextSnapshot (opt-in: quadratic size)
+freelance inspect [<traversalId>] --fields currentNode --fields neighbors
+                                                 # additive projections (repeatable):
+                                                 # currentNode | neighbors | contextSchema | definition
 ```
 
 `--active` lists every active traversal with its current node. `--waits` filters that list to traversals sitting on a wait node.
+
+`freelance status` includes a `loadErrors: [{file, message}]` array if any workflow yaml in the graphs dir failed to parse or validate. The field is elided when empty — its presence means at least one file was silently dropped from the `graphs` listing.
 
 ## Lean responses (`--minimal`)
 

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -562,3 +562,150 @@ describe("traversalReset", () => {
     }
   });
 });
+
+describe("traversalInspect options (#122)", () => {
+  it("forwards --fields to the store and surfaces projections in the response", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      await store.createTraversal(graphId);
+      traversalInspect(store, undefined, "position", { fields: ["currentNode", "neighbors"] });
+      const parsed = stdoutJson() as {
+        currentNodeDefinition?: unknown;
+        neighbors?: unknown;
+      };
+      expect(parsed.currentNodeDefinition).toBeDefined();
+      expect(parsed.neighbors).toBeDefined();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("forwards --limit/--offset to history detail", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      await store.createTraversal(graphId);
+      traversalInspect(store, undefined, "history", { limit: "3", offset: "0" });
+      const parsed = stdoutJson() as {
+        traversalHistory: unknown[];
+        totalSteps: number;
+      };
+      // Pagination applies — the slice is bounded even on an empty
+      // history. The total-field contract (pre-pagination count) is
+      // covered by the engine tests; here we only assert the CLI
+      // threads the options through without error.
+      expect(Array.isArray(parsed.traversalHistory)).toBe(true);
+      expect(parsed.traversalHistory.length).toBeLessThanOrEqual(3);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("forwards --include-snapshots so history entries retain contextSnapshot", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      const { traversalId } = await store.createTraversal(graphId);
+      // Advance once so there's something in history to project. The
+      // fixture is valid-branching; the first edge label from `start`
+      // varies — just grab it from the validTransitions.
+      const inspectRaw = store.inspect(traversalId, "position") as {
+        validTransitions: Array<{ label: string }>;
+      };
+      const firstEdge = inspectRaw.validTransitions[0]?.label;
+      if (!firstEdge) return;
+      await store.advance(traversalId, firstEdge, undefined);
+      stdoutSpy.mockClear();
+      traversalInspect(store, traversalId, "history", { includeSnapshots: true });
+      const parsed = stdoutJson() as {
+        traversalHistory: Array<{ contextSnapshot?: unknown }>;
+      };
+      expect(parsed.traversalHistory.length).toBeGreaterThan(0);
+      expect(parsed.traversalHistory[0]).toHaveProperty("contextSnapshot");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("emits INVALID_FLAG_VALUE on non-integer --limit", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      await store.createTraversal(graphId);
+      expect(() => traversalInspect(store, undefined, "history", { limit: "abc" })).toThrow(
+        "process.exit",
+      );
+      const parsed = stdoutJson() as {
+        isError: true;
+        error: { code: string; kind: string };
+      };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.error.code).toBe("INVALID_FLAG_VALUE");
+      expect(parsed.error.kind).toBe("structural");
+      expect(exitSpy).toHaveBeenCalledWith(5); // EXIT.INVALID_INPUT
+    } finally {
+      store.close();
+    }
+  });
+
+  it("emits INVALID_FLAG_VALUE on non-integer --offset", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      await store.createTraversal(graphId);
+      expect(() => traversalInspect(store, undefined, "history", { offset: "1.5" })).toThrow(
+        "process.exit",
+      );
+      const parsed = stdoutJson() as {
+        isError: true;
+        error: { code: string };
+      };
+      expect(parsed.error.code).toBe("INVALID_FLAG_VALUE");
+      expect(exitSpy).toHaveBeenCalledWith(5);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("traversalStatus loadErrors surface (#122)", () => {
+  it("includes loadErrors when the store was constructed with non-empty errors", () => {
+    const fixture = path.resolve("test/fixtures/valid-branching.workflow.yaml");
+    const loaded = loadSingleGraph(fixture);
+    const graphs = new Map<string, ValidatedGraph>([[loaded.id, loaded]]);
+    const db = openStateStore(":memory:");
+    const store = new TraversalStore(db, graphs, {
+      maxDepth: 5,
+      hookRunner: new HookRunner(),
+      loadErrors: [{ file: "broken.workflow.yaml", message: "unexpected end of stream" }],
+    });
+    try {
+      traversalStatus(store);
+      const parsed = stdoutJson() as {
+        loadErrors?: Array<{ file: string; message: string }>;
+      };
+      expect(parsed.loadErrors).toBeDefined();
+      expect(parsed.loadErrors).toHaveLength(1);
+      expect(parsed.loadErrors?.[0].file).toBe("broken.workflow.yaml");
+    } finally {
+      store.close();
+    }
+  });
+
+  it("elides loadErrors when empty — preserves the pre-#122 status shape", () => {
+    const store = createTestStore();
+    try {
+      traversalStatus(store);
+      const parsed = stdoutJson() as Record<string, unknown>;
+      expect("loadErrors" in parsed).toBe(false);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // Ignore agent worktrees — team members run parallel branches under
+    // `.claude/worktrees/<name>/`. Without this, vitest walks those
+    // checkouts and runs whichever test state exists on that branch
+    // alongside the local suite, producing confusing duplicate /
+    // timing-out results. The `node_modules/**` default stays.
+    exclude: ["**/node_modules/**", "**/dist/**", ".claude/**"],
     coverage: {
       provider: "v8",
       reporter: ["text"],


### PR DESCRIPTION
## Summary

- Threads the engine-level inspect parameters (`fields`, `limit`, `offset`, `includeSnapshots`) through to the `freelance inspect` CLI surface. The engine already supported them (via `engine.inspect(detail, fields, historyOpts)`); this PR closes the gap on the commander surface that was missing since the MCP removal in #116.
- Surfaces `loadErrors: [{file, message}]` in `freelance status` when any workflow yaml in the graphs dir failed to parse or validate — previously such files were silently dropped from the `graphs` listing with no indication to the caller. Elided when empty, preserving the pre-#122 success shape.
- Adds a top-level `parseAsync().catch(handleRuntimeError)` in `bin.ts` so errors thrown inside commander argParsers (which fire before the action handler's try/catch) still emit the unified JSON envelope with the right semantic exit code.

Two incidental project-config fixes, flagged in their own commits:

- `chore(biome)`: adds `!.claude` to `files.includes` so Biome v2 tolerates the nested `biome.json` that appears inside agent worktrees.
- `chore(vitest)`: adds `.claude/**` to `test.exclude` so vitest doesn't walk teammate worktrees and double-run their test state.

## Flag reference

| flag | detail | semantics |
|------|--------|-----------|
| `--fields <name>` | position / history | Repeatable additive projections: `currentNode\|neighbors\|contextSchema\|definition`. Unknown values emit `INVALID_FLAG_VALUE` (exit 5). |
| `--limit <n>` | history | Page size on `traversalHistory`. Default 50, max 200 (matches engine). Parsed via `parseIntArg`; non-integer input is `INVALID_FLAG_VALUE` exit 5. |
| `--offset <n>` | history | Skip first N entries. Same parse semantics as `--limit`. |
| `--include-snapshots` | history | Opt-in per-entry `contextSnapshot` (quadratic size; off by default). |

## Test plan

- [x] `npm test` — 766/766 pass (+7 new tests in `test/cli-traversals.test.ts`: `traversalInspect options (#122)` × 5 and `traversalStatus loadErrors surface (#122)` × 2)
- [x] E2E smoke in `/tmp/freelance-parity-test`:
  - `freelance inspect --fields currentNode --fields neighbors` returns `currentNodeDefinition` + `neighbors` projections
  - `freelance inspect --detail history --limit 10 --offset 0 --include-snapshots` paginates + includes snapshots
  - `freelance inspect --limit xxx` → `{isError, error:{code:"INVALID_FLAG_VALUE", kind:"structural"}}`, exit 5
  - `freelance inspect --fields bogus` → `INVALID_FLAG_VALUE`, exit 5
  - `freelance status` with a broken `.workflow.yaml` present shows the file in `loadErrors`; clean dir has no `loadErrors` field
- [x] `tsc` + `biome check` clean (pre-commit hook)

Closes #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)