### PR TITLE
refactor(engine,memory): save-before-hook ordering + emit transactional wrap + mtime_ms drop

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -238,3 +238,11 @@ This complements § "Observable state transitions are durable before side effect
 **What would break if reversed:** any mechanism tying emit durability to transition success re-introduces speculative writes — the agent sees "emitted" but the row vanishes if the next advance blocks. Worse: a `HOOK_FAILED` on the next node swallows the emit the caller believed was durable.
 
 Anchors: `src/memory/store.ts` (emit is synchronous, transaction-scoped to the emit call alone, no traversal-id entanglement), `docs/memory-intent.md` § "Append-only across corpus frames", § "The store is a passive sink", § "Not an emit-time garbage collector".
+
+### mtime_ms column removed from `proposition_sources`
+
+Post-#74 the `mtime_ms` column was neither written nor read — drift detection now re-hashes content per-call via `StalenessCache` amortization. The column was retained only as a no-op for existing databases. 1.4 drops it outright with an in-place migration matching the `propositions.collection` pattern (#135).
+
+**What would break if reversed:** re-adding the column re-introduces the mtime fast-path footgun (#74 rationale: mtime is preserved across real edits by `git checkout`, `rsync -t`, `touch -r`, etc.). The column has no legitimate use absent that fast path.
+
+Anchors: `src/memory/db.ts`, `src/memory/sources.ts`.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -206,3 +206,35 @@ Single recovery verb across destructive ops means SKILL.md teaches "on `CONFIRM_
 **What would break if reversed:** dropping the `commandName` slot forces per-verb recovery templates in `RECOVERY`, which defeats the "teach once" property above.
 
 Anchors: `src/cli/program.ts` (flag registration), `src/cli/memory.ts` (`memoryPrune`, `memoryReset`), `src/cli/traversals.ts` (`traversalReset`), `src/error-codes.ts` (`CONFIRM_REQUIRED` + `RECOVERY[CONFIRM_REQUIRED]`).
+
+### Prune is content-reachability, not commit-reachability; schema unchanged
+
+The #80 design proposed capturing a `git_ref` on each `proposition_sources` row at emit time so prune could later ask "is the commit that produced this row still reachable?" Empirical work during implementation pivoted to **content-reachability**: "are these bytes live anywhere — disk or any declared-live ref?" No schema change; `content_hash` already carries the information.
+
+The pivot is forced by git's history-rewriting workflows. Rebase, squash-merge, and amend all *rewrite commit SHAs* while *preserving tree content*. A `git_ref` column captured at emit time would become unreachable after any of these, classifying live knowledge as stale. Content-reachability sidesteps the entire class by asking about bytes, not commits.
+
+**What would break if reversed:** re-adding a `git_ref` column re-introduces the rebase/squash/amend footgun. The column drifts out-of-sync with reality on every history rewrite, leaving the user to choose between "prune aggressively and lose knowledge" or "never prune and accumulate forever." Neither is acceptable.
+
+Anchors: `src/memory/prune.ts`, `src/memory/git.ts`, `docs/memory-intent.md` § "Knowledge is append-only across corpus frames". Commit `10beb0e` documents the pivot in its body despite a misleading subject line. Closes #80.
+
+### Prune does not GC entities — entity survival preserves branch-switch re-linkability
+
+`prune` never deletes entity rows. It removes stale `proposition_sources` rows (and, when an entity's last valid proposition goes, that entity becomes orphaned in the read-time filter sense) but the entity row survives. Prune output reports `entities_now_orphaned` — a count of entities that transitioned to zero valid propositions as a result of this prune — not `entities_orphaned` or `entities_pruned`; the tense is load-bearing.
+
+The rule is a direct consequence of `docs/memory-intent.md` § "Knowledge is append-only across corpus frames". An entity is a coordinate a proposition links to, not a fact in itself; deleting it would break re-linking when a reverted branch or future emit re-introduces propositions that cite the same name. The default orphan-hiding filter on `memory_browse` (`valid_proposition_count > 0`, `src/memory/store.ts`) is the *lens* that controls visibility; the row's continued existence is what makes the lens reversible.
+
+**What would break if reversed:** emit-time or prune-time entity GC collapses the multi-frame store into single-frame — branch switch, `git revert`, or a re-emit after temporary removal would have to *recreate* the entity, breaking any external reference (saved workflow context, agent transcript) that named it by id. Orphan accumulation is the cost; it's bounded by the fact that entities are small and name-deduped.
+
+Anchors: `src/memory/prune.ts`, `src/memory/store.ts`, `docs/memory-intent.md` § "Knowledge is append-only across corpus frames" and § "Not an emit-time garbage collector".
+
+### Memory emit attribution is emit-time, not transition-time
+
+`memory_emit` writes the proposition at the node the caller was on when emit fired, independent of any subsequent traversal move. A prop emitted at node N persists even if the caller's next `freelance advance` fails a gate (edge condition, wait, return schema, validation) or throws `HOOK_FAILED`. Memory writes are not part of the traversal transition — they are not rolled back when a later transition fails.
+
+The rationale is the append-only-across-corpus-frames contract from `docs/memory-intent.md`. A proposition captures *what the agent derived while reasoning at N*. That reasoning happened regardless of whether the agent successfully left N afterward. Coupling emit to "the next successful advance" would make the knowledge graph speculative on every workflow step and collide with § "The store is a passive sink" — the store does not track traversal outcomes and must not.
+
+This complements § "Observable state transitions are durable before side effects": traversal state is transitional and persists via log-then-apply; memory state is not transitional and persists on emit regardless of what happens next.
+
+**What would break if reversed:** any mechanism tying emit durability to transition success re-introduces speculative writes — the agent sees "emitted" but the row vanishes if the next advance blocks. Worse: a `HOOK_FAILED` on the next node swallows the emit the caller believed was durable.
+
+Anchors: `src/memory/store.ts` (emit is synchronous, transaction-scoped to the emit call alone, no traversal-id entanglement), `docs/memory-intent.md` § "Append-only across corpus frames", § "The store is a passive sink", § "Not an emit-time garbage collector".

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -102,7 +102,7 @@ export function memoryRelated(
 export function memoryBySource(
   store: MemoryStore,
   filePath: string,
-  opts?: { limit?: string; offset?: string; shape?: string },
+  opts?: { limit?: string; offset?: string; shape?: string; includeOrphans?: boolean },
 ): void {
   try {
     outputJson(
@@ -110,6 +110,7 @@ export function memoryBySource(
         limit: parseIntArg(opts?.limit, "--limit"),
         offset: parseIntArg(opts?.offset, "--offset"),
         shape: parseShape(opts?.shape),
+        includeOrphans: opts?.includeOrphans,
       }),
     );
   } catch (e) {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -92,7 +92,9 @@ export function mapEngineErrorToExit(code: EngineErrorCode): number {
  *     identity on HOOK_* throws, PR D).
  *   - `context.envelopeSlots` → spread at envelope root (e.g.
  *     CONFIRM_REQUIRED carries `commandName`, AMBIGUOUS_TRAVERSAL
- *     carries `candidates`). The `recoveryVerb` template in
+ *     carries `candidates`; HOOK_FAILED carries `currentNode`,
+ *     `validTransitions`, `context` / `contextDelta` for gate-block
+ *     envelope parity). The `recoveryVerb` template in
  *     `RECOVERY[code]` interpolates against these root fields, so
  *     they live next to the envelope's other top-level fields, not
  *     buried under `error.*`.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -420,7 +420,11 @@ addWorkflowsOpt(
     .description("All propositions derived from a source file")
     .option("--limit <n>", "Maximum propositions (default 50, max 200)")
     .option("--offset <n>", "Skip first N propositions")
-    .option("--shape <shape>", 'Proposition shape: "full" (default) or "minimal"'),
+    .option("--shape <shape>", 'Proposition shape: "full" (default) or "minimal"')
+    .option(
+      "--include-orphans",
+      "Include propositions whose source bytes no longer match disk/any live ref (hidden by default)",
+    ),
 ).action((file, opts) => {
   const { store } = createMemoryStore({ workflows: opts.workflows });
   try {

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -546,10 +546,7 @@ export class GraphEngine {
    * when omitted, `contextDelta` is empty and `context` is the full
    * snapshot.
    */
-  captureHookFailureEnvelope(opts?: {
-    minimal?: boolean;
-    writesBefore?: number;
-  }): {
+  captureHookFailureEnvelope(opts?: { minimal?: boolean; writesBefore?: number }): {
     currentNode: string;
     validTransitions: readonly import("../types.js").TransitionInfo[];
     context?: Readonly<Record<string, unknown>>;

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -213,6 +213,9 @@ export class GraphEngine {
     const currentNodeDef = def.nodes[session.currentNode];
     const minimal = options?.responseMode === "minimal";
 
+    // Anchor for the minimal `contextDelta`: caller writes + hook
+    // writes both append to contextHistory, so slicing from here
+    // captures both paths without parallel bookkeeping.
     const writesBefore = session.contextHistory.length;
 
     if (contextUpdates) {
@@ -221,6 +224,8 @@ export class GraphEngine {
       session.turnCount++;
     }
 
+    // Compute once for the pre-hook window (gate checks + subgraph
+    // push/pop branches). The full shape never reads this.
     const preHookDelta = minimal ? keysSince(session.contextHistory, writesBefore) : [];
     const gateOpts: GateOptions = {
       minimal,

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -11,6 +11,7 @@ import type {
   InspectField,
   InspectMinimalResult,
   InspectResult,
+  NodeDefinition,
   ResetResult,
   SessionState,
   StartResult,
@@ -43,6 +44,51 @@ import { evaluateTransitions } from "./transitions.js";
 import { computeTimeoutAt, evaluateWaitConditions } from "./wait.js";
 
 export type { ResponseMode } from "./context.js";
+
+/**
+ * Internal — returned by `GraphEngine.advanceTransition` and consumed
+ * by `GraphEngine.runArrivalHooks`. Not on the wire; callers outside
+ * the engine should use the convenience `advance()` which wires the
+ * two phases back-to-back.
+ *
+ * Three shapes:
+ * - `early`: transition was short-circuited (gate block, subgraph pop,
+ *   subgraph-condition-not-met). Session state is already in its final
+ *   post-advance form; the wire response is already built. No hooks
+ *   run. The caller should save once and return `result` directly.
+ * - `subgraph-push`: a subgraph node was the edge target. The parent
+ *   session's `currentNode` already moved to the subgraph node, but
+ *   the child session hasn't been pushed yet. `runArrivalHooks` pushes
+ *   the child + fires hooks on its start node + builds the response.
+ *   `TraversalStore` sandwiches a persist between push and hook via
+ *   the `persistBetween` callback so a hook throw leaves disk with
+ *   the child pushed, not the parent pre-push.
+ * - `standard`: normal node arrival. `currentNode` already moved on
+ *   the active session. `runArrivalHooks` fires `onEnter` + builds
+ *   the response. Caller saves BEFORE the hooks run (so a hook throw
+ *   leaves disk on the new node, not the stale pre-advance one) and
+ *   AFTER the hooks complete (to capture hook-written context + meta).
+ */
+export type TransitionCommit =
+  | { kind: "early"; result: AdvanceResult | AdvanceMinimalResult }
+  | {
+      kind: "subgraph-push";
+      previousNode: string;
+      edge: string;
+      writesBefore: number;
+      minimal: boolean;
+      newNodeDef: NodeDefinition;
+    }
+  | {
+      kind: "standard";
+      previousNode: string;
+      edge: string;
+      writesBefore: number;
+      minimal: boolean;
+      newNodeDef: NodeDefinition;
+      isTerminal: boolean;
+      isWait: boolean;
+    };
 
 export interface GraphEngineOptions {
   maxDepth?: number;
@@ -142,20 +188,31 @@ export class GraphEngine {
     } satisfies StartResult;
   }
 
-  async advance(
+  /**
+   * Transition phase of `advance`. Applies context updates, runs gate
+   * checks, and — if everything passes — mutates session state
+   * synchronously (pushes history, moves `currentNode`, pops a
+   * terminating subgraph). Does NOT run `onEnter` hooks. Returns a
+   * `TransitionCommit` carrying either an early-return wire result
+   * (gate-block, pop, push-skipped) or the metadata needed by
+   * `runArrivalHooks` to finish the advance.
+   *
+   * The split exists so `TraversalStore.advance` can persist the
+   * post-transition session BEFORE firing hooks — if a hook throws,
+   * disk matches the in-memory post-transition state and the next
+   * advance runs gates on the new node, not the stale one.
+   */
+  advanceTransition(
     edge: string,
     contextUpdates?: Record<string, unknown>,
-    options?: { metaCollector?: MetaCollector; responseMode?: ResponseMode },
-  ): Promise<AdvanceResult | AdvanceMinimalResult> {
+    options?: { responseMode?: ResponseMode },
+  ): TransitionCommit {
     const session = this.requireSession();
     const graph = this.currentGraph();
     const def = graph.definition;
     const currentNodeDef = def.nodes[session.currentNode];
     const minimal = options?.responseMode === "minimal";
 
-    // Anchor for the minimal `contextDelta`: caller writes + hook
-    // writes both append to contextHistory, so slicing from here
-    // captures both paths without parallel bookkeeping.
     const writesBefore = session.contextHistory.length;
 
     if (contextUpdates) {
@@ -164,8 +221,6 @@ export class GraphEngine {
       session.turnCount++;
     }
 
-    // Compute once for the pre-hook window (gate checks + subgraph
-    // push/pop branches). The full shape never reads this.
     const preHookDelta = minimal ? keysSince(session.contextHistory, writesBefore) : [];
     const gateOpts: GateOptions = {
       minimal,
@@ -173,15 +228,14 @@ export class GraphEngine {
       graphSources: def.sources,
     };
     const waitBlock = checkWaitBlocking(session, currentNodeDef, gateOpts);
-    if (waitBlock) return waitBlock;
+    if (waitBlock) return { kind: "early", result: waitBlock };
 
     const returnBlock = checkReturnSchema(session, currentNodeDef, gateOpts);
-    if (returnBlock) return returnBlock;
+    if (returnBlock) return { kind: "early", result: returnBlock };
 
     const validationBlock = checkValidations(session, currentNodeDef, gateOpts);
-    if (validationBlock) return validationBlock;
+    if (validationBlock) return { kind: "early", result: validationBlock };
 
-    // Find and validate edge
     if (!currentNodeDef.edges) {
       throw new EngineError(
         `Node "${session.currentNode}" is a terminal node with no outgoing edges`,
@@ -205,10 +259,9 @@ export class GraphEngine {
         edge,
         gateOpts,
       );
-      if (condBlock) return condBlock;
+      if (condBlock) return { kind: "early", result: condBlock };
     }
 
-    // Record history and advance
     const previousNode = session.currentNode;
     session.history.push({
       node: previousNode,
@@ -223,11 +276,11 @@ export class GraphEngine {
     const isTerminal = newNodeDef.type === "terminal";
     const isWait = newNodeDef.type === "wait";
 
-    // Subgraph transitions. Push runs hooks on the child's start node;
-    // pop does not re-fire hooks on the resumed parent (already fired on
-    // initial arrival).
+    // Subgraph pop: stack mutation + response build happen here. No
+    // hooks fire on the resumed parent — return early with the built
+    // wire result.
     if (isTerminal && this.stack.length > 1) {
-      return popSubgraph({
+      const result = popSubgraph({
         stack: this.stack,
         graphs: this.graphs,
         previousNode,
@@ -235,19 +288,68 @@ export class GraphEngine {
         minimal,
         contextDelta: preHookDelta,
       });
+      return { kind: "early", result };
     }
+    // Subgraph push deferred to runArrivalHooks so push + onEnter
+    // share a save boundary (persistBetween threads disk reflection
+    // of the push before hooks run).
     if (!isTerminal && !isWait && newNodeDef.subgraph) {
+      return {
+        kind: "subgraph-push",
+        previousNode,
+        edge,
+        writesBefore,
+        minimal,
+        newNodeDef,
+      };
+    }
+
+    return {
+      kind: "standard",
+      previousNode,
+      edge,
+      writesBefore,
+      minimal,
+      newNodeDef,
+      isTerminal,
+      isWait,
+    };
+  }
+
+  /**
+   * Arrival-hook phase of `advance`. Runs `onEnter` for the
+   * post-transition node and builds the wire response. Must be
+   * called after `advanceTransition` returned. Gate-block +
+   * subgraph-pop branches (`kind: "early"`) pass through their
+   * pre-built response unchanged.
+   *
+   * `persistBetween` is only consumed by the subgraph-push branch:
+   * `maybePushSubgraph` pushes the child, invokes `persistBetween`,
+   * then fires hooks on the child's start node.
+   */
+  async runArrivalHooks(
+    commit: TransitionCommit,
+    options?: { metaCollector?: MetaCollector; persistBetween?: () => void },
+  ): Promise<AdvanceResult | AdvanceMinimalResult> {
+    if (commit.kind === "early") return commit.result;
+
+    const session = this.requireSession();
+    const graph = this.currentGraph();
+    const def = graph.definition;
+
+    if (commit.kind === "subgraph-push") {
       return maybePushSubgraph({
         stack: this.stack,
         graphs: this.graphs,
-        previousNode,
-        edge,
-        newNodeDef,
+        previousNode: commit.previousNode,
+        edge: commit.edge,
+        newNodeDef: commit.newNodeDef,
         maxDepth: this.maxDepth,
         hookRunner: this.hookRunner,
         metaCollector: options?.metaCollector,
-        minimal,
-        contextDelta: preHookDelta,
+        minimal: commit.minimal,
+        contextDelta: commit.minimal ? keysSince(session.contextHistory, commit.writesBefore) : [],
+        ...(options?.persistBetween && { persistBetween: options.persistBetween }),
       });
     }
 
@@ -255,6 +357,7 @@ export class GraphEngine {
     // the response so hook writes land in validTransitions and context.
     await this.runHooksOnArrival(session, graph, options?.metaCollector);
 
+    const { previousNode, edge, writesBefore, minimal, newNodeDef, isTerminal, isWait } = commit;
     const contextDelta = minimal ? keysSince(session.contextHistory, writesBefore) : [];
     const validTransitions = evaluateTransitions(newNodeDef, session.context);
 
@@ -334,6 +437,22 @@ export class GraphEngine {
     }
 
     return result;
+  }
+
+  /**
+   * Library convenience: run `advanceTransition` + `runArrivalHooks`
+   * back-to-back without an intermediate persist. `TraversalStore.advance`
+   * invokes the two phases separately so it can sandwich a save between
+   * them; direct engine callers (tests, programmatic use) stay on this
+   * shape.
+   */
+  async advance(
+    edge: string,
+    contextUpdates?: Record<string, unknown>,
+    options?: { metaCollector?: MetaCollector; responseMode?: ResponseMode },
+  ): Promise<AdvanceResult | AdvanceMinimalResult> {
+    const commit = this.advanceTransition(edge, contextUpdates, options);
+    return this.runArrivalHooks(commit, options);
   }
 
   contextSet(

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -533,6 +533,50 @@ export class GraphEngine {
     } satisfies ResetResult;
   }
 
+  /**
+   * Build the envelope-sibling snapshot (`currentNode`,
+   * `validTransitions`, `context` / `contextDelta`) that the CLI
+   * attaches to a post-transition hook-throw. Mirrors the gate-block
+   * shape so HOOK_FAILED surfaces the same recover-or-stop fields
+   * the caller sees on any other advance error. Returns `null` when
+   * no session is active (the throw happened before any transition
+   * committed — unusual; the CLI falls back to the bare envelope).
+   *
+   * `writesBefore` narrows `contextDelta` on `--minimal` responses;
+   * when omitted, `contextDelta` is empty and `context` is the full
+   * snapshot.
+   */
+  captureHookFailureEnvelope(opts?: {
+    minimal?: boolean;
+    writesBefore?: number;
+  }): {
+    currentNode: string;
+    validTransitions: readonly import("../types.js").TransitionInfo[];
+    context?: Readonly<Record<string, unknown>>;
+    contextDelta?: readonly string[];
+  } | null {
+    if (this.stack.length === 0) return null;
+    const session = this.activeSession();
+    const def = this.currentGraphDef();
+    const nodeDef = def.nodes[session.currentNode];
+    const validTransitions = evaluateTransitions(nodeDef, session.context);
+    if (opts?.minimal) {
+      return {
+        currentNode: session.currentNode,
+        validTransitions,
+        contextDelta:
+          opts.writesBefore !== undefined
+            ? keysSince(session.contextHistory, opts.writesBefore)
+            : [],
+      };
+    }
+    return {
+      currentNode: session.currentNode,
+      validTransitions,
+      context: cloneContext(session.context),
+    };
+  }
+
   // --- Serialization (for persistence) ---
 
   getStack(): SessionState[] {

--- a/src/engine/hooks.ts
+++ b/src/engine/hooks.ts
@@ -53,7 +53,12 @@ export interface HookMemoryAccess {
   related(entityIdOrName: string, options?: { limit?: number; offset?: number }): RelatedResult;
   bySource(
     filePath: string,
-    options?: { limit?: number; offset?: number; shape?: PropositionShape },
+    options?: {
+      limit?: number;
+      offset?: number;
+      shape?: PropositionShape;
+      includeOrphans?: boolean;
+    },
   ): BySourceResult;
   inspect(
     entityIdOrName: string,

--- a/src/engine/hooks.ts
+++ b/src/engine/hooks.ts
@@ -168,7 +168,7 @@ export class HookRunner {
       const rawArgs = specs[i].args ?? {};
       const resolvedArgs = resolveHookArgs(rawArgs, session.context);
 
-      const fn = await this.loadHookFn(resolved, nodeId);
+      const fn = await this.loadHookFn(resolved, nodeId, i);
 
       const hookCtx: HookContext = {
         args: resolvedArgs,
@@ -187,6 +187,7 @@ export class HookRunner {
         throw new EngineError(
           `onEnter hook "${resolved.call}" on node "${nodeId}" failed: ${message}`,
           EC.HOOK_FAILED,
+          { hook: { name: resolved.call, nodeId, index: i } },
         );
       }
 
@@ -195,6 +196,7 @@ export class HookRunner {
           `onEnter hook "${resolved.call}" on node "${nodeId}" must return a plain object; ` +
             `got ${Array.isArray(result) ? "array" : typeof result}`,
           EC.HOOK_BAD_RETURN,
+          { hook: { name: resolved.call, nodeId, index: i } },
         );
       }
 
@@ -219,7 +221,8 @@ export class HookRunner {
    * + typeof-default checks here on first invocation, surfacing the
    * same error codes.
    */
-  private async loadHookFn(resolved: ResolvedHook, nodeId: string): Promise<HookFn> {
+  private async loadHookFn(resolved: ResolvedHook, nodeId: string, index: number): Promise<HookFn> {
+    const hookCtx = { name: resolved.call, nodeId, index };
     if (resolved.kind === "builtin") {
       const fn = this.builtinHooks.get(resolved.name);
       if (!fn) {
@@ -227,6 +230,7 @@ export class HookRunner {
           `Built-in hook "${resolved.name}" referenced by node "${nodeId}" is not registered. ` +
             `Available built-ins: [${[...this.builtinHooks.keys()].join(", ")}]`,
           EC.HOOK_BUILTIN_MISSING,
+          { hook: hookCtx },
         );
       }
       return fn;
@@ -240,6 +244,7 @@ export class HookRunner {
       throw new EngineError(
         `Failed to import hook script "${resolved.absolutePath}" for node "${nodeId}": ${message}`,
         EC.HOOK_IMPORT_FAILED,
+        { hook: hookCtx },
       );
     }
 
@@ -248,6 +253,7 @@ export class HookRunner {
       throw new EngineError(
         `Hook script "${resolved.absolutePath}" must export a default function (got ${typeof fn})`,
         EC.HOOK_BAD_SHAPE,
+        { hook: hookCtx },
       );
     }
 

--- a/src/engine/subgraph.ts
+++ b/src/engine/subgraph.ts
@@ -27,6 +27,16 @@ interface PushSubgraphArgs {
   minimal: boolean;
   /** Keys written this advance (caller updates ∪ hook writes in parent, before push). Only used on minimal shape. */
   contextDelta: readonly string[];
+  /**
+   * Optional save boundary invoked after the child session is pushed
+   * onto the stack but BEFORE `onEnter` fires on the child's start
+   * node. `TraversalStore.advance` threads its `saveEngine` through
+   * here; a hook throw below then leaves disk with the child pushed
+   * (next advance resumes from the child's start node, not the
+   * parent's pre-push state). Direct engine callers omit the callback
+   * and accept one-shot semantics.
+   */
+  persistBetween?: () => void;
 }
 
 export async function maybePushSubgraph(args: PushSubgraphArgs): Promise<SubgraphResult> {
@@ -41,6 +51,7 @@ export async function maybePushSubgraph(args: PushSubgraphArgs): Promise<Subgrap
     metaCollector,
     minimal,
     contextDelta,
+    persistBetween,
   } = args;
   const parentSession = stack[stack.length - 1];
   const subgraph = newNodeDef.subgraph!;
@@ -122,6 +133,13 @@ export async function maybePushSubgraph(args: PushSubgraphArgs): Promise<Subgrap
     turnCount: 0,
     startedAt: new Date().toISOString(),
   });
+
+  // Save boundary between child push and child-start onEnter. When
+  // TraversalStore threads a callback here, a hook throw below leaves
+  // disk reflecting the pushed child (next advance runs on the
+  // child's start node). Direct engine callers omit the callback and
+  // get one-shot semantics.
+  persistBetween?.();
 
   const activeSession = stack[stack.length - 1];
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,9 +14,13 @@ export { EC, type EngineErrorCode } from "./error-codes.js";
  *     `isError`, `error`). Carries the top-level fields a
  *     `recoveryVerb` template interpolates against (e.g.
  *     CONFIRM_REQUIRED carries `commandName`, AMBIGUOUS_TRAVERSAL
- *     carries `candidates`). Values are `unknown` so throw sites
- *     don't fight the type system for structured payloads —
- *     `outputError` is the only consumer and it spreads directly.
+ *     carries `candidates`). PR D populates `currentNode` /
+ *     `validTransitions` / `context` / `contextDelta` here on
+ *     HOOK_FAILED for gate-block envelope parity — caller is in
+ *     the same recover-or-stop state, wire shape must not differ
+ *     by code path. Values are `unknown` so throw sites don't
+ *     fight the type system for structured payloads — `outputError`
+ *     is the only consumer and it spreads directly.
  *
  * Open-ended — add a new subfield when a fourth spread target (e.g.
  * a future `breadcrumb` field) emerges. Don't widen `envelopeSlots`

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -77,10 +77,6 @@ CREATE TABLE IF NOT EXISTS proposition_sources (
   proposition_id TEXT NOT NULL REFERENCES propositions(id) ON DELETE CASCADE,
   file_path TEXT NOT NULL,
   content_hash TEXT NOT NULL,
-  -- Retained on the table for pre-1.3.4 rows. Not written to by new emits
-  -- and not read anywhere — mtime proved unsafe as a drift signal (can be
-  -- preserved across edits by git checkout, rsync -t, touch -r, etc.).
-  mtime_ms REAL,
   PRIMARY KEY (proposition_id, file_path)
 );
 CREATE INDEX IF NOT EXISTS idx_ps_file ON proposition_sources(file_path);
@@ -147,6 +143,28 @@ function migrateDropCollectionColumn(db: Db): void {
   db.exec("DROP INDEX IF EXISTS idx_prop_hash_coll");
   db.exec("DROP INDEX IF EXISTS idx_prop_collection");
   db.exec("ALTER TABLE propositions DROP COLUMN collection");
+}
+
+/**
+ * Transparent migration for the dead `mtime_ms` column on
+ * `proposition_sources`. Post-#74 the column was neither written nor
+ * read — drift detection re-hashes content per-call via
+ * `StalenessCache` amortization — but the column was retained for
+ * existing databases. 1.4 drops it outright. Mirrors the
+ * `propositions.collection` drop pattern above.
+ *
+ * mtime-based drift detection is fundamentally unsafe: `git checkout`,
+ * `rsync -t`, and `touch -r` all preserve mtime across real edits. No
+ * legitimate use absent the removed fast path. See `docs/decisions.md`
+ * § "mtime_ms column removed from `proposition_sources`".
+ */
+function migrateDropMtimeColumn(db: Db): void {
+  const cols = db
+    .prepare("PRAGMA table_info(proposition_sources)")
+    .all() as Array<{ name: string }>;
+  if (!cols.some((c) => c.name === "mtime_ms")) return;
+
+  db.exec("ALTER TABLE proposition_sources DROP COLUMN mtime_ms");
 }
 
 /**
@@ -228,6 +246,7 @@ function openDatabaseOnce(dbPath: string): Db {
   checkSchemaCompatibility(db);
   inner.exec(SCHEMA_SQL);
   migrateDropCollectionColumn(db);
+  migrateDropMtimeColumn(db);
 
   // Converge older databases that were created with the propositions_au
   // AFTER UPDATE trigger. memory_emit's ON CONFLICT DO NOTHING means

--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -159,9 +159,9 @@ function migrateDropCollectionColumn(db: Db): void {
  * § "mtime_ms column removed from `proposition_sources`".
  */
 function migrateDropMtimeColumn(db: Db): void {
-  const cols = db
-    .prepare("PRAGMA table_info(proposition_sources)")
-    .all() as Array<{ name: string }>;
+  const cols = db.prepare("PRAGMA table_info(proposition_sources)").all() as Array<{
+    name: string;
+  }>;
   if (!cols.some((c) => c.name === "mtime_ms")) return;
 
   db.exec("ALTER TABLE proposition_sources DROP COLUMN mtime_ms");

--- a/src/memory/prune.ts
+++ b/src/memory/prune.ts
@@ -30,6 +30,7 @@
  */
 
 import path from "node:path";
+import { EC, EngineError } from "../errors.js";
 import { hashContent, hashSourceFile } from "../sources.js";
 import type { Db } from "./db.js";
 import { readBlobsAtRefs, resolveGitTopLevel, resolveRef } from "./git.js";
@@ -77,16 +78,18 @@ function sqlPlaceholders(n: number): string {
 export function prune(db: Db, sourceRoot: string, options: PruneOptions): PruneResult {
   const { keep, dryRun = false } = options;
   if (!keep || keep.length === 0) {
-    throw new Error(
+    throw new EngineError(
       "memory prune requires at least one --keep <ref>. There is no default preserve set.",
+      EC.MISSING_KEEP,
     );
   }
 
   const gitRoot = resolveGitTopLevel(sourceRoot);
   if (!gitRoot) {
-    throw new Error(
+    throw new EngineError(
       `memory prune requires a git checkout at the source root (${sourceRoot}). ` +
         `Refs can't be resolved outside a git repository.`,
+      EC.PRUNE_NOT_GIT_CHECKOUT,
     );
   }
 
@@ -99,8 +102,9 @@ export function prune(db: Db, sourceRoot: string, options: PruneOptions): PruneR
     else failures.push(`${res.ref}: ${res.error}`);
   }
   if (failures.length > 0) {
-    throw new Error(
+    throw new EngineError(
       `Unresolvable --keep ref(s); prune aborted without touching the db:\n  - ${failures.join("\n  - ")}`,
+      EC.PRUNE_UNRESOLVABLE_REF,
     );
   }
 

--- a/src/memory/prune.ts
+++ b/src/memory/prune.ts
@@ -45,7 +45,15 @@ export interface PruneResult {
   dry_run: boolean;
   rows_pruned: number;
   propositions_hard_deleted: number;
-  entities_orphaned: number;
+  /**
+   * Count of entity rows that transitioned to zero valid propositions
+   * *as a result of this prune*. Load-bearing tense: these entities
+   * aren't deleted — prune never GCs entity rows. The count tells the
+   * caller how many names flipped into the orphan-hidden default
+   * browse lens on this run. See `docs/decisions.md` § "Prune does
+   * not GC entities".
+   */
+  entities_now_orphaned: number;
   /** Distinct refs in the preserve set (SHAs they resolved to). */
   preserve_set: Array<{ ref: string; sha: string }>;
 }
@@ -106,7 +114,7 @@ export function prune(db: Db, sourceRoot: string, options: PruneOptions): PruneR
       dry_run: dryRun,
       rows_pruned: 0,
       propositions_hard_deleted: 0,
-      entities_orphaned: 0,
+      entities_now_orphaned: 0,
       preserve_set: resolved,
     };
   }
@@ -183,10 +191,10 @@ export function prune(db: Db, sourceRoot: string, options: PruneOptions): PruneR
       .map((r) => r.proposition_id);
   }
 
-  let entitiesOrphaned = 0;
+  let entitiesNowOrphaned = 0;
   if (hardDeletedPropIds.length > 0) {
     const placeholders = sqlPlaceholders(hardDeletedPropIds.length);
-    entitiesOrphaned = (
+    entitiesNowOrphaned = (
       db
         .prepare(
           `SELECT COUNT(*) as c FROM entities e
@@ -207,7 +215,7 @@ export function prune(db: Db, sourceRoot: string, options: PruneOptions): PruneR
     dry_run: dryRun,
     rows_pruned: victims.length,
     propositions_hard_deleted: hardDeletedPropIds.length,
-    entities_orphaned: entitiesOrphaned,
+    entities_now_orphaned: entitiesNowOrphaned,
     preserve_set: resolved,
   };
 

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -13,6 +13,7 @@
 
 import crypto from "node:crypto";
 import path from "node:path";
+import { EC, EngineError } from "../errors.js";
 import { hashSourceFile } from "../sources.js";
 import type { Db } from "./db.js";
 import { computeStatus, countNeighbors, countValidForEntity, getNeighbors } from "./enrichment.js";
@@ -185,7 +186,10 @@ export class MemoryStore {
       !normalizedPath.startsWith(normalizedRoot) &&
       normalizedPath !== path.resolve(this.sourceRoot)
     ) {
-      throw new Error(`Source file is outside the source root: ${filePath}`);
+      throw new EngineError(
+        `Source file is outside the source root: ${filePath}`,
+        EC.SOURCE_OUTSIDE_ROOT,
+      );
     }
 
     const storedPath = path.isAbsolute(filePath)
@@ -269,7 +273,10 @@ export class MemoryStore {
           const { storedPath, resolvedPath } = this.prepareSourcePath(sourcePath);
           const hash = hashSourceFile(resolvedPath);
           if (hash === null) {
-            throw new Error(`Cannot read source file "${sourcePath}" during emit.`);
+            throw new EngineError(
+              `Cannot read source file "${sourcePath}" during emit.`,
+              EC.SOURCE_FILE_UNREADABLE,
+            );
           }
           insertPropSource.run(propId, storedPath, hash);
         }
@@ -385,7 +392,7 @@ export class MemoryStore {
         .prepare("SELECT * FROM entities WHERE LOWER(name) = ?")
         .get(idOrName.toLowerCase()) as EntityRow | undefined);
     if (!entity) {
-      throw new Error(`Entity not found: ${idOrName}`);
+      throw new EngineError(`Entity not found: ${idOrName}`, EC.ENTITY_NOT_FOUND);
     }
     return entity;
   }

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -228,57 +228,70 @@ export class MemoryStore {
       "INSERT OR IGNORE INTO proposition_sources (proposition_id, file_path, content_hash) VALUES (?, ?, ?)",
     );
 
-    for (const prop of propositions) {
-      const contentHash = hashPropContent(prop.content);
-      const newId = generateId();
-      const inserted = upsertProp.get(newId, prop.content, contentHash, now()) as
-        | { id: string }
-        | undefined;
+    // Atomically — partial emit (proposition rows with some but not all
+    // source attributions) is worse than no emit, because the caller
+    // expects every prop in the batch to have its full source set on
+    // success. Mirrors the prune and resetAll BEGIN/COMMIT/ROLLBACK
+    // pattern. Any throw inside the loop (missing source file,
+    // constraint violation) rolls back to pre-emit state.
+    this.db.exec("BEGIN");
+    try {
+      for (const prop of propositions) {
+        const contentHash = hashPropContent(prop.content);
+        const newId = generateId();
+        const inserted = upsertProp.get(newId, prop.content, contentHash, now()) as
+          | { id: string }
+          | undefined;
 
-      const propResult: EmitResult["propositions"][number] = {
-        id: "",
-        content: prop.content,
-        status: "created",
-        entities: [],
-      };
+        const propResult: EmitResult["propositions"][number] = {
+          id: "",
+          content: prop.content,
+          status: "created",
+          entities: [],
+        };
 
-      let propId: string;
-      if (inserted) {
-        propId = newId;
-        propResult.status = "created";
-        result.created++;
-      } else {
-        const existing = selectExistingProp.get(contentHash) as { id: string };
-        propId = existing.id;
-        propResult.status = "deduplicated";
-        result.deduplicated++;
-      }
-      propResult.id = propId;
-
-      // Per-proposition source attribution. Each source file is hashed fresh
-      // at emit time; if the file can't be read, the emit fails for this prop.
-      for (const sourcePath of prop.sources) {
-        const { storedPath, resolvedPath } = this.prepareSourcePath(sourcePath);
-        const hash = hashSourceFile(resolvedPath);
-        if (hash === null) {
-          throw new Error(`Cannot read source file "${sourcePath}" during emit.`);
-        }
-        insertPropSource.run(propId, storedPath, hash);
-      }
-
-      for (const entityName of prop.entities) {
-        const kind = prop.entityKinds?.[entityName];
-        const resolved = this.resolveEntity(entityName, kind, warnings);
-        propResult.entities.push(resolved);
-        insertAbout.run(propId, resolved.id);
-        if (resolved.resolution === "created") {
-          result.entities_created++;
+        let propId: string;
+        if (inserted) {
+          propId = newId;
+          propResult.status = "created";
+          result.created++;
         } else {
-          result.entities_resolved++;
+          const existing = selectExistingProp.get(contentHash) as { id: string };
+          propId = existing.id;
+          propResult.status = "deduplicated";
+          result.deduplicated++;
         }
-      }
+        propResult.id = propId;
 
-      result.propositions.push(propResult);
+        // Per-proposition source attribution. Each source file is hashed fresh
+        // at emit time; if the file can't be read, the emit fails for this prop.
+        for (const sourcePath of prop.sources) {
+          const { storedPath, resolvedPath } = this.prepareSourcePath(sourcePath);
+          const hash = hashSourceFile(resolvedPath);
+          if (hash === null) {
+            throw new Error(`Cannot read source file "${sourcePath}" during emit.`);
+          }
+          insertPropSource.run(propId, storedPath, hash);
+        }
+
+        for (const entityName of prop.entities) {
+          const kind = prop.entityKinds?.[entityName];
+          const resolved = this.resolveEntity(entityName, kind, warnings);
+          propResult.entities.push(resolved);
+          insertAbout.run(propId, resolved.id);
+          if (resolved.resolution === "created") {
+            result.entities_created++;
+          } else {
+            result.entities_resolved++;
+          }
+        }
+
+        result.propositions.push(propResult);
+      }
+      this.db.exec("COMMIT");
+    } catch (e) {
+      this.db.exec("ROLLBACK");
+      throw e;
     }
 
     if (warnings.length > 0) {
@@ -527,23 +540,39 @@ export class MemoryStore {
 
   bySource(
     filePath: string,
-    options?: { limit?: number; offset?: number; shape?: PropositionShape },
+    options?: {
+      limit?: number;
+      offset?: number;
+      shape?: PropositionShape;
+      includeOrphans?: boolean;
+    },
   ): BySourceResult {
     const cache = createStalenessCache();
     const limit = clampLimit(options?.limit);
     const offset = clampOffset(options?.offset);
     const shape: PropositionShape = options?.shape ?? "full";
+    const includeOrphans = options?.includeOrphans ?? false;
 
     const storedPath = path.isAbsolute(filePath)
       ? path.relative(this.sourceRoot, filePath)
       : filePath;
+
+    // Mirror `browse`'s staleness filter: propositions whose declared
+    // source bytes don't match disk/any live ref are hidden by default.
+    // Caller opts in with includeOrphans to see orphans during audits.
+    // getStalePropositionIds materializes STALE_PROP_IDS_TABLE for the
+    // NOT EXISTS join below.
+    getStalePropositionIds(this.db, this.sourceRoot, cache);
+    const notStaleJoin = includeOrphans
+      ? ""
+      : ` AND NOT EXISTS (SELECT 1 FROM ${STALE_PROP_IDS_TABLE} _s WHERE _s.proposition_id = p.id)`;
 
     const total = (
       this.db
         .prepare(
           `SELECT COUNT(DISTINCT p.id) as c FROM propositions p
            JOIN proposition_sources ps ON p.id = ps.proposition_id
-           WHERE ps.file_path = ?`,
+           WHERE ps.file_path = ?${notStaleJoin}`,
         )
         .get(storedPath) as { c: number }
     ).c;
@@ -552,7 +581,7 @@ export class MemoryStore {
       .prepare(
         `SELECT DISTINCT p.* FROM propositions p
          JOIN proposition_sources ps ON p.id = ps.proposition_id
-         WHERE ps.file_path = ?
+         WHERE ps.file_path = ?${notStaleJoin}
          ORDER BY p.created_at DESC
          LIMIT ? OFFSET ?`,
       )

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -233,14 +233,35 @@ export class TraversalStore {
     return this.withLock(traversalId, async () => {
       const { engine, record } = this.loadEngine(traversalId);
       const hookMeta: Record<string, string> = {};
-      const result = await engine.advance(edge, contextUpdates, {
-        metaCollector: (updates) => Object.assign(hookMeta, updates),
+      const metaCollector = (updates: Record<string, string>) =>
+        Object.assign(hookMeta, updates);
+
+      // Phase 1: transition + gate checks. On a gate-block ("early"),
+      // session state is already final and runArrivalHooks is a
+      // pass-through. On a committed transition, currentNode has
+      // moved; we save THAT state before hooks run so a hook throw
+      // leaves disk on the new node, not the stale pre-advance one.
+      // See docs/decisions.md § "Observable state transitions are
+      // durable before side effects".
+      const commit = engine.advanceTransition(edge, contextUpdates, {
         ...(options?.responseMode ? { responseMode: options.responseMode } : {}),
       });
-      // Merge collected hook updates into the in-memory record before save —
-      // saveEngine carries record.meta forward verbatim, so this is the
-      // single point of integration. Avoids a separate setMeta + extra disk
-      // write per advance.
+      this.saveEngine(record, engine);
+
+      // Phase 2: onEnter hooks + response construction. persistBetween
+      // is only consumed by the subgraph-push branch: maybePushSubgraph
+      // pushes the child, invokes it (so disk reflects the push), then
+      // fires child-start hooks. Standard-arrival runArrivalHooks
+      // ignores the callback — the pre-hook save above is the boundary
+      // for that branch.
+      const persistBetween = () => this.saveEngine(record, engine);
+      const result = await engine.runArrivalHooks(commit, {
+        metaCollector,
+        persistBetween,
+      });
+
+      // Merge collected hook updates into the in-memory record before
+      // the final save.
       if (Object.keys(hookMeta).length > 0) {
         record.meta = { ...record.meta, ...hookMeta };
       }
@@ -430,7 +451,11 @@ export class TraversalStore {
     // `record.version` is what we observed at loadEngine() time —
     // putIfVersion throws TRAVERSAL_CONFLICT if another writer bumped
     // the version meanwhile. `version ?? 0` handles legacy records
-    // written before the field existed.
-    this.state.putIfVersion(next, record.version ?? 0);
+    // written before the field existed. Track the bumped version in
+    // place so repeat saveEngine calls within one advance (the
+    // log-then-apply bracket around hook execution) don't trip
+    // conflict on themselves.
+    const written = this.state.putIfVersion(next, record.version ?? 0);
+    record.version = written.version;
   }
 }

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -233,8 +233,7 @@ export class TraversalStore {
     return this.withLock(traversalId, async () => {
       const { engine, record } = this.loadEngine(traversalId);
       const hookMeta: Record<string, string> = {};
-      const metaCollector = (updates: Record<string, string>) =>
-        Object.assign(hookMeta, updates);
+      const metaCollector = (updates: Record<string, string>) => Object.assign(hookMeta, updates);
 
       // Phase 1: transition + gate checks. On a gate-block ("early"),
       // session state is already final and runArrivalHooks is a

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -255,10 +255,32 @@ export class TraversalStore {
       // ignores the callback — the pre-hook save above is the boundary
       // for that branch.
       const persistBetween = () => this.saveEngine(record, engine);
-      const result = await engine.runArrivalHooks(commit, {
-        metaCollector,
-        persistBetween,
-      });
+      let result: AdvanceResult | AdvanceMinimalResult;
+      try {
+        result = await engine.runArrivalHooks(commit, { metaCollector, persistBetween });
+      } catch (e) {
+        // Post-transition hook throw. Attach the envelope-sibling
+        // snapshot (currentNode, validTransitions, context / contextDelta)
+        // so the CLI surfaces the same recover-or-stop fields as a
+        // gate-block response — HOOK_FAILED callers are in the same
+        // state. The hook attribution on `context.hook` is already set
+        // by the hook runner.
+        if (e instanceof EngineError) {
+          const minimal = options?.responseMode === "minimal";
+          const writesBefore =
+            commit.kind === "standard" || commit.kind === "subgraph-push"
+              ? commit.writesBefore
+              : undefined;
+          const extras = engine.captureHookFailureEnvelope({
+            minimal,
+            ...(writesBefore !== undefined && { writesBefore }),
+          });
+          if (extras) {
+            e.context = { ...e.context, envelopeSlots: extras };
+          }
+        }
+        throw e;
+      }
 
       // Merge collected hook updates into the in-memory record before
       // the final save.

--- a/test/engine-save-before-hook.test.ts
+++ b/test/engine-save-before-hook.test.ts
@@ -17,8 +17,8 @@ import type { HookFn } from "../src/engine/hooks.js";
 import { HookRunner } from "../src/engine/hooks.js";
 import { EC, EngineError } from "../src/errors.js";
 import { loadGraphs } from "../src/loader.js";
-import { openStateStore, TraversalStore } from "../src/state/index.js";
 import type { TraversalRecord } from "../src/state/index.js";
+import { openStateStore, TraversalStore } from "../src/state/index.js";
 import type { ValidatedGraph } from "../src/types.js";
 
 const FIXTURES_DIR = path.resolve(import.meta.dirname, "fixtures");

--- a/test/engine-save-before-hook.test.ts
+++ b/test/engine-save-before-hook.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Save-before-hook invariant tests for PR D.
+ *
+ * The transition commit lands on disk BEFORE onEnter hooks run, so a
+ * hook throw leaves the traversal's on-disk `currentNode` at the
+ * edge's target. Next advance runs gates on the new node, not the
+ * stale one. See `docs/decisions.md` § "Observable state transitions
+ * are durable before side effects".
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BUILTIN_HOOKS } from "../src/engine/builtin-hooks.js";
+import type { HookFn } from "../src/engine/hooks.js";
+import { HookRunner } from "../src/engine/hooks.js";
+import { EC, EngineError } from "../src/errors.js";
+import { loadGraphs } from "../src/loader.js";
+import { openStateStore, TraversalStore } from "../src/state/index.js";
+import type { TraversalRecord } from "../src/state/index.js";
+import type { ValidatedGraph } from "../src/types.js";
+
+const FIXTURES_DIR = path.resolve(import.meta.dirname, "fixtures");
+
+function stageGraphWithThrowingHook(tmpDir: string): Map<string, ValidatedGraph> {
+  // Graph: start --next--> middle (onEnter: throwing built-in stub) --next--> done
+  fs.writeFileSync(
+    path.join(tmpDir, "g.workflow.yaml"),
+    [
+      "id: throw-on-middle",
+      'version: "1.0.0"',
+      'name: "Throwing hook on middle"',
+      'description: ""',
+      "startNode: start",
+      "context: { seed: 1 }",
+      "nodes:",
+      "  start:",
+      "    type: action",
+      '    description: ""',
+      "    edges:",
+      "      - target: middle",
+      "        label: next",
+      "  middle:",
+      "    type: action",
+      '    description: ""',
+      "    onEnter:",
+      "      - call: memory_status",
+      "    edges:",
+      "      - target: done",
+      "        label: next",
+      "  done:",
+      "    type: terminal",
+      '    description: ""',
+    ].join("\n"),
+  );
+  return loadGraphs(tmpDir);
+}
+
+function stageGraphWithMultiHook(tmpDir: string): Map<string, ValidatedGraph> {
+  // Graph: start --next--> middle (onEnter: ok, then throwing) --next--> done
+  fs.writeFileSync(
+    path.join(tmpDir, "g.workflow.yaml"),
+    [
+      "id: multi-hook",
+      'version: "1.0.0"',
+      'name: "Multi-hook, second throws"',
+      'description: ""',
+      "startNode: start",
+      "context: { seed: 1 }",
+      "nodes:",
+      "  start:",
+      "    type: action",
+      '    description: ""',
+      "    edges:",
+      "      - target: middle",
+      "        label: next",
+      "  middle:",
+      "    type: action",
+      '    description: ""',
+      "    onEnter:",
+      "      - call: memory_browse",
+      "      - call: memory_status",
+      "    edges:",
+      "      - target: done",
+      "        label: next",
+      "  done:",
+      "    type: terminal",
+      '    description: ""',
+    ].join("\n"),
+  );
+  return loadGraphs(tmpDir);
+}
+
+function makeRunner(overrides: Record<string, HookFn>): HookRunner {
+  const merged = new Map<string, HookFn>(BUILTIN_HOOKS);
+  for (const [k, v] of Object.entries(overrides)) merged.set(k, v);
+  return new HookRunner({ builtinHooks: merged });
+}
+
+describe("save-before-hook invariant (PR D)", () => {
+  let tmpDir: string;
+  let traversalsDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sbh-test-"));
+    traversalsDir = path.join(tmpDir, "traversals");
+    fs.mkdirSync(traversalsDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readRecord(id: string): TraversalRecord {
+    const raw = fs.readFileSync(path.join(traversalsDir, `${id}.json`), "utf-8");
+    return JSON.parse(raw) as TraversalRecord;
+  }
+
+  it("persists the edge target on disk when an onEnter hook throws", async () => {
+    const graphs = stageGraphWithThrowingHook(tmpDir);
+    const runner = makeRunner({
+      memory_status: async () => {
+        throw new Error("boom");
+      },
+    });
+    const store = new TraversalStore(openStateStore(traversalsDir), graphs, {
+      hookRunner: runner,
+    });
+
+    const t = await store.createTraversal("throw-on-middle");
+    expect(readRecord(t.traversalId).currentNode).toBe("start");
+
+    await expect(store.advance(t.traversalId, "next")).rejects.toThrow(/boom/);
+
+    // Disk reflects the post-transition node even though the hook failed.
+    expect(readRecord(t.traversalId).currentNode).toBe("middle");
+    store.close();
+  });
+
+  it("HOOK_FAILED carries structured hook context", async () => {
+    const graphs = stageGraphWithThrowingHook(tmpDir);
+    const runner = makeRunner({
+      memory_status: async () => {
+        throw new Error("boom");
+      },
+    });
+    const store = new TraversalStore(openStateStore(traversalsDir), graphs, {
+      hookRunner: runner,
+    });
+
+    const t = await store.createTraversal("throw-on-middle");
+
+    let caught: EngineError | undefined;
+    try {
+      await store.advance(t.traversalId, "next");
+    } catch (e) {
+      if (e instanceof EngineError) caught = e;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught?.code).toBe(EC.HOOK_FAILED);
+    expect(caught?.context).toEqual({
+      hook: { name: "memory_status", nodeId: "middle", phase: "onEnter", index: 0 },
+    });
+    store.close();
+  });
+
+  it("next advance after a hook throw runs gates on the new node (no re-fire)", async () => {
+    const graphs = stageGraphWithThrowingHook(tmpDir);
+    let calls = 0;
+    const runner = makeRunner({
+      memory_status: async () => {
+        calls++;
+        if (calls === 1) throw new Error("boom");
+        return {};
+      },
+    });
+    const store = new TraversalStore(openStateStore(traversalsDir), graphs, {
+      hookRunner: runner,
+    });
+
+    const t = await store.createTraversal("throw-on-middle");
+    await expect(store.advance(t.traversalId, "next")).rejects.toThrow();
+    expect(calls).toBe(1);
+
+    // Next advance runs against the new node "middle". Its own onEnter
+    // must NOT re-fire — it already transitioned, and we're leaving it.
+    // The NEXT node "done" has no hooks, so calls stays at 1.
+    const second = await store.advance(t.traversalId, "next");
+    expect(second.isError).toBe(false);
+    expect(calls).toBe(1);
+    store.close();
+  });
+
+  it("later hook in a chain throws — earlier hook's writes are NOT in record.meta", async () => {
+    // Multi-hook chain: first writes meta (via collector), second
+    // throws. The collected meta is merged into record.meta only on
+    // the post-hook save path, so when the hook throw aborts before
+    // that merge, disk's meta stays pristine. Proves the replay-after
+    // contract: earlier-hook side effects visible only on success.
+    const graphs = stageGraphWithMultiHook(tmpDir);
+    const runner = makeRunner({
+      memory_browse: async (ctx) => {
+        ctx.setMeta?.({ echo: "from-browse" });
+        return {};
+      },
+      memory_status: async () => {
+        throw new Error("later-hook-boom");
+      },
+    });
+    const store = new TraversalStore(openStateStore(traversalsDir), graphs, {
+      hookRunner: runner,
+    });
+
+    const t = await store.createTraversal("multi-hook");
+    await expect(store.advance(t.traversalId, "next")).rejects.toThrow(/later-hook-boom/);
+
+    const rec = readRecord(t.traversalId);
+    expect(rec.currentNode).toBe("middle");
+    // Pre-hook save happens before any hook runs, so the in-memory
+    // hookMeta collector hasn't been merged onto record.meta yet. The
+    // post-hook save that WOULD merge it never runs because of the
+    // throw. Disk meta therefore excludes "echo".
+    expect(rec.meta?.echo).toBeUndefined();
+    store.close();
+  });
+});

--- a/test/engine-save-before-hook.test.ts
+++ b/test/engine-save-before-hook.test.ts
@@ -160,9 +160,22 @@ describe("save-before-hook invariant (PR D)", () => {
 
     expect(caught).toBeDefined();
     expect(caught?.code).toBe(EC.HOOK_FAILED);
-    expect(caught?.context).toEqual({
-      hook: { name: "memory_status", nodeId: "middle", phase: "onEnter", index: 0 },
+    // `context.hook` identifies the failing hook (populated by the
+    // runner). `context.envelope` carries the post-transition
+    // snapshot the CLI lifts to envelope-root siblings — gate-block
+    // parity so HOOK_FAILED and a gate block surface the same
+    // recover-or-stop fields. Runner-set and store-set, respectively.
+    expect(caught?.context?.hook).toEqual({
+      name: "memory_status",
+      nodeId: "middle",
+      index: 0,
     });
+    expect(caught?.context?.envelopeSlots).toBeDefined();
+    expect(caught?.context?.envelopeSlots?.currentNode).toBe("middle");
+    expect(caught?.context?.envelopeSlots?.validTransitions).toEqual([
+      { label: "next", target: "done", conditionMet: true },
+    ]);
+    expect(caught?.context?.envelopeSlots?.context).toEqual({ seed: 1 });
     store.close();
   });
 
@@ -223,6 +236,67 @@ describe("save-before-hook invariant (PR D)", () => {
     // post-hook save that WOULD merge it never runs because of the
     // throw. Disk meta therefore excludes "echo".
     expect(rec.meta?.echo).toBeUndefined();
+    store.close();
+  });
+
+  it("HOOK_FAILED wire envelope carries currentNode, validTransitions, context as siblings to error", async () => {
+    // End-to-end wire-format check: route the thrown EngineError
+    // through `outputError` (the same function CLI handlers call)
+    // and capture the JSON payload. Asserts gate-block parity on the
+    // envelope shape: top-level `currentNode` / `validTransitions` /
+    // `context` + `error.hook` with hook identity.
+    const { outputError } = await import("../src/cli/output.js");
+    const graphs = stageGraphWithThrowingHook(tmpDir);
+    const runner = makeRunner({
+      memory_status: async () => {
+        throw new Error("boom");
+      },
+    });
+    const store = new TraversalStore(openStateStore(traversalsDir), graphs, {
+      hookRunner: runner,
+    });
+
+    const t = await store.createTraversal("throw-on-middle");
+    let thrown: unknown;
+    try {
+      await store.advance(t.traversalId, "next");
+    } catch (e) {
+      thrown = e;
+    }
+
+    const writes: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      outputError(thrown);
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    const payload = JSON.parse(writes.join("")) as {
+      isError: boolean;
+      error: { code: string; message: string; kind: string; hook?: unknown };
+      currentNode?: string;
+      validTransitions?: readonly unknown[];
+      context?: Record<string, unknown>;
+    };
+
+    expect(payload.isError).toBe(true);
+    expect(payload.error.code).toBe(EC.HOOK_FAILED);
+    expect(payload.error.kind).toBe("structural");
+    expect(payload.error.hook).toEqual({
+      name: "memory_status",
+      nodeId: "middle",
+      index: 0,
+    });
+    expect(payload.currentNode).toBe("middle");
+    expect(payload.validTransitions).toEqual([
+      { label: "next", target: "done", conditionMet: true },
+    ]);
+    expect(payload.context).toEqual({ seed: 1 });
     store.close();
   });
 });

--- a/test/memory-prune.test.ts
+++ b/test/memory-prune.test.ts
@@ -127,7 +127,7 @@ describe("memory prune (content-reachability)", () => {
       const result = store.prune({ keep: ["main"] });
       expect(result.rows_pruned).toBe(1);
       expect(result.propositions_hard_deleted).toBe(1);
-      expect(result.entities_orphaned).toBe(1);
+      expect(result.entities_now_orphaned).toBe(1);
 
       expect(readPropSources(dbPath)).toHaveLength(0);
     });

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1091,6 +1091,56 @@ describe("MemoryStore schema migration", () => {
       second.close();
     }
   });
+
+  it("drops mtime_ms column from a pre-migration proposition_sources", () => {
+    const dbPath = path.join(tmpDir, "memory.db");
+    const raw = new DatabaseSync(dbPath);
+    raw.exec("PRAGMA journal_mode = WAL");
+    raw.exec(`
+      CREATE TABLE propositions (
+        id TEXT PRIMARY KEY,
+        content TEXT NOT NULL,
+        content_hash TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL
+      );
+      CREATE TABLE proposition_sources (
+        proposition_id TEXT NOT NULL REFERENCES propositions(id) ON DELETE CASCADE,
+        file_path TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        mtime_ms REAL,
+        PRIMARY KEY (proposition_id, file_path)
+      );
+    `);
+    raw.exec(
+      "INSERT INTO propositions (id, content, content_hash, created_at) VALUES ('p1', 'foo', 'h1', '2024-01-01')",
+    );
+    raw.exec(
+      "INSERT INTO proposition_sources (proposition_id, file_path, content_hash, mtime_ms) VALUES ('p1', 'a.ts', 'src-hash-1', 1234567890)",
+    );
+    raw.close();
+
+    const db = openDatabase(dbPath);
+    try {
+      const cols = db.prepare("PRAGMA table_info(proposition_sources)").all() as Array<{
+        name: string;
+      }>;
+      expect(cols.map((c) => c.name)).not.toContain("mtime_ms");
+
+      // Row survived the column drop.
+      const row = db
+        .prepare(
+          "SELECT proposition_id, file_path, content_hash FROM proposition_sources WHERE proposition_id = 'p1'",
+        )
+        .get() as { proposition_id: string; file_path: string; content_hash: string };
+      expect(row).toEqual({
+        proposition_id: "p1",
+        file_path: "a.ts",
+        content_hash: "src-hash-1",
+      });
+    } finally {
+      db.close();
+    }
+  });
 });
 
 describe("MemoryStore lazy open (#138)", () => {

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -131,6 +131,49 @@ describe("MemoryStore", () => {
       expect(result.entities_created).toBe(2);
       expect(result.propositions[0].entities).toHaveLength(2);
     });
+
+    it("rolls back the whole batch when a later proposition references a missing source", () => {
+      // Partial emit (some rows committed, others aborted) breaks the
+      // "every prop in the batch has its full source set on success"
+      // invariant. The BEGIN/COMMIT wrapper around the loop rolls back
+      // EVERY row the batch wrote (propositions, proposition_sources,
+      // entities, about) when any prop throws.
+      writeFile(tmpDir, "a.ts", "class A {}");
+
+      expect(() =>
+        store.emit([
+          { content: "A exists.", entities: ["A"], sources: ["a.ts"] },
+          {
+            content: "B exists.",
+            entities: ["B"],
+            sources: ["a.ts", "missing.ts"],
+          },
+        ]),
+      ).toThrow(/Cannot read source file/);
+
+      // Close the store so we can re-open a sibling connection on the
+      // same db file and read out the raw row counts post-rollback.
+      const dbPath = path.join(tmpDir, "memory.db");
+      store.close();
+      const db = new DatabaseSync(dbPath);
+      try {
+        const propCount = (db.prepare("SELECT COUNT(*) as c FROM propositions").get() as {
+          c: number;
+        }).c;
+        const sourceCount = (
+          db.prepare("SELECT COUNT(*) as c FROM proposition_sources").get() as {
+            c: number;
+          }
+        ).c;
+        expect(propCount).toBe(0);
+        expect(sourceCount).toBe(0);
+      } finally {
+        db.close();
+      }
+
+      // Replace the closed store so afterEach's close() is a no-op.
+      store = makeMemoryStore(dbPath, tmpDir);
+    });
   });
 
   describe("entity resolution", () => {
@@ -369,6 +412,29 @@ describe("MemoryStore", () => {
       const minimal = store.bySource("auth.ts", { shape: "minimal" });
       const first = minimal.propositions[0] as Record<string, unknown>;
       expect(Object.keys(first).sort()).toEqual(["content", "id"]);
+    });
+
+    it("hides orphans by default, surfaces them with includeOrphans", () => {
+      // Emit against a file, then overwrite the file to break hash
+      // equivalence (content-drift staleness). Default lens hides the
+      // now-orphaned prop. `includeOrphans: true` surfaces it for
+      // audit paths. Mirrors browse's orphan lens.
+      writeFile(tmpDir, "drift.ts", "original");
+      store.emit([
+        { content: "Drift claim.", entities: ["Drift"], sources: ["drift.ts"] },
+      ]);
+
+      // Overwrite — disk hash no longer matches the proposition's
+      // stored source hash. Prop becomes stale.
+      writeFile(tmpDir, "drift.ts", "replaced");
+
+      const hidden = store.bySource("drift.ts");
+      expect(hidden.total).toBe(0);
+      expect(hidden.propositions).toHaveLength(0);
+
+      const surfaced = store.bySource("drift.ts", { includeOrphans: true });
+      expect(surfaced.total).toBe(1);
+      expect(surfaced.propositions).toHaveLength(1);
     });
   });
 

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -157,9 +157,11 @@ describe("MemoryStore", () => {
       store.close();
       const db = new DatabaseSync(dbPath);
       try {
-        const propCount = (db.prepare("SELECT COUNT(*) as c FROM propositions").get() as {
-          c: number;
-        }).c;
+        const propCount = (
+          db.prepare("SELECT COUNT(*) as c FROM propositions").get() as {
+            c: number;
+          }
+        ).c;
         const sourceCount = (
           db.prepare("SELECT COUNT(*) as c FROM proposition_sources").get() as {
             c: number;
@@ -420,9 +422,7 @@ describe("MemoryStore", () => {
       // now-orphaned prop. `includeOrphans: true` surfaces it for
       // audit paths. Mirrors browse's orphan lens.
       writeFile(tmpDir, "drift.ts", "original");
-      store.emit([
-        { content: "Drift claim.", entities: ["Drift"], sources: ["drift.ts"] },
-      ]);
+      store.emit([{ content: "Drift claim.", entities: ["Drift"], sources: ["drift.ts"] }]);
 
       // Overwrite — disk hash no longer matches the proposition's
       // stored source hash. Prop becomes stale.

--- a/test/traversal-store.test.ts
+++ b/test/traversal-store.test.ts
@@ -575,8 +575,14 @@ describe("TraversalStore — stateless JSON", () => {
       store.setMeta(t.traversalId, { owner: "alice" });
       expect(raw().version).toBe(3);
 
+      // advance saves twice — once after the gate-checks + transition
+      // commit (before onEnter), once after hooks complete. The double
+      // write is load-bearing: a hook throw between the saves leaves
+      // disk on the new node, not the stale pre-advance one. See
+      // docs/decisions.md § "Observable state transitions are durable
+      // before side effects".
       await store.advance(t.traversalId, "work-done");
-      expect(raw().version).toBe(4);
+      expect(raw().version).toBe(5);
     });
 
     it("detects cross-process writer races via TRAVERSAL_CONFLICT", async () => {


### PR DESCRIPTION
## Summary

- Flip hook ordering to transition-commits-first / replay-after (engine.ts, subgraph.ts, traversal-store.ts). `advanceTransition` + `runArrivalHooks` split with a save between them so a hook throw leaves disk on the moved-to node.
- HOOK_FAILED envelope carries `currentNode`, `validTransitions`, `context` / `contextDelta` as top-level siblings to `error`, plus `error.hook = { name, nodeId, index }`. Achieved via `EngineError.context.{hook, envelopeSlots}` split; `outputError` spreads each slot to the appropriate destination.
- Memory `emit()` wrapped in BEGIN/COMMIT/ROLLBACK — partial-emit rollback on mid-batch failure.
- `bySource()` default hides orphans; `--include-orphans` CLI flag mirrors `browse`.
- Prune counter rename `entities_orphaned` → `entities_now_orphaned` — tense is load-bearing (entities are never GC'd; the count reports transitions into the orphan lens).
- Drop vestigial `mtime_ms` column from `proposition_sources` with in-place migration matching the `collection` drop pattern.
- Six `throw new Error` sites in memory code converted to typed `EngineError` with PR B catalog codes.
- `docs/decisions.md` entries 5 (prune is content-reachability), 6 (entity non-GC), 9 (emit attribution is emit-time), 10 (mtime_ms removal).

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test -- --run` — 41 files / 800 pass + 4 todo.
- [x] New `test/engine-save-before-hook.test.ts` — 5 cases covering: save-before-hook invariant, HOOK_FAILED carrying structured hook context, no re-fire on next advance, multi-hook chain throw discarding earlier writes, wire-envelope assertion through `outputError`.
- [x] `test/memory.test.ts` extended — emit rollback + bySource orphan lens + mtime_ms migration.
- [x] `test/traversal-store.test.ts` updated — version counter now bumps twice per advance (load-bearing double-save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)