### PR TITLE
fix(state): putIfVersion rejects resurrection of deleted records (#163)

### DIFF
--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -38,11 +38,14 @@ export interface StateStore {
   /** Unconditional write. Use for first-time creation; prefer `putIfVersion` for updates. */
   put(record: TraversalRecord): void;
   /**
-   * Optimistic-concurrency write. Writes `record` iff the on-disk
-   * version still matches `expectedVersion`. Throws
-   * `EngineError(TRAVERSAL_CONFLICT)` otherwise. The caller passes the
-   * version it observed at load time; a mismatch means another writer
-   * raced between the caller's get() and this put().
+   * Optimistic-concurrency update. Writes `record` iff a record with
+   * the same id exists and its on-disk version still matches
+   * `expectedVersion`. Throws `EngineError(TRAVERSAL_CONFLICT)`
+   * otherwise — including when the record was deleted between the
+   * caller's load and this call. Use `put` for first-time creation;
+   * this method assumes the caller loaded a prior record and rejects
+   * the resurrection case where `freelance reset --confirm` races an
+   * in-flight advance.
    *
    * The supplied `record.version` is ignored on input — the store
    * always writes `expectedVersion + 1`. Returns the record actually
@@ -85,8 +88,11 @@ class InMemoryStateStore implements StateStore {
   }
   putIfVersion(record: TraversalRecord, expectedVersion: number): TraversalRecord {
     const current = this.records.get(record.id);
-    const currentVersion = current?.version ?? 0;
-    if (current && currentVersion !== expectedVersion) {
+    if (!current) {
+      throw new TraversalConflictError(record.id, expectedVersion, 0);
+    }
+    const currentVersion = current.version ?? 0;
+    if (currentVersion !== expectedVersion) {
       throw new TraversalConflictError(record.id, expectedVersion, currentVersion);
     }
     const next = { ...record, version: expectedVersion + 1 };
@@ -165,8 +171,11 @@ class JsonDirectoryStateStore implements StateStore {
     // workload (per-checkout tool, rare cross-process concurrency)
     // detection via TRAVERSAL_CONFLICT beats silent loss.
     const existing = this.get(record.id);
-    const current = existing?.version ?? 0;
-    if (existing && current !== expectedVersion) {
+    if (!existing) {
+      throw new TraversalConflictError(record.id, expectedVersion, 0);
+    }
+    const current = existing.version ?? 0;
+    if (current !== expectedVersion) {
       throw new TraversalConflictError(record.id, expectedVersion, current);
     }
     const next = { ...record, version: expectedVersion + 1 };

--- a/test/traversal-store.test.ts
+++ b/test/traversal-store.test.ts
@@ -625,6 +625,46 @@ describe("TraversalStore — stateless JSON", () => {
       }
     });
 
+    it.each([
+      ["json", () => path.join(tmpDir, "resurrection-json")],
+      [":memory:", () => ":memory:"],
+    ])("putIfVersion rejects resurrection of a deleted record (%s)", (_label, dirOrSentinel) => {
+      // Writer A loads, writer B deletes (e.g. `freelance reset
+      // --confirm`), writer A's saveEngine fires putIfVersion.
+      // Without the guard the write proceeds as a fresh create,
+      // silently undoing the operator's explicit clear. The check
+      // is on record existence, not `expectedVersion > 0`: the
+      // `version ?? 0` normalization for pre-1.4 records means
+      // `expectedVersion === 0` can legitimately come from a loaded
+      // legacy record, so zero is not a safe "is this a create"
+      // signal.
+      const backend = openStateStore(dirOrSentinel());
+      try {
+        for (const expectedVersion of [5, 0]) {
+          const record = {
+            id: `tr_ghost_v${expectedVersion}`,
+            stack: [],
+            graphId: "valid-simple",
+            currentNode: "start",
+            stackDepth: 0,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            version: expectedVersion,
+          };
+          try {
+            backend.putIfVersion(record, expectedVersion);
+            throw new Error("expected TRAVERSAL_CONFLICT, none thrown");
+          } catch (e) {
+            expect(e).toBeInstanceOf(EngineError);
+            expect((e as EngineError).code).toBe("TRAVERSAL_CONFLICT");
+          }
+          expect(backend.get(record.id)).toBeUndefined();
+        }
+      } finally {
+        backend.close();
+      }
+    });
+
     it("rejection in one advance doesn't poison subsequent calls on the same id", async () => {
       const t = await store.createTraversal("valid-simple");
       // First advance fails (no matching edge, no contextSet first).


### PR DESCRIPTION
## Summary

- `putIfVersion` no longer silently resurrects a traversal record that was deleted between the caller's load and save (e.g. `freelance reset --confirm` racing an in-flight advance). Missing record → `TRAVERSAL_CONFLICT`, always.
- Guard is on record existence, **not** `expectedVersion > 0`. The `version ?? 0` normalization for pre-1.4 records means `expectedVersion === 0` can legitimately come from a loaded legacy record, so zero can't double as a "this is a create" signal — that would re-open the same resurrection hole for legacy records.
- Interface docstring tightened to codify `putIfVersion` as update-only; `put` remains the create path (`createTraversal` already uses it).

Closes #163.

## Test plan

- [x] New parameterized test covers both backends (`json`, `:memory:`) and both `expectedVersion` values (`5` post-1.4 case, `0` pre-1.4-legacy case) — both reject with `TRAVERSAL_CONFLICT` and leave the store empty.
- [x] Existing cross-process writer-race test (#88, `TRAVERSAL_CONFLICT` detection) still passes — that path goes through the version-mismatch branch, not the new missing-record branch.
- [x] Full suite: 820 tests pass, `tsc --noEmit` clean, `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)