### PR TITLE
docs+cli: conventions, feature checklist, meta byte caps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,25 @@ After a non-trivial batch of code changes (multiple files or a cohesive multi-st
 
 When iterating on a design (proposal, issue body, new mode/option, added column), check each addition against existing system invariants **before** drafting. If the case the addition addresses isn't expressible in the current schema or types, the addition is solving an imaginary problem — kill it at the premise, not at review. Memory invariants live in `docs/memory-intent.md` (architectural qualities + anti-patterns) and in the schemas under `src/memory/` + `src/schema/`; read both before proposing a new mode, column, or tool. Concrete example: `memory_emit` requires `sources: [min 1]` on every proposition, so there is no "non-source-aligned" proposition — a prune mode scoped to that case would be solving a case the schema makes malformed.
 
+## Feature authoring checklist
+
+Before declaring a feature done, walk the five dimensions — otherwise the first pass will miss adjacent surfaces and take multiple rounds to catch up. This is a prompt for Claude as much as a human reference.
+
+- **Agent journey.** What does the LLM see on discovery (e.g. `freelance_guide <topic>`), on successful use (response shape, suggested tools, next edges), and on recovery (blocked vs. structural error, recovery hint)? Trace it end-to-end.
+- **Operator journey.** Human at the shell with `freelance <verb>`. JSON output is the wire format; does it parse cleanly under `jq`? What does a debugging operator see on disk under `.freelance/`?
+- **Adjacent-surface sweep.** Touch each relevant surface or consciously skip:
+  - `docs/decisions.md` if the feature names a cross-file invariant.
+  - `plugins/freelance/skills/freelance/SKILL.md` + `templates/skills/freelance/SKILL.md` (byte-identical — `plugin-manifest.test.ts` enforces) if the skill protocol changes.
+  - CLI verb descriptions / tool descriptions if behavior changes.
+  - Error messages that reference the new surface where the operator is likely to hit them.
+  - Graph schema (`src/schema/`) if a new field or validation applies.
+  - `freelance validate` if there's a new lint rule.
+  - `freelance init` templates if a starter should demonstrate the pattern.
+- **Migration.** Existing on-disk records (traversal JSON, memory.db rows), existing scripts calling the verb, existing graph yaml. Does the change read correctly against pre-feature state, or is a migration needed?
+- **Observability.** How do success, failure, and ambiguous cases surface? Structured error envelope (`errorKind: "blocked" | "structural"`), exit codes, breadcrumbs on stderr — pick the right channel for each.
+
+Not a PR template — keep it inline so it's visible during authoring, not a checkbox exercise on submit.
+
 ## WHY-comments vs decisions log
 
 Inline WHY comments are fine when a reader scanning *this file* needs the context at the point of reading: a local invariant, a subtle workaround, a non-obvious choice the code itself can't express. When the WHY has cross-file implications — names an invariant other modules rely on, documents a tradeoff a future change elsewhere would break, or captures a decision deliberated in an issue thread — elevate to `docs/decisions.md` and optionally cross-link from the inline comment.
@@ -105,6 +124,16 @@ Source bindings in graphs use relative paths (e.g. `docs/topics/training.md`). T
 - `~/.freelance/` → source root is `~/`
 
 Override with `--source-root <path>` (CLI) or `sourceRoot` (ServerOptions).
+
+## Conventions
+
+Durable contracts surfaced across multiple features. If a new feature extends one of these, match the shape; don't re-invent a parallel idiom.
+
+**Keyed-dict fields on traversal responses are always-present, possibly-empty.** `context` and `meta` are `Record<K, V>` on every response — empty `{}` when untouched, never absent. Callers (agents, hooks) read `meta[key]` without null-checking the map. On-disk `TraversalRecord` keeps these optional for storage compactness; the store normalizes at read time with a frozen-empty sentinel (see `EMPTY_META` in `src/state/traversal-store.ts`). New keyed-dict fields follow the same pattern: optional on disk, always-present on the wire.
+
+**Hook cross-layer capabilities flow through `runHooksFor` parameters, surfaced via optional `HookContext` fields.** Hooks can't import the store; host capabilities they need (memory reads, meta writes) are threaded as parameters through `engine.runHooksOnArrival` → `runHooksFor` → `HookContext`. `HookRunner` stays stateless — it holds configuration, not capabilities. Adding a new capability = add a parameter on `runHooksFor` and an optional field on `HookContext` (`src/engine/hooks.ts`). Don't open a back door by reaching into the store from inside a hook body.
+
+**`splitKeyValue` is the single CLI primitive for `key=value` flags.** `--meta`, `--filter`, and `context set` all parse `key=value` pairs. One helper in `src/cli/traversals.ts` splits on the first `=`, validates a non-empty key, and throws a consistent error. Value handling (string-only for meta, JSON-coerced for context, byte-capped for meta via `parseMetaPairs`) stays at the caller — domain-specific — but the split + empty-key guard is shared.
 
 ## Project structure
 

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -54,6 +54,13 @@ function parseContextJson(raw: string): Record<string, unknown> {
   }
 }
 
+// Byte caps for meta key/value pairs at the CLI boundary. Key names
+// are short by design; values are tag-sized (URLs, ticket ids, branch
+// names), not blob-sized. `--filter` uses the same caps since a value
+// larger than the cap couldn't have been stored to match against.
+export const META_KEY_MAX_BYTES = 256;
+export const META_VALUE_MAX_BYTES = 4096;
+
 // Values stay strings — meta is deliberately opaque, so (unlike
 // `freelance context set`) no JSON coercion here.
 function parseMetaPairs(pairs: string[] | undefined, flag: string): Record<string, string> {
@@ -61,6 +68,20 @@ function parseMetaPairs(pairs: string[] | undefined, flag: string): Record<strin
   if (!pairs) return out;
   for (const pair of pairs) {
     const [key, value] = splitKeyValue(pair, flag);
+    const keyBytes = Buffer.byteLength(key, "utf-8");
+    if (keyBytes > META_KEY_MAX_BYTES) {
+      throw new EngineError(
+        `${flag} key exceeds ${META_KEY_MAX_BYTES}-byte cap (got ${keyBytes} bytes)`,
+        EC.INVALID_META,
+      );
+    }
+    const valueBytes = Buffer.byteLength(value, "utf-8");
+    if (valueBytes > META_VALUE_MAX_BYTES) {
+      throw new EngineError(
+        `${flag} value for "${key}" exceeds ${META_VALUE_MAX_BYTES}-byte cap (got ${valueBytes} bytes)`,
+        EC.INVALID_META,
+      );
+    }
     out[key] = value;
   }
   return out;

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -292,6 +292,87 @@ describe("traversalStart --meta", () => {
       store.close();
     }
   });
+
+  it("rejects a --meta key over the 256-byte cap with INVALID_META", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      const oversizedKey = "k".repeat(257);
+      await expect(
+        traversalStart(store, graphId, undefined, { meta: [`${oversizedKey}=x`] }),
+      ).rejects.toThrow("process.exit");
+      const parsed = stdoutJson() as { error?: { code?: string; message?: string } };
+      expect(parsed.error?.code).toBe("INVALID_META");
+      expect(parsed.error?.message).toMatch(/256-byte cap/);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rejects a --meta value over the 4096-byte cap with INVALID_META", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      const oversizedValue = "v".repeat(4097);
+      await expect(
+        traversalStart(store, graphId, undefined, { meta: [`k=${oversizedValue}`] }),
+      ).rejects.toThrow("process.exit");
+      const parsed = stdoutJson() as { error?: { code?: string; message?: string } };
+      expect(parsed.error?.code).toBe("INVALID_META");
+      expect(parsed.error?.message).toMatch(/4096-byte cap/);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("accepts --meta at exactly the cap", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      const key = "k".repeat(256);
+      const value = "v".repeat(4096);
+      await traversalStart(store, graphId, undefined, { meta: [`${key}=${value}`] });
+      const parsed = stdoutJson() as { meta: Record<string, string> };
+      expect(parsed.meta[key]).toBe(value);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("measures byte length not character length (rejects multibyte UTF-8 over cap)", async () => {
+    const store = createTestStore();
+    try {
+      const graphId = store.listGraphs().graphs[0]?.id;
+      if (!graphId) return;
+      // "🎯" is 4 UTF-8 bytes; 1025 repeats = 4100 bytes (> 4096 cap) but
+      // only 2050 JS string length. Confirms we cap on Buffer.byteLength.
+      const multibyte = "🎯".repeat(1025);
+      await expect(
+        traversalStart(store, graphId, undefined, { meta: [`k=${multibyte}`] }),
+      ).rejects.toThrow("process.exit");
+      const parsed = stdoutJson() as { error?: { code?: string } };
+      expect(parsed.error?.code).toBe("INVALID_META");
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe("traversalStatus --filter enforces the same meta caps (#62)", () => {
+  it("rejects --filter value over the cap — caps are symmetric", () => {
+    const store = createTestStore();
+    try {
+      const oversized = "v".repeat(4097);
+      expect(() => traversalStatus(store, { filter: [`k=${oversized}`] })).toThrow("process.exit");
+      const parsed = stdoutJson() as { error?: { code?: string } };
+      expect(parsed.error?.code).toBe("INVALID_META");
+    } finally {
+      store.close();
+    }
+  });
 });
 
 describe("traversalStatus --filter (operator-side)", () => {


### PR DESCRIPTION
Closes #60, #61, #62.

## Summary

Three small, related cleanups batched as one PR since they all touch authoring hygiene.

**#60 — Conventions section in CLAUDE.md.** Captures three durable contracts surfaced across recent features so they don't get re-invented:
- Keyed-dict response fields (`context`, `meta`) are always-present, empty when untouched — callers read `meta[key]` without null checks. `EMPTY_META` sentinel in `src/state/traversal-store.ts`.
- Hook cross-layer capabilities flow through `runHooksFor` parameters surfaced via optional `HookContext` fields (`src/engine/hooks.ts`). `HookRunner` stays stateless.
- `splitKeyValue` is the single CLI primitive for `key=value` flags (`src/cli/traversals.ts`). `--meta`, `--filter`, `context set` all use it.

**#61 — Feature authoring checklist in CLAUDE.md.** Five dimensions to walk before declaring a feature done: agent journey, operator journey, adjacent-surface sweep, migration, observability. Kept inline rather than as `.github/pull_request_template.md` so it's visible *during* authoring, not a checkbox on submit.

**#62 — Meta key/value byte caps at the CLI boundary.** `parseMetaPairs` now rejects keys > 256 bytes or values > 4096 bytes with `EngineError(EC.INVALID_META)`. Measures `Buffer.byteLength("utf-8")` so a multibyte payload can't slip past a character-length check. Caps exported as `META_KEY_MAX_BYTES` / `META_VALUE_MAX_BYTES`. Applies to `--filter` too for symmetry (nothing larger than the cap could have been stored, so nothing to match against).

## Notes

- #62 re-scoped per my earlier comment on the issue: post-MCP-removal, the boundary is `parseMetaPairs` not a Zod tool schema.
- UTF-8 byte-length test included — `"🎯".repeat(1025)` has 2050 JS string length but 4100 bytes, and is correctly rejected.

## Test plan

- [x] `npm test` — 779 → 784 passing (5 new `#62` tests: oversized key, oversized value, at-cap pass, multibyte byte-length check, `--filter` symmetry).
- [x] `npx tsc --noEmit` clean.
- [x] CLAUDE.md edits reviewed against CLAUDE.md's own comment rules (no WHAT-narration, no PR name-drops in inline text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)