### PR TITLE
docs(CLAUDE+SKILL+decisions): cleanup dead MCP surface, promote 3 invariants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,13 +52,13 @@ npm publishing is **CI-driven by GitHub Releases** (`.github/workflows/publish.y
 Flow for a patch release (e.g. 1.3.2 → 1.3.3):
 
 1. Graduate `[Unreleased]` in `CHANGELOG.md` to `[<version>] - YYYY-MM-DD`. Leave a fresh empty `[Unreleased]` above it.
-2. `npm version patch --no-git-tag-version` — bumps `package.json` + `package-lock.json`, runs the `version` script which invokes `scripts/sync-plugin-version.mjs` to rewrite `plugin.json`, `marketplace.json`, and `plugins/freelance/.mcp.json` (exact pin `freelance-mcp@<version>`).
-3. The `version` script only `git add`s `plugin.json` — **manually stage the rest**: `git add CHANGELOG.md package.json package-lock.json .claude-plugin/marketplace.json plugins/freelance/.mcp.json`.
+2. `npm version patch --no-git-tag-version` — bumps `package.json` + `package-lock.json`, runs the `version` script which invokes `scripts/sync-plugin-version.mjs` to rewrite `plugin.json` and `marketplace.json`.
+3. The `version` script only `git add`s `plugin.json` — **manually stage the rest**: `git add CHANGELOG.md package.json package-lock.json .claude-plugin/marketplace.json`.
 4. `git commit -m "release: <version>"` and `git tag v<version>`.
 5. Push main + tag: `git push origin main v<version>`.
 6. `gh release create v<version> --title "v<version>" --notes "$(...)"` — CI workflow picks this up and publishes to npm.
 
-Why `.mcp.json` pins exactly (not `^<major>`): npx keys its `_npx/<hash>` cache by the raw spec string, so a range reuses any satisfying cached version and never re-resolves (npm/cli#7838, #6804). Exact pinning changes the cache key each release so `/plugin update` actually delivers the new server. See CHANGELOG [1.3.3] and the file-header comment in `scripts/sync-plugin-version.mjs`.
+Historical context: Why `.mcp.json` pins exactly (not `^<major>`): npx keys its `_npx/<hash>` cache by the raw spec string, so a range reuses any satisfying cached version and never re-resolves (npm/cli#7838, #6804). Exact pinning changes the cache key each release so `/plugin update` actually delivers the new server. See CHANGELOG [1.3.3] and the file-header comment in `scripts/sync-plugin-version.mjs`. The mechanism is inactive after MCP removal in #121.
 
 ## Code navigation
 
@@ -83,49 +83,33 @@ Schema: `workflows` (string[]), `memory.enabled` (bool), `memory.dir` (string), 
 
 Arrays concatenate across files. Scalars use highest-precedence value. Per-field CLI/env/config surface is documented in `src/config.ts` and in the README's Configuration section.
 
-### Graph Directory Resolution
+### Graph directory resolution
 
-Graphs can be loaded from multiple directories in cascading order (later directories shadow earlier ones):
+Graphs load from multiple directories in cascading order (later shadow earlier):
 
-**Automatic resolution** (no flags needed):
 1. `./.freelance` (project-level, if exists)
 2. `~/.freelance` (user-level, if exists)
-3. Additional dirs from `config.yml` / `config.local.yml` `workflows:` key
+3. Additional dirs from `workflows:` in `config.yml` / `config.local.yml`
 
-**Explicit directories** (CLI):
-```bash
-# Load from multiple directories (repeatable)
-freelance mcp --workflows ./.freelance --workflows ~/.freelance
-```
+Override automatic resolution with repeatable `--workflows <dir>` on any runtime verb.
 
 ### Commands
 
 ```bash
-# Validate graph definitions
-freelance validate ./path/to/graphs/
-
-# Visualize a graph
-freelance visualize ./graphs/my.workflow.yaml --format mermaid
-
-# Start standalone MCP server (auto-loads from ./graphs + ~/.freelance)
-freelance mcp
-
-# Start standalone with explicit directories
-freelance mcp --workflows ./graphs --workflows ~/.freelance
-
-# Project setup
-freelance init
+freelance status                                     # discover loaded graphs + active traversals
+freelance start <graphId>                            # begin a traversal
+freelance advance <edge>                             # step; emits JSON
+freelance inspect [<id>]                             # recover after compaction
+freelance validate ./path/to/graphs/                 # author-time check
+freelance visualize ./graphs/my.workflow.yaml        # JSON with mermaid inline
+freelance init                                       # project setup
 ```
 
-### Source Path Resolution
+All runtime verbs emit structured JSON with semantic exit codes. There is no long-running server process — see `docs/decisions.md` § "CLI is the execution surface for agents" and § "MCP server and tool surface deleted".
 
-Source bindings in graphs use relative paths (e.g. `docs/topics/training.md`). These resolve relative to the **source root**, which defaults to the parent of the first graphsDir:
+### Source path resolution
 
-- `./.freelance/` → source root is `./` (project root)
-- `../dev-docs/.freelance/` → source root is `../dev-docs/`
-- `~/.freelance/` → source root is `~/`
-
-Override with `--source-root <path>` (CLI) or `sourceRoot` (ServerOptions).
+Source bindings in graphs use relative paths; they resolve relative to the **source root**, which defaults to the parent of the first graphsDir. See `docs/decisions.md` § "Source root binds to first graphsDir's parent". Override with `--source-root <path>`.
 
 ## Conventions
 
@@ -164,7 +148,6 @@ Durable contracts surfaced across multiple features. If a new feature extends on
 - `src/builder.ts` — Programmatic workflow graph construction (GraphBuilder)
 - `src/config.ts` — Unified config loader (config.yml + config.local.yml schema, merging, writing); per-field CLI/env/config surface documented inline
 - `src/graph-resolution.ts` — Graph directory resolution and loading (env var, project, user, config cascading)
-- `src/server.ts` — MCP tool surface (traversal, guide, distill, sources, validate, memory); calls `composeRuntime` and registers tools
 - `src/cli/` — CLI subcommand handlers (init, validate, visualize, traversals, stateless, memory, config, output, setup)
   - `cli/program.ts` — Commander program construction (imported by `bin.ts`)
   - `cli/setup.ts` — `createTraversalStore` + `createMemoryStore`; layout helpers (`ensureFreelanceDir`, `resolveTraversalsDir`, `memoryDbPathFor`); `resolveMemoryConfig` with symmetric `--memory`/`--no-memory` precedence

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -116,3 +116,39 @@ The rationale is cumulative: small surface (one parser, one evaluator, bounded g
 **What would break if reversed:** Adding a `startsWith` or regex operator looks cheap in isolation. The second operator has to decide whether it composes with the first (is `!startsWith(x, "http")` valid? how about `startsWith(lower(x), "http")`?); the third has to decide whether built-ins can take other built-ins as arguments. Each choice accretes parser complexity and user-facing surprise. Keeping the grammar closed and pushing derivations to hooks means the extension point is `onEnter` hooks — which already have a trust model, a timeout, and a well-defined error envelope — rather than an ever-growing DSL.
 
 See issue [#93](https://github.com/duct-tape-and-markdown/freelance/issues/93).
+
+### Source root binds to first graphsDir's parent
+
+Relative source paths in graph `sources:` bindings resolve against the **source root**, which defaults to the parent of the *first* graphsDir in the resolution cascade. Under multi-dir cascade (`./.freelance` + `~/.freelance` + workflow dirs), graphs in later dirs resolving their sources relative to their *own* dir get stale/missing reads — the loader doesn't rewrite per-graph.
+
+Workflows intended to ship in user-level or plugin directories must use absolute paths or set a shared source root via `--source-root <path>` (CLI) or `sourceRoot` on `composeRuntime`.
+
+**What would break if reversed:** per-graph source roots would let plugin authors ship workflows with sources co-located in the plugin directory, but introduces ambiguity when a user-level workflow references a project-level source file. The first-graphsDir rule is a single anchor; every graph author knows where their paths resolve from.
+
+Anchors: `src/graph-resolution.ts`, `src/sources.ts`, `src/compose.ts` (sourceRoot plumbing), README § "Workflow directories". Closes #98.
+
+### Subgraph traversal is a session-boundary crossing; returnMap is the explicit contract
+
+A subgraph push is a traversal-session boundary. `freelance inspect --detail history` treats the push as a boundary marker — context writes inside the subgraph are visible via the subgraph's own history, and values flow back to the parent *only* through the explicit `returnMap` declared on the subgraph node.
+
+Implicit context bleed (subgraph writes a key, parent reads it on resume) is not supported. Callers that want cross-boundary data pass it via `returnMap: { parentKey: childKey }`; the engine validates the shape and fails loudly on missing return keys.
+
+**What would break if reversed:** implicit bleed makes subgraphs non-reusable — a subgraph's internal context keys become an API the parent depends on. `returnMap` as the explicit contract means a subgraph can refactor its internals without breaking callers, and a parent knows exactly which keys it receives.
+
+Anchors: `src/engine/subgraph.ts` (push/pop + returnMap validation), `src/schema/graph-schema.ts` (SubgraphNode schema), `src/engine/engine.ts` (pop path). Closes #96.
+
+### Projection vocabulary is a deliberate three-way split
+
+Three projection flags, three non-overlapping axes — don't unify:
+
+- `--minimal` (bool) = response-size tier on the hot path (`advance`, `context set`, `inspect`)
+- `--fields <name>` (repeatable) = opt-in graph-piece projections on inspect (`currentNode | neighbors | contextSchema | definition`)
+- `--shape minimal|full` (enum) = memory-specific provenance detail level (`memory inspect`)
+
+They don't substitute. `advance --shape` and `memory inspect --minimal` both fail `INVALID_FLAG_VALUE`. SKILL.md teaches the one-sentence mental model; the flags map to different surfaces and different caller contracts.
+
+**Rejected proposal: unify on a single projection verb (e.g. `--shape` everywhere).** The three flags cover three axes: response-size tier, additive graph-piece projection, memory provenance detail. Collapsing them erases axis distinctions and breaks caller contracts — `memory_inspect` onEnter defaults to `shape: "minimal"` for response-ceiling reasons specific to memory; `--fields` on inspect must be repeatable because callers combine projections; `--minimal` is a bool on the hot path because that's what per-turn size-tier branching needs. Any future proposal to unify must first specify which of these three contracts it breaks and why the break is worth it.
+
+**What would break if reversed:** a single projection verb collapses three axes into one; callers lose the per-surface defaults and additivity they rely on.
+
+Anchors: `src/types.ts` (minimal response shapes), `src/memory/types.ts` (PropositionShape), `src/cli/output.ts`, SKILL.md § "Three projection verbs, three axes".

--- a/plugins/freelance/skills/freelance/SKILL.md
+++ b/plugins/freelance/skills/freelance/SKILL.md
@@ -134,6 +134,14 @@ freelance inspect [<traversalId>] --fields currentNode --fields neighbors
 
 Use it on the steady-state loop once you've seen the node's `instructions` at least once and you're just picking edges. Drop `--minimal` (or call `freelance inspect`) to resync to the full shape after compaction or when you land on a new node you haven't seen yet.
 
+### Three projection verbs, three axes
+
+- Response size → `--minimal` (bool, hot-path verbs: `advance`, `context set`, `inspect`)
+- Extra fields → `--fields <name>` (repeatable, inspect only)
+- Memory provenance depth → `--shape minimal|full` (memory inspect only)
+
+They don't substitute. `advance --shape` and `memory inspect --minimal` both fail `INVALID_FLAG_VALUE`.
+
 ## Subgraphs
 
 Some workflows push subgraph calls. Responses include:

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -559,7 +559,7 @@ Start with \`externalKey\` only. After the PR is opened, call \`freelance meta s
 
   "memory-workflows": `# Memory Workflows
 
-Freelance ships two sealed workflows that own writes to the knowledge graph. Direct calls to \`memory_emit\` and \`memory_prune\` are gated — they only succeed while a workflow traversal is active. Read tools (\`memory_browse\`, \`memory_inspect\`, \`memory_search\`, \`memory_related\`, \`memory_by_source\`, \`memory_status\`) are always available.
+Freelance ships two sealed workflows that own writes to the knowledge graph. Direct calls to \`memory_emit\` and the CLI verb \`freelance memory prune\` are gated — they only succeed while a workflow traversal is active. Read tools (\`memory_browse\`, \`memory_inspect\`, \`memory_search\`, \`memory_related\`, \`memory_by_source\`, \`memory_status\`) are always available.
 
 ## memory:compile
 
@@ -585,7 +585,7 @@ The proposition rubric (atomicity, independence test, relationship exception) an
 
 ## User-authored graphs can also use memory tools
 
-The \`memory_emit\` / \`memory_prune\` gate only checks that *some* traversal is active — not specifically one of the sealed workflows. If you author your own graph that writes to memory, carry your own authoring guidance in your node instructions (or reuse the sealed workflow's via a subgraph push).`,
+The \`memory_emit\` / \`freelance memory prune\` gate only checks that *some* traversal is active — not specifically one of the sealed workflows. If you author your own graph that writes to memory, carry your own authoring guidance in your node instructions (or reuse the sealed workflow's via a subgraph push).`,
 
   "anti-patterns": `# Anti-Patterns
 

--- a/templates/skills/freelance/SKILL.md
+++ b/templates/skills/freelance/SKILL.md
@@ -134,6 +134,14 @@ freelance inspect [<traversalId>] --fields currentNode --fields neighbors
 
 Use it on the steady-state loop once you've seen the node's `instructions` at least once and you're just picking edges. Drop `--minimal` (or call `freelance inspect`) to resync to the full shape after compaction or when you land on a new node you haven't seen yet.
 
+### Three projection verbs, three axes
+
+- Response size → `--minimal` (bool, hot-path verbs: `advance`, `context set`, `inspect`)
+- Extra fields → `--fields <name>` (repeatable, inspect only)
+- Memory provenance depth → `--shape minimal|full` (memory inspect only)
+
+They don't substitute. `advance --shape` and `memory inspect --minimal` both fail `INVALID_FLAG_VALUE`.
+
 ## Subgraphs
 
 Some workflows push subgraph calls. Responses include:


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — drop the stale `freelance mcp` surface from § Graph directory resolution / Commands / Source path resolution; delete `src/server.ts` bullet from § Project structure; mark the `.mcp.json` exact-pin paragraph as historical context after MCP removal in #121. The Commands block now lists the actual CLI verbs and cross-refs `docs/decisions.md` § "CLI is the execution surface for agents" / § "MCP server and tool surface deleted".
- **SKILL.md** (both copies, byte-identical per `plugin-manifest.test.ts`) — new subsection `### Three projection verbs, three axes` after the `--minimal` section, teaching the one-sentence mental model for `--minimal` vs `--fields` vs `--shape`.
- **docs/decisions.md** — three new invariant entries: "Source root binds to first graphsDir's parent" (closes #98), "Subgraph traversal is a session-boundary crossing; returnMap is the explicit contract" (closes #96), and "Projection vocabulary is a deliberate three-way split". `src/guide.ts` § Memory Workflows updated to distinguish the MCP `memory_emit` tool from the CLI `freelance memory prune` verb.

Docs/comments only — no runtime code or schema changes.

## Test plan

- [x] \`npm run build\` — passes (tsc clean)
- [x] \`npm test\` — 39 test files, 784 tests passed (includes \`plugin-manifest.test.ts\` SKILL.md byte-identity check)
- [x] \`git diff --stat\` — scoped to 5 files (CLAUDE.md, docs/decisions.md, both SKILL.md copies, src/guide.ts)
- [x] \`grep -n "freelance mcp" CLAUDE.md\` — no matches
- [x] \`diff plugins/freelance/skills/freelance/SKILL.md templates/skills/freelance/SKILL.md\` — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)