### PR TITLE
refactor(cli): align memoryReset with destructive-verb + runCliHandler pattern (#164)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -13,14 +13,7 @@ import { EC, EngineError } from "../errors.js";
 import { EmitBatchSchema } from "../memory/emit-schema.js";
 import type { MemoryStore } from "../memory/index.js";
 import type { PropositionShape } from "../memory/types.js";
-import {
-  CliExit,
-  EXIT,
-  errorEnvelope,
-  handleRuntimeError as handleError,
-  outputJson,
-  parseIntArg,
-} from "./output.js";
+import { CliExit, EXIT, errorEnvelope, outputJson, parseIntArg } from "./output.js";
 
 export function memoryStatus(store: MemoryStore): void {
   outputJson(store.status());
@@ -174,26 +167,24 @@ export function memoryPrune(
  */
 export function memoryReset(dbPath: string, opts: { confirm?: boolean }): void {
   if (!opts.confirm) {
-    outputJson({
-      ...errorEnvelope(
-        EC.CONFIRM_REQUIRED,
-        "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
-      ),
-      commandName: "memory reset",
-    });
-    process.exit(EXIT.INVALID_INPUT);
+    throw new CliExit(
+      {
+        ...errorEnvelope(
+          EC.CONFIRM_REQUIRED,
+          "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
+        ),
+        commandName: "memory reset",
+      },
+      EXIT.INVALID_INPUT,
+    );
   }
   const targets = [dbPath, `${dbPath}-shm`, `${dbPath}-wal`];
   const deleted: string[] = [];
-  try {
-    for (const f of targets) {
-      if (fs.existsSync(f)) {
-        fs.unlinkSync(f);
-        deleted.push(f);
-      }
+  for (const f of targets) {
+    if (fs.existsSync(f)) {
+      fs.unlinkSync(f);
+      deleted.push(f);
     }
-  } catch (e) {
-    handleError(e);
   }
   outputJson({ status: "reset", deleted, dbPath });
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -426,7 +426,10 @@ addWorkflowsOpt(
   // Does NOT open the db — resolves the path from config and unlinks
   // the files directly. This is the recovery path for "old memory.db
   // schema is incompatible with the current build," which would
-  // otherwise block composeRuntime from opening the db at all.
+  // otherwise block composeRuntime from opening the db at all. No
+  // resource to dispose, but the wrapper still carries its weight:
+  // `CliExit` from the `--confirm` refusal and any `EngineError` from
+  // the unlink loop both route through the standard exit plumbing.
   const dirs = resolveGraphsDirs(opts.workflows);
   const fileConfig = loadConfigFromDirs(dirs);
   const memConfig = resolveMemoryConfig(dirs, {}, fileConfig);
@@ -434,7 +437,7 @@ addWorkflowsOpt(
     outputJson({ status: "noop", reason: "memory disabled in config" });
     return;
   }
-  memoryReset(memConfig.db, { confirm: opts.confirm });
+  runCliHandler({ close() {} }, () => memoryReset(memConfig.db, { confirm: opts.confirm }));
 });
 
 // --- Stateless commands ---


### PR DESCRIPTION
## Summary

- `memoryReset` now throws `CliExit` for the `--confirm` refusal, matching `traversalReset` and `memoryPrune`. One pattern across all three destructive verbs.
- Wrap the `program.ts` action in `runCliHandler({ close() {} }, …)`. Memory reset doesn't open the db (by design — it's the schema-mismatch recovery path), so there's no resource to dispose, but the wrapper still routes `CliExit` and unlink-loop errors through the standard exit plumbing.
- Drop the internal `try/catch { handleError }` around the unlink loop — runCliHandler is the outer catch now.

Closes #164.

## Test plan

- [x] Existing `envelope-contract.test.ts` check for `memory reset` without `--confirm` (envelope shape + `commandName: "memory reset"`) still passes — payload shape is unchanged, only the delivery path moved from inline `outputJson` to `CliExit`.
- [x] `npm test` — 818 tests pass.
- [x] `tsc --noEmit` clean, `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)