### PR TITLE
refactor(memory): route bySource through prepareSourcePath (#157)

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -169,8 +169,13 @@ export class MemoryStore {
 
   /**
    * Validate a source file path against the source root. Returns the stored
-   * (relative) path and the resolved absolute path. Throws if the path
-   * escapes the source root.
+   * (relative) path and the resolved absolute path. Throws
+   * `SOURCE_OUTSIDE_ROOT` if the path escapes the source root.
+   *
+   * Shared by write paths (`emit`) and reads (`bySource`) so the
+   * "user-supplied file path → stored path" contract lives in one place
+   * and a request for `../../etc/passwd` becomes a structured error on
+   * reads too, not a silent empty match.
    */
   private prepareSourcePath(filePath: string): {
     storedPath: string;
@@ -560,9 +565,7 @@ export class MemoryStore {
     const shape: PropositionShape = options?.shape ?? "full";
     const includeOrphans = options?.includeOrphans ?? false;
 
-    const storedPath = path.isAbsolute(filePath)
-      ? path.relative(this.sourceRoot, filePath)
-      : filePath;
+    const { storedPath } = this.prepareSourcePath(filePath);
 
     // Mirror `browse`'s staleness filter: propositions whose declared
     // source bytes don't match disk/any live ref are hidden by default.

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EngineError } from "../src/errors.js";
 import { openDatabase, retryOnSqliteBusy } from "../src/memory/db.js";
 import { MemoryStore } from "../src/memory/store.js";
 
@@ -49,6 +50,16 @@ describe("MemoryStore", () => {
       expect(() =>
         store.emit([{ content: "Foo exists.", entities: ["Foo"], sources: ["nonexistent.ts"] }]),
       ).toThrow("Cannot read source file");
+    });
+
+    it("rejects emit with SOURCE_OUTSIDE_ROOT when source escapes the root", () => {
+      try {
+        store.emit([{ content: "Foo.", entities: ["Foo"], sources: ["../escape.ts"] }]);
+        expect.fail("emit should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(EngineError);
+        expect((e as EngineError).code).toBe("SOURCE_OUTSIDE_ROOT");
+      }
     });
 
     it("emits propositions with entities", () => {
@@ -435,6 +446,16 @@ describe("MemoryStore", () => {
       const surfaced = store.bySource("drift.ts", { includeOrphans: true });
       expect(surfaced.total).toBe(1);
       expect(surfaced.propositions).toHaveLength(1);
+    });
+
+    it("rejects bySource with SOURCE_OUTSIDE_ROOT when path escapes the root", () => {
+      try {
+        store.bySource("../../etc/passwd");
+        expect.fail("bySource should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(EngineError);
+        expect((e as EngineError).code).toBe("SOURCE_OUTSIDE_ROOT");
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace `bySource`'s inline path translation with `prepareSourcePath`, so the source-root escape check runs on reads too (previously a path like `../../etc/passwd` silently matched zero rows; now surfaces a structured error).
- Convert the escape throw from a plain `Error` to `EngineError(SOURCE_OUTSIDE_ROOT)` (new code, INVALID_INPUT category).

Closes #157.

## Test plan
- [x] `npm test` — 768 passed
- [x] New test: `bySource` with a path escaping root throws `EngineError` with `code === "SOURCE_OUTSIDE_ROOT"`
- [x] New test: `emit` with an escaping source also throws with the new code (previously plain `Error`, uncovered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)