### PR TITLE
feat(state): surface orphaned traversals; actionable GRAPH_NOT_FOUND hint

### DIFF
--- a/plugins/freelance/skills/freelance/SKILL.md
+++ b/plugins/freelance/skills/freelance/SKILL.md
@@ -126,6 +126,8 @@ freelance inspect [<traversalId>] --fields currentNode --fields neighbors
 
 `freelance status` includes a `loadErrors: [{file, message}]` array if any workflow yaml in the graphs dir failed to parse or validate. The field is elided when empty — its presence means at least one file was silently dropped from the `graphs` listing.
 
+`freelance status` also includes an `orphanedTraversals: [{traversalId, graphId, currentNode, lastUpdated, ...}]` array when any traversal record points at a graph that isn't loaded (yaml deleted, renamed, or in `loadErrors`). Also elided when empty. Orphans are _not_ in `activeTraversals` — reporting them distinctly tells the user the traversal can't advance without operator action: either restore the graph yaml, or run `freelance reset <traversalId> --confirm` to clear. Calling `freelance advance` / `freelance inspect` on an orphan fails with `GRAPH_NOT_FOUND` (structural, exit 4) and the message repeats the same two recovery options.
+
 ## Lean responses (`--minimal`)
 
 `freelance advance`, `freelance context set`, and `freelance inspect` accept `--minimal`. The response drops the full `context` echo and the `node` NodeInfo blob (instructions, suggestedTools, sources) and returns `{ currentNode, validTransitions, contextDelta, status, ... }`. `contextDelta` names the keys written this turn — your own updates plus anything an `onEnter` hook wrote — so hook activity stays visible without re-shipping unchanged state.

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -126,13 +126,24 @@ export class TraversalStore {
       });
     }
     graphList.sort((a, b) => a.id.localeCompare(b.id));
-    const base: TraversalListResult = {
+
+    // Split active vs. orphaned. An orphan is a traversal whose top-of-
+    // stack graphId isn't among the currently-loaded graphs — the yaml
+    // was deleted/renamed/failed to parse between `start` and this read.
+    // `advance`/`inspect` on an orphan fails with GRAPH_NOT_FOUND; the
+    // split surfaces them on `status` so the skill can suggest reset.
+    const active: TraversalInfo[] = [];
+    const orphaned: TraversalInfo[] = [];
+    for (const t of this.listTraversals()) {
+      (this.graphs.has(t.graphId) ? active : orphaned).push(t);
+    }
+
+    return {
       graphs: graphList,
-      activeTraversals: this.listTraversals(),
+      activeTraversals: active,
+      ...(this.loadErrors.length > 0 && { loadErrors: this.loadErrors }),
+      ...(orphaned.length > 0 && { orphanedTraversals: orphaned }),
     };
-    // Elide loadErrors entirely when empty — the field is optional so a
-    // clean run still serializes to the pre-#122 shape.
-    return this.loadErrors.length > 0 ? { ...base, loadErrors: this.loadErrors } : base;
   }
 
   listTraversals(): TraversalInfo[] {
@@ -298,7 +309,37 @@ export class TraversalStore {
   }
 
   resetTraversal(traversalId: string): { traversalId: string } & ResetResult {
-    const { engine } = this.loadEngine(traversalId);
+    // Reset is the documented recovery path for orphaned traversals
+    // (loadEngine's error message points here), so it must succeed even
+    // when the graph isn't loaded. We open-code the record fetch rather
+    // than going through loadEngine, which would throw GRAPH_NOT_FOUND
+    // and make orphan recovery unreachable. Engine hydration isn't
+    // needed — reset() only reads the stored stack to build its
+    // ResetResult.
+    const record = this.state.get(traversalId);
+    if (!record) {
+      throw new EngineError(`Traversal "${traversalId}" not found`, EC.TRAVERSAL_NOT_FOUND);
+    }
+
+    if (!this.graphs.has(record.graphId)) {
+      this.state.delete(traversalId);
+      const root = record.stack[0];
+      const clearedStack = record.stack.map((s) => ({
+        graphId: s.graphId,
+        node: s.currentNode,
+      }));
+      return {
+        traversalId,
+        status: "reset",
+        previousGraph: root?.graphId ?? null,
+        previousNode: root?.currentNode ?? null,
+        message: `Cleared orphaned traversal (graph "${record.graphId}" was not loaded).`,
+        ...(clearedStack.length > 1 && { clearedStack }),
+      };
+    }
+
+    const engine = this.newEngine();
+    engine.restoreStack(record.stack);
     const result = engine.reset();
     this.state.delete(traversalId);
     return { traversalId, ...result };
@@ -343,6 +384,19 @@ export class TraversalStore {
     const record = this.state.get(traversalId);
     if (!record) {
       throw new EngineError(`Traversal "${traversalId}" not found`, EC.TRAVERSAL_NOT_FOUND);
+    }
+
+    // Orphan check — the traversal record exists but its graph doesn't
+    // resolve. Throw GRAPH_NOT_FOUND here with a recovery hint rather
+    // than letting the engine throw the bare form from its own lookup;
+    // the hint tells the operator how to get unstuck (reset or restore).
+    if (!this.graphs.has(record.graphId)) {
+      throw new EngineError(
+        `Graph "${record.graphId}" not found. Traversal "${traversalId}" is orphaned — ` +
+          `its workflow yaml is missing, renamed, or failed to parse. Run ` +
+          `\`freelance reset ${traversalId} --confirm\` to clear it, or restore the graph yaml.`,
+        EC.GRAPH_NOT_FOUND,
+      );
     }
 
     const engine = this.newEngine();

--- a/src/types.ts
+++ b/src/types.ts
@@ -383,4 +383,12 @@ export interface TraversalListResult {
   readonly activeTraversals: readonly TraversalInfo[];
   /** Only included when non-empty — keeps the success shape unchanged. */
   readonly loadErrors?: readonly LoadError[];
+  /**
+   * Traversals whose top-of-stack `graphId` doesn't resolve against the
+   * graphs currently loaded (yaml deleted / renamed / failed to parse).
+   * Split out so callers can see them distinctly from `activeTraversals`
+   * without having to cross-reference `graphs`. Only included when
+   * non-empty; mirrors the `loadErrors` elision pattern.
+   */
+  readonly orphanedTraversals?: readonly TraversalInfo[];
 }

--- a/templates/skills/freelance/SKILL.md
+++ b/templates/skills/freelance/SKILL.md
@@ -126,6 +126,8 @@ freelance inspect [<traversalId>] --fields currentNode --fields neighbors
 
 `freelance status` includes a `loadErrors: [{file, message}]` array if any workflow yaml in the graphs dir failed to parse or validate. The field is elided when empty — its presence means at least one file was silently dropped from the `graphs` listing.
 
+`freelance status` also includes an `orphanedTraversals: [{traversalId, graphId, currentNode, lastUpdated, ...}]` array when any traversal record points at a graph that isn't loaded (yaml deleted, renamed, or in `loadErrors`). Also elided when empty. Orphans are _not_ in `activeTraversals` — reporting them distinctly tells the user the traversal can't advance without operator action: either restore the graph yaml, or run `freelance reset <traversalId> --confirm` to clear. Calling `freelance advance` / `freelance inspect` on an orphan fails with `GRAPH_NOT_FOUND` (structural, exit 4) and the message repeats the same two recovery options.
+
 ## Lean responses (`--minimal`)
 
 `freelance advance`, `freelance context set`, and `freelance inspect` accept `--minimal`. The response drops the full `context` echo and the `node` NodeInfo blob (instructions, suggestedTools, sources) and returns `{ currentNode, validTransitions, contextDelta, status, ... }`. `contextDelta` names the keys written this turn — your own updates plus anything an `onEnter` hook wrote — so hook activity stays visible without re-shipping unchanged state.

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -709,3 +709,41 @@ describe("traversalStatus loadErrors surface (#122)", () => {
     }
   });
 });
+
+describe("traversalStatus orphanedTraversals surface (#136)", () => {
+  it("moves a traversal into orphanedTraversals when its graph isn't loaded", async () => {
+    const fixture = path.resolve("test/fixtures/valid-branching.workflow.yaml");
+    const loaded = loadSingleGraph(fixture);
+    const graphs = new Map<string, ValidatedGraph>([[loaded.id, loaded]]);
+    const db = openStateStore(":memory:");
+    const store = new TraversalStore(db, graphs, { maxDepth: 5, hookRunner: new HookRunner() });
+    try {
+      await store.createTraversal(loaded.id);
+      // Drop the graph from the map to simulate the yaml being
+      // removed/renamed between CLI invocations.
+      store.updateGraphs(new Map());
+
+      traversalStatus(store);
+      const parsed = stdoutJson() as {
+        activeTraversals: unknown[];
+        orphanedTraversals?: Array<{ traversalId: string; graphId: string }>;
+      };
+      expect(parsed.activeTraversals).toHaveLength(0);
+      expect(parsed.orphanedTraversals).toHaveLength(1);
+      expect(parsed.orphanedTraversals?.[0].graphId).toBe(loaded.id);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("elides orphanedTraversals when empty — preserves the pre-#136 status shape", () => {
+    const store = createTestStore();
+    try {
+      traversalStatus(store);
+      const parsed = stdoutJson() as Record<string, unknown>;
+      expect("orphanedTraversals" in parsed).toBe(false);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/test/traversal-store.test.ts
+++ b/test/traversal-store.test.ts
@@ -400,6 +400,70 @@ describe("TraversalStore — stateless JSON", () => {
     });
   });
 
+  describe("orphanedTraversals split (#136)", () => {
+    it("splits traversals whose graph no longer loads into a distinct array", async () => {
+      const t1 = await store.createTraversal("valid-simple");
+      const t2 = await store.createTraversal("valid-branching");
+
+      // Simulate the yaml for one graph disappearing between CLI
+      // invocations — the store is constructed fresh each time, so
+      // this models the post-#127 reality (no watcher; each run loads
+      // graphs from disk).
+      const pruned = new Map(graphs);
+      pruned.delete("valid-simple");
+      store.updateGraphs(pruned);
+
+      const result = store.listGraphs();
+      expect(result.activeTraversals).toHaveLength(1);
+      expect(result.activeTraversals[0].traversalId).toBe(t2.traversalId);
+      expect(result.orphanedTraversals).toHaveLength(1);
+      expect(result.orphanedTraversals?.[0].traversalId).toBe(t1.traversalId);
+      expect(result.orphanedTraversals?.[0].graphId).toBe("valid-simple");
+    });
+
+    it("elides orphanedTraversals when every traversal's graph resolves", async () => {
+      await store.createTraversal("valid-simple");
+      const result = store.listGraphs();
+      expect("orphanedTraversals" in result).toBe(false);
+    });
+  });
+
+  describe("loadEngine orphan recovery hint (#136)", () => {
+    it("throws GRAPH_NOT_FOUND with a reset hint when the graph is gone", async () => {
+      const t = await store.createTraversal("valid-simple");
+      const pruned = new Map(graphs);
+      pruned.delete("valid-simple");
+      store.updateGraphs(pruned);
+
+      await expect(store.advance(t.traversalId, "work-done")).rejects.toMatchObject({
+        code: "GRAPH_NOT_FOUND",
+        message: expect.stringContaining(`freelance reset ${t.traversalId} --confirm`),
+      });
+    });
+
+    it("preserves TRAVERSAL_NOT_FOUND precedence over orphan detection", async () => {
+      // An unknown traversalId is a bigger miss than an orphan; the
+      // skill gets the same error whether or not the referenced graph
+      // would have been orphaned.
+      await expect(store.advance("tr_nonexistent", "work-done")).rejects.toMatchObject({
+        code: "TRAVERSAL_NOT_FOUND",
+      });
+    });
+
+    it("lets resetTraversal clear an orphan (recovery path the error message recommends)", async () => {
+      const t = await store.createTraversal("valid-simple");
+      const pruned = new Map(graphs);
+      pruned.delete("valid-simple");
+      store.updateGraphs(pruned);
+
+      const result = store.resetTraversal(t.traversalId);
+      expect(result.status).toBe("reset");
+      expect(result.previousGraph).toBe("valid-simple");
+      expect(result.message).toMatch(/orphaned/);
+      expect(store.listTraversals()).toHaveLength(0);
+    });
+  });
+
   describe("listGraphs determinism", () => {
     it("returns graphs sorted by id regardless of insertion order", async () => {
       // Reinstall store with graphs inserted in reverse-alphabetical order to


### PR DESCRIPTION
Closes #136.

## Summary

- `freelance status` now splits `activeTraversals` vs. `orphanedTraversals`. An orphan is a traversal whose top-of-stack `graphId` doesn't resolve against currently-loaded graphs (yaml deleted, renamed, or in `loadErrors`). `orphanedTraversals` is elided when empty, matching the #122 `loadErrors` pattern.
- `loadEngine` throws `GRAPH_NOT_FOUND` with a recovery hint instead of letting the engine throw the bare form from its own lookup: `` `freelance reset <id> --confirm` to clear it, or restore the graph yaml``.
- `resetTraversal` bypasses `loadEngine` so the recovery path the error message recommends stays reachable when the graph is gone — previously, the `loadEngine` throw would have made orphan recovery unreachable.
- SKILL.md (plugin + template copies, byte-identical per `plugin-manifest.test.ts`) documents the new field and the orphan error flow.

## Notes

- The issue body proposed `freelance reset --confirm --traversal <id>`, but the CLI is positional (`freelance reset <id> --confirm`, src/cli/program.ts:321). Used the real syntax in the error message.
- Orphan detection checks `record.graphId` (the top-of-stack graphId). A mid-stack orphan (a subgraph's yaml gone while its parent's is present) would still surface as `GRAPH_NOT_FOUND` from the engine on pop — follow-up if observed.

## Test plan

- [x] `npm test` — 773/773 passing (6 new assertions: split active/orphaned, elision, orphan `GRAPH_NOT_FOUND` carries the reset hint, `TRAVERSAL_NOT_FOUND` precedence, reset-clears-orphan, CLI elision contract).
- [x] `npx tsc --noEmit` clean.
- [x] SKILL.md copies still byte-identical (`plugin-manifest.test.ts` enforces).
- [x] `/simplify` pass applied one cleanup (removed a WHAT-narrating comment with issue-number name-drops per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)