### PR TITLE
fix(memory): lazy open + SQLITE_BUSY retry on memory.db

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -75,3 +75,13 @@ What ships today is the assertion surface, not the sandbox:
 **What would break if reversed:** Making user scripts sandboxed-by-default would require picking a sandbox technology now — each option has real tradeoffs (vm2 is unmaintained, isolated-vm is a native dep, subprocess adds IPC overhead to every hook) and picking wrong is worse than the honest "no sandbox, don't load untrusted graphs" stance.
 
 See issue [#89](https://github.com/duct-tape-and-markdown/freelance/issues/89).
+
+### Memory database opens lazily on first access
+
+`MemoryStore`'s constructor accepts a `() => Db` thunk alongside the eager `Db` form. `composeRuntime` passes the thunk so the SQLite handle is only opened when a memory method is actually invoked. Non-memory CLI verbs (`freelance status`, `visualize`, `validate`) then never touch `memory.db` — which shrinks the cross-process collision surface on WAL-mode open-time locks. That surface is real: `PRAGMA journal_mode = WAL` takes a write lock, last-connection WAL checkpoint takes an exclusive lock, and crash recovery bypasses the busy handler entirely (see `sqlite.org/wal.html` §5). Two concurrent `freelance status` calls used to race each other on a db neither one read.
+
+Two adjacent mitigations travel with the lazy open: (a) `PRAGMA busy_timeout = 5000` is now set *before* `PRAGMA journal_mode = WAL` in `openDatabase` — previously, a losing writer's WAL switch returned `SQLITE_BUSY` immediately because the busy handler hadn't been installed yet; (b) `openDatabase` retries the entire open on SQLITE_BUSY (3 × 50 ms) and, if every attempt is busy, throws `EngineError(EC.DATABASE_BUSY)` so the CLI error envelope replaces the raw `ERR_SQLITE_ERROR` stack trace.
+
+**What would break if reversed:** eager opens re-expose every CLI verb to the open-time races, re-surface the uncaught `ERR_SQLITE_ERROR` stack traces, and drag every invocation's startup cost up by the WAL setup and schema-compatibility checks even when they never read memory.
+
+See issue [#138](https://github.com/duct-tape-and-markdown/freelance/issues/138).

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -23,14 +23,10 @@ import type { SectionResolver, SourceOptions } from "./sources.js";
 import { openStateStore, TraversalStore } from "./state/index.js";
 import type { LoadError, ValidatedGraph } from "./types.js";
 
-/**
- * Build a MemoryStore from a MemoryConfig. Shared by `composeRuntime`
- * and the CLI's `createMemoryStore` helper so the "open the db, build
- * the store" sequence has exactly one site — if we ever add migration
- * or schema-version checks, this is where they go.
- */
+// Thunk form: defers the SQLite open until first memory access. See
+// `docs/decisions.md` § "Memory database opens lazily on first access".
 export function buildMemoryStore(memConfig: MemoryConfig, sourceRoot: string): MemoryStore {
-  return new MemoryStore(openDatabase(memConfig.db), sourceRoot);
+  return new MemoryStore(() => openDatabase(memConfig.db), sourceRoot);
 }
 
 export interface ComposeConfig {

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -54,7 +54,7 @@ export const ENGINE_ERROR_CODES = {
     "INVALID_SHAPE",
     "INVALID_FLAG_VALUE",
   ],
-  BLOCKED: ["NO_EDGES", "STACK_DEPTH_EXCEEDED", ...GATE_BLOCK_CODES],
+  BLOCKED: ["NO_EDGES", "STACK_DEPTH_EXCEEDED", "DATABASE_BUSY", ...GATE_BLOCK_CODES],
   // Hook wiring failures (missing export, bad shape, import error,
   // timeout). Retrying with new context won't repair a broken hook
   // script — surface as INTERNAL so the skill reports instead of loops.
@@ -128,6 +128,7 @@ export const EC = {
   INVALID_FLAG_VALUE: "INVALID_FLAG_VALUE",
   NO_EDGES: "NO_EDGES",
   STACK_DEPTH_EXCEEDED: "STACK_DEPTH_EXCEEDED",
+  DATABASE_BUSY: "DATABASE_BUSY",
   WAIT_BLOCKING: "WAIT_BLOCKING",
   RETURN_SCHEMA_VIOLATION: "RETURN_SCHEMA_VIOLATION",
   VALIDATION_FAILED: "VALIDATION_FAILED",

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -5,6 +5,7 @@
 
 import "./suppress-warnings.js";
 import { DatabaseSync, type SQLInputValue, type StatementSync } from "node:sqlite";
+import { EC, EngineError } from "../errors.js";
 
 // Loose-typed adapter over `node:sqlite`. Centralises the `unknown ↔
 // SQLInputValue / SQLOutputValue` casts in one place so store.ts can
@@ -148,11 +149,76 @@ function migrateDropCollectionColumn(db: Db): void {
   db.exec("ALTER TABLE propositions DROP COLUMN collection");
 }
 
+/**
+ * SQLITE_BUSY detection across node:sqlite's error shape. Matches both
+ * "database is locked" (short timeout / immediate) and "database is
+ * busy" (long-held writer) variants.
+ */
+function isSqliteBusy(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const code = (e as { code?: unknown }).code;
+  return code === "ERR_SQLITE_ERROR" && /database is (locked|busy)/i.test(e.message);
+}
+
+/**
+ * Pause the event loop without pinning a core. Atomics.wait is the only
+ * sync-sleep available to node that's neither a busy loop nor a shell
+ * subprocess. The SharedArrayBuffer is allocated per call — allocation
+ * cost is negligible next to the ms-scale sleep we're timing.
+ */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Retry profile for open-time contention. busy_timeout covers in-query
+// waits (5s of internal retry), but a handful of code paths bypass it:
+// last-connection WAL checkpoint, crash recovery, and deadlock-avoid.
+// https://www.sqlite.org/wal.html §5, https://sqlite.org/forum/forumpost/4350638e78869137.
+// Three 50 ms retries = 150 ms worst-case added latency; low enough to
+// absorb into a CLI invocation, high enough to clear typical sibling-
+// process contention.
+const BUSY_RETRY_DELAYS_MS = [50, 50, 50];
+
+/**
+ * Run `fn`, retrying on SQLITE_BUSY up to BUSY_RETRY_DELAYS_MS.length
+ * extra times. Non-busy errors propagate immediately (no retry). When
+ * every attempt is busy, throws `EngineError(DATABASE_BUSY)` so the
+ * CLI error envelope replaces the raw `ERR_SQLITE_ERROR` stack trace.
+ */
+export function retryOnSqliteBusy<T>(fn: () => T, context: string): T {
+  let lastBusyError: Error | undefined;
+  for (let attempt = 0; attempt <= BUSY_RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return fn();
+    } catch (e) {
+      if (!isSqliteBusy(e)) throw e;
+      lastBusyError = e as Error;
+      if (attempt < BUSY_RETRY_DELAYS_MS.length) {
+        sleepSync(BUSY_RETRY_DELAYS_MS[attempt]);
+      }
+    }
+  }
+  throw new EngineError(
+    `Memory database is busy — another Freelance process has a conflicting lock on ` +
+      `${context}. Re-run the command; contention usually clears in <1s. ` +
+      `(Underlying: ${lastBusyError?.message ?? "SQLITE_BUSY"})`,
+    EC.DATABASE_BUSY,
+  );
+}
+
 export function openDatabase(dbPath: string): Db {
+  return retryOnSqliteBusy(() => openDatabaseOnce(dbPath), dbPath);
+}
+
+function openDatabaseOnce(dbPath: string): Db {
   const inner = new DatabaseSync(dbPath);
+  // busy_timeout must be set before journal_mode: switching to WAL takes
+  // a write lock, and without busy_timeout the SQLite C layer returns
+  // SQLITE_BUSY immediately on contention instead of retrying for 5s.
+  // Default busy handling is 0 ms — per-connection, reset on every open.
+  inner.exec("PRAGMA busy_timeout = 5000");
   inner.exec("PRAGMA journal_mode = WAL");
   inner.exec("PRAGMA foreign_keys = ON");
-  inner.exec("PRAGMA busy_timeout = 5000");
   // Default auto-checkpoint is 1000 pages (≈4 MB at 4 KB pages). We saw a
   // 385 KB database with a 4.25 MB WAL in the wild, which is exactly that
   // threshold. Tighten to 200 pages (≈800 KB) so the WAL is recycled more

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -95,17 +95,26 @@ function hashPropContent(content: string): string {
 }
 
 export class MemoryStore {
-  private db: Db;
+  private _db: Db | undefined;
+  private readonly dbFactory: () => Db;
   private sourceRoot: string;
   private closed = false;
 
-  // Takes an already-opened Db handle. Opening the database (PRAGMA +
-  // DDL + schema check) is a composition-root concern and lives in
-  // src/compose.ts — keeps this constructor pure and makes the class
-  // trivially testable with an in-process db handle.
-  constructor(db: Db, sourceRoot: string) {
-    this.db = db;
+  // Thunk form opens lazily on first `db` access. See
+  // `docs/decisions.md` § "Memory database opens lazily on first access".
+  constructor(db: Db | (() => Db), sourceRoot: string) {
+    if (typeof db === "function") {
+      this.dbFactory = db;
+    } else {
+      this._db = db;
+      this.dbFactory = () => db;
+    }
     this.sourceRoot = sourceRoot;
+  }
+
+  private get db(): Db {
+    if (!this._db) this._db = this.dbFactory();
+    return this._db;
   }
 
   // Thin delegation to the standalone `prune` function. The prune
@@ -126,7 +135,10 @@ export class MemoryStore {
   close(): void {
     if (this.closed) return;
     this.closed = true;
-    this.db.close();
+    // Only close if we actually opened. Close on a never-used lazy store
+    // must be a no-op — otherwise a harmless `status` invocation would
+    // trigger the open it was designed to avoid.
+    if (this._db) this._db.close();
   }
 
   resetAll(): { deleted_propositions: number; deleted_entities: number } {

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { openDatabase } from "../src/memory/db.js";
+import { openDatabase, retryOnSqliteBusy } from "../src/memory/db.js";
 import { MemoryStore } from "../src/memory/store.js";
 
 function createTempDir(): string {
@@ -1023,6 +1023,104 @@ describe("MemoryStore schema migration", () => {
       expect(cols.map((c) => c.name)).not.toContain("collection");
     } finally {
       second.close();
+    }
+  });
+});
+
+describe("MemoryStore lazy open (#138)", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = createTempDir();
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does not invoke the db factory at construction", () => {
+    let opened = 0;
+    const store = new MemoryStore(() => {
+      opened++;
+      return openDatabase(path.join(tmpDir, "memory.db"));
+    }, tmpDir);
+    expect(opened).toBe(0);
+    // Confirm a cleanup without any method call is a pure no-op — no
+    // CLI verb that avoided touching memory should ever accidentally
+    // force the open via close() in a finally block.
+    store.close();
+    expect(opened).toBe(0);
+  });
+
+  it("opens on first memory access and reuses the handle", () => {
+    let opened = 0;
+    const store = new MemoryStore(() => {
+      opened++;
+      return openDatabase(path.join(tmpDir, "memory.db"));
+    }, tmpDir);
+    store.status();
+    expect(opened).toBe(1);
+    store.status();
+    expect(opened).toBe(1);
+    store.close();
+  });
+});
+
+describe("retryOnSqliteBusy (#138)", () => {
+  function busyError(): Error {
+    const e = new Error("database is locked");
+    (e as { code?: string }).code = "ERR_SQLITE_ERROR";
+    return e;
+  }
+
+  it("returns the first successful attempt", () => {
+    let calls = 0;
+    const result = retryOnSqliteBusy(() => {
+      calls++;
+      return "ok";
+    }, "test");
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries through up to 3 busy errors then succeeds", () => {
+    let calls = 0;
+    const result = retryOnSqliteBusy(() => {
+      calls++;
+      if (calls <= 3) throw busyError();
+      return "ok";
+    }, "test");
+    expect(result).toBe("ok");
+    expect(calls).toBe(4);
+  });
+
+  it("throws EngineError DATABASE_BUSY after all retries exhaust", () => {
+    let calls = 0;
+    try {
+      retryOnSqliteBusy(() => {
+        calls++;
+        throw busyError();
+      }, "/tmp/x");
+      expect.fail("expected DATABASE_BUSY to throw");
+    } catch (e) {
+      expect(calls).toBe(4);
+      expect(e).toMatchObject({
+        code: "DATABASE_BUSY",
+        message: expect.stringContaining("/tmp/x"),
+      });
+    }
+  });
+
+  it("re-throws non-busy errors immediately without retry", () => {
+    let calls = 0;
+    const other = new Error("unrelated");
+    try {
+      retryOnSqliteBusy(() => {
+        calls++;
+        throw other;
+      }, "test");
+      expect.fail("expected throw");
+    } catch (e) {
+      expect(calls).toBe(1);
+      expect(e).toBe(other);
     }
   });
 });


### PR DESCRIPTION
Closes #138.

## Summary

Three layered fixes for cross-process CLI concurrency on `memory.db`:

1. **Lazy open.** `MemoryStore` now accepts `Db | (() => Db)`. `composeRuntime` passes a thunk so the SQLite handle is only opened when a memory method is actually invoked. Non-memory verbs (`freelance status`, `visualize`, `validate`) don't touch `memory.db` — eliminates the open-time collision surface for the case the issue's repro hits.
2. **PRAGMA order fix.** `busy_timeout = 5000` is now set *before* `journal_mode = WAL`. Previously, a losing writer's WAL switch returned `SQLITE_BUSY` immediately because the 5s busy handler hadn't been installed yet. Root cause of the race the issue describes, not just a mitigation.
3. **Retry + structured error.** `openDatabase` wraps the real open in `retryOnSqliteBusy` (3 × 50 ms, 150 ms worst case). On exhaustion, throws `EngineError(EC.DATABASE_BUSY)` — a new `BLOCKED`-category code (exit 2) — so the CLI error envelope from #134 replaces the raw `ERR_SQLITE_ERROR` stack trace. Covers the residual SQLite paths that bypass `busy_timeout`: last-connection WAL checkpoint, crash recovery, deadlock-avoidance ([sqlite.org/wal.html §5](https://www.sqlite.org/wal.html), [sqlite forum 4350638e](https://sqlite.org/forum/forumpost/4350638e78869137)).

Issue body proposed direction 1 alone (retry + code). The web-research pass (sqlite.org docs + forum) surfaced the PRAGMA-ordering root cause, so that got folded in as a bonus.

## Notes

- The `Db | (() => Db)` constructor union keeps the eager path for tests + any caller that opens explicitly. The getter (`private get db()`) makes all 42 internal `this.db.X` call sites work unchanged.
- `sleepSync` uses `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)` — only sync sleep node offers that doesn't pin a core or spawn a subprocess. Only fires on the failure path.
- `docs/decisions.md` captures the invariant and what would break if reversed.

## Test plan

- [x] `npm test` — 773 → 779 passing (6 new: 2 lazy-open + 4 `retryOnSqliteBusy`).
- [x] `npx tsc --noEmit` clean.
- [x] `/simplify` pass: removed duplicated cross-file prose from compose.ts and store.ts, elevated to `docs/decisions.md`. Dismissed a dead-closure finding as false positive (alternatives strictly worse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)