### PR TITLE
refactor(cli): move splitKeyValue to output.ts so its location matches its convention status (#165)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Durable contracts surfaced across multiple features. If a new feature extends on
 
 **Hook cross-layer capabilities flow through `runHooksFor` parameters, surfaced via optional `HookContext` fields.** Hooks can't import the store; host capabilities they need (memory reads, meta writes) are threaded as parameters through `engine.runHooksOnArrival` → `runHooksFor` → `HookContext`. `HookRunner` stays stateless — it holds configuration, not capabilities. Adding a new capability = add a parameter on `runHooksFor` and an optional field on `HookContext` (`src/engine/hooks.ts`). Don't open a back door by reaching into the store from inside a hook body.
 
-**`splitKeyValue` is the single CLI primitive for `key=value` flags.** `--meta`, `--filter`, and `context set` all parse `key=value` pairs. One helper in `src/cli/traversals.ts` splits on the first `=`, validates a non-empty key, and throws a consistent error. Value handling (string-only for meta, JSON-coerced for context, byte-capped for meta via `parseMetaPairs`) stays at the caller — domain-specific — but the split + empty-key guard is shared.
+**`splitKeyValue` is the single CLI primitive for `key=value` flags.** `--meta`, `--filter`, and `context set` all parse `key=value` pairs. One helper in `src/cli/output.ts` (co-located with `parseIntArg` and other cross-feature CLI primitives) splits on the first `=`, validates a non-empty key, and throws a consistent error. Value handling (string-only for meta, JSON-coerced for context, byte-capped for meta via `parseMetaPairs`) stays at the caller — domain-specific — but the split + empty-key guard is shared.
 
 ## Project structure
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -28,6 +28,28 @@ export function parseIntArg(raw: string | undefined, flag: string): number | und
 }
 
 /**
+ * Shared primitive for CLI flags that accept `key=value` pairs. Splits on
+ * the first `=`, validates a non-empty key, and throws with a consistent
+ * error message across `--meta`, `--filter`, and `context set`. Callers
+ * layer their own value handling on top (string-only for meta, JSON-
+ * coerced for context).
+ */
+export function splitKeyValue(pair: string, flag: string): [string, string] {
+  const eqIdx = pair.indexOf("=");
+  if (eqIdx === -1) {
+    throw new EngineError(
+      `${flag} requires key=value pairs; got "${pair}"`,
+      EC.INVALID_KEY_VALUE_PAIR,
+    );
+  }
+  const key = pair.slice(0, eqIdx);
+  if (!key) {
+    throw new EngineError(`${flag} key is empty in "${pair}"`, EC.INVALID_KEY_VALUE_PAIR);
+  }
+  return [key, pair.slice(eqIdx + 1)];
+}
+
+/**
  * Semantic exit codes. Consumed by the skill body (and any shell-driving
  * client) to branch on outcome without parsing stdout. Categorized by
  * "who can do something about this":

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -14,29 +14,7 @@ import type { InspectHistoryOptions } from "../engine/context.js";
 import { EC, EngineError } from "../errors.js";
 import type { TraversalStore } from "../state/index.js";
 import type { InspectField, InspectPositionResult } from "../types.js";
-import { CliExit, EXIT, errorEnvelope, outputJson, parseIntArg } from "./output.js";
-
-/**
- * Shared primitive for CLI flags that accept `key=value` pairs. Splits on
- * the first `=`, validates a non-empty key, and throws with a consistent
- * error message across `--meta`, `--filter`, and `context set`. Callers
- * layer their own value handling on top (string-only for meta, JSON-
- * coerced for context).
- */
-function splitKeyValue(pair: string, flag: string): [string, string] {
-  const eqIdx = pair.indexOf("=");
-  if (eqIdx === -1) {
-    throw new EngineError(
-      `${flag} requires key=value pairs; got "${pair}"`,
-      EC.INVALID_KEY_VALUE_PAIR,
-    );
-  }
-  const key = pair.slice(0, eqIdx);
-  if (!key) {
-    throw new EngineError(`${flag} key is empty in "${pair}"`, EC.INVALID_KEY_VALUE_PAIR);
-  }
-  return [key, pair.slice(eqIdx + 1)];
-}
+import { CliExit, EXIT, errorEnvelope, outputJson, parseIntArg, splitKeyValue } from "./output.js";
 
 // Shared by `start` and `advance` for their `--context` JSON payload.
 function parseContextJson(raw: string): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- CLAUDE.md § Conventions names `splitKeyValue` as **the** cross-feature CLI primitive for `key=value` flags, but the function lived as a private `function` in `src/cli/traversals.ts`. Any future CLI surface introducing a `key=value` flag outside traversals would either duplicate the helper or import from a domain-specific handler — neither holds the convention up.
- Move the helper to `src/cli/output.ts` (alongside `parseIntArg`; this file already hosts the cross-feature CLI primitives), export it, update the lone caller (`traversals.ts`), and update the CLAUDE.md pointer.
- No behavior change — same signature, same guard, same error codes.

Closes #165.

## Test plan

- [x] `npm test` — 818 tests pass (same total as pre-move; no test touches this helper directly but every `--meta` / `--filter` / `context set` parse path exercises it end-to-end).
- [x] `tsc --noEmit` clean, `biome check` clean.
- [x] Grep confirms the only import site is `src/cli/traversals.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)