### PR TITLE
docs(evaluator): declare expression-language stop-line (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ nodes:
 
 **Subgraph composition** — Nodes can push into child workflows with scoped context. `contextMap` passes parent values in, `returnMap` passes child values back. The engine manages a stack, so subgraphs can nest.
 
-**Expression evaluator** — Edge conditions and validations use a safe expression language (`context.x == 'value'`, `context.count > 0`, boolean operators, nested property access). Validated at load time, evaluated at runtime.
+**Expression evaluator** — Edge conditions and validations use a safe expression language (`context.x == 'value'`, `context.count > 0`, boolean operators, nested property access). Validated at load time, evaluated at runtime. The grammar is deliberately closed — expressions are predicates, not computations; derive values in an `onEnter` hook and compare the result. See `docs/decisions.md` § "Expression language stop-line" or `freelance guide expressions`.
 
 **onEnter hooks** — Any node can declare `onEnter: [{ call, args }]` hooks that run before the agent sees the node. `call` resolves to either a built-in hook (`memory_status`, `memory_browse`) or a local script path (`./scripts/fetch-context.js`). Hooks receive resolved args, live context, and the memory store, and return a plain object of context updates. Strict-context enforcement still applies. Per-hook timeout defaults to 5000ms, configurable via `hooks.timeoutMs` in `config.yml`. Script hooks are validated at `freelance validate` time (eager import) — syntax errors, missing deps, and non-function default exports surface before the first traversal hits the node.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -85,3 +85,17 @@ Two adjacent mitigations travel with the lazy open: (a) `PRAGMA busy_timeout = 5
 **What would break if reversed:** eager opens re-expose every CLI verb to the open-time races, re-surface the uncaught `ERR_SQLITE_ERROR` stack traces, and drag every invocation's startup cost up by the WAL setup and schema-compatibility checks even when they never read memory.
 
 See issue [#138](https://github.com/duct-tape-and-markdown/freelance/issues/138).
+
+### Expression language stop-line: predicates, not computations
+
+`src/evaluator.ts` is a hand-rolled tokenizer plus recursive-descent parser — literals, `context.` property access, `&& || !`, `== != > < >= <=`, and a single built-in `len()`. Every request to extend it (add `startsWith`, add regex, add arithmetic, add array membership) has to answer the same question: what's the stop-line? Without one, the language ratchets outward one operator at a time until it's a general-purpose mini-language with its own tokenizer bugs and security surface. Three rules, in order:
+
+1. **Expressions are predicates, not computations.** The evaluator returns `boolean`. No arithmetic, no string construction, no value transformations. If a graph needs `lowercase(x)` or `a + b`, that work belongs in a hook that writes the derived value back to context; the edge condition then compares the derived field. This keeps the parser's output type trivially checkable at load time and keeps graph authors from debugging subtle coercion in a DSL they didn't know they were writing.
+2. **Built-in functions must be total and side-effect free.** `len()` qualifies — it's defined for every input (returns 0 for non-array-non-string), throws nothing, reads nothing outside its argument. A hypothetical `fileExists()` or `fetchStatus()` would not; those belong in hooks where the failure mode is a visible hook error, not a silent `false`. New built-ins must clear both bars: total (defined everywhere, no throw paths) and side-effect free (no I/O, no globals, no `Date.now()`).
+3. **Context is the only data source.** No environment variables, no `process.env`, no `Date.now()`, no filesystem reads. An expression evaluated twice with the same context must return the same value. This makes graphs reproducible — replay the same context, get the same routing decision — and keeps the attack surface tiny (a malicious graph can't exfiltrate env via an edge condition).
+
+The rationale is cumulative: small surface (one parser, one evaluator, bounded grammar), small attack area (no I/O primitive a graph author can reach), auditable load-time validation (`extractPropertyComparisons` can statically enumerate every comparison because the grammar is closed), and forced separation of concerns (derivations live in hooks, which have a trust model, timeouts, and a test story — see "Hook trust model" above).
+
+**What would break if reversed:** Adding a `startsWith` or regex operator looks cheap in isolation. The second operator has to decide whether it composes with the first (is `!startsWith(x, "http")` valid? how about `startsWith(lower(x), "http")`?); the third has to decide whether built-ins can take other built-ins as arguments. Each choice accretes parser complexity and user-facing surprise. Keeping the grammar closed and pushing derivations to hooks means the extension point is `onEnter` hooks — which already have a trust model, a timeout, and a well-defined error envelope — rather than an ever-growing DSL.
+
+See issue [#93](https://github.com/duct-tape-and-markdown/freelance/issues/93).

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1,3 +1,5 @@
+// Grammar scope is a deliberate stop-line — see docs/decisions.md § "Expression language stop-line".
+
 export class EvaluatorError extends Error {
   constructor(
     message: string,
@@ -187,7 +189,7 @@ function tokenize(expr: string): Token[] {
         tokens.push({ type: "PROPERTY", value: ident, pos: start });
       } else {
         throw new EvaluatorError(
-          `Unexpected identifier '${ident}' at position ${start}. Property access must start with 'context.', or call a built-in function (${[...BUILTIN_FUNCTIONS].join(", ")}).`,
+          `Unexpected identifier '${ident}' at position ${start}. Property access must start with 'context.', or call a built-in function (${[...BUILTIN_FUNCTIONS].join(", ")}). Expressions are predicates, not computations — derive values in an onEnter hook and compare the result.`,
           expr,
           start,
         );

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -6,6 +6,7 @@ export const GUIDE_TOPICS = [
   "subgraphs",
   "wait-nodes",
   "onenter-hooks",
+  "expressions",
   "multi-agent",
   "meta",
   "memory-workflows",
@@ -383,6 +384,54 @@ Operators in shared-graph-registry scenarios (untrusted contributors, multi-agen
 - **Fail loud**: if a hook can't complete its job, throw. Don't return partial data.
 - **Keep hooks short**: they block node arrival. Use them for fast lookups (<100ms typical), not heavy work.
 - **Version scripts alongside graphs**: \`.freelance/scripts/\` lives next to the workflows that reference it.`,
+
+  expressions: `# Expressions
+
+Edge conditions (\`condition: "context.x == 'ready'"\`) and gate validations (\`expr: "context.count > 0"\`) use a small expression language. It's deliberately narrow — the grammar is closed and will stay that way.
+
+## What's in the language
+
+- **Literals:** strings (\`'single-quoted'\`), numbers (\`42\`, \`3.14\`), booleans (\`true\`, \`false\`), \`null\`
+- **Property access:** \`context.foo\`, \`context.nested.value\` — must start with \`context.\`
+- **Comparison:** \`==\`, \`!=\`, \`>\`, \`<\`, \`>=\`, \`<=\`. No type coercion — \`context.x == '5'\` is false when \`x\` is the number \`5\`
+- **Logic:** \`&&\`, \`||\`, \`!\`, parentheses for grouping
+- **Built-in:** \`len(x)\` — length of arrays and strings; \`0\` for anything else (including null/missing)
+
+## What's not in the language (and won't be)
+
+No arithmetic (\`a + b\`), no string operations (\`startsWith\`, \`contains\`, regex), no array membership (\`x in xs\`), no environment access (\`Date.now()\`, \`process.env\`), no multi-argument functions.
+
+Three rules govern the stop-line (see \`docs/decisions.md\` § "Expression language stop-line"):
+
+1. **Expressions are predicates, not computations.** The evaluator returns boolean. No value transformations.
+2. **Built-in functions must be total and side-effect free.** \`len\` qualifies. A function that reads files, calls APIs, or throws on bad input doesn't.
+3. **Context is the only data source.** No env vars, no clock, no filesystem. Replaying the same context must yield the same result.
+
+## When you want something that isn't there
+
+The pattern is **derive in a hook, compare in the expression**. If you need \`context.url.startsWith('https://')\`, add an \`onEnter\` hook that computes \`context.isHttps\` and write the edge condition as \`context.isHttps == true\`.
+
+\`\`\`yaml
+nodes:
+  fetch:
+    type: action
+    onEnter:
+      - call: ./scripts/classify-url.js
+        args:
+          url: context.url
+      # script returns { isHttps: true/false }
+    edges:
+      - target: secure-path
+        condition: "context.isHttps == true"
+      - target: insecure-path
+        default: true
+\`\`\`
+
+This keeps the expression language auditable (every comparison is statically enumerable via \`extractPropertyComparisons\`), keeps the hook surface the place where I/O and derivations live (with timeouts and a trust model — see \`onenter-hooks\`), and keeps edge conditions reproducible from context alone.
+
+## Load-time checks
+
+\`freelance validate\` tokenizes and parses every \`condition\` and \`validations[].expr\`. Syntax errors surface at validate time, not mid-traversal. If a node declares a \`context\` schema with an \`enum\`, comparisons against that field are statically checked against the declared values — a typo like \`context.phase == 'raceSpecific'\` against \`enum: [race-specific, ...]\` fails validation. See the \`conventions\` topic § "Context Enums".`,
 
   "multi-agent": `# Multi-Agent Workflows
 


### PR DESCRIPTION
Closes #93.

## Summary
Three rules, written down in `docs/decisions.md`:
- Expressions are predicates, not computations.
- Built-in functions must be total and side-effect free.
- Context is the only data source.

Cross-linked from `src/evaluator.ts` header, a new `freelance_guide expressions` topic, and the README's expression-evaluator paragraph so the next "please add `startsWith` / regex / arithmetic" request has a pointer.

Also adds a one-line nudge to the `Unexpected identifier` evaluator error — an author who types `startsWith(context.x, 'y')` into a condition now hits the stop-line language at the failure point instead of a bare "unexpected identifier".

## Test plan
- [x] `npm run build`
- [x] `npm test` (784 passed)
- [x] `npx tsc --noEmit`
- [x] Feature authoring checklist walked