### PR TITLE
refactor(memory): drop unreachable prune barrel export from memory/index.ts (#166)

### DIFF
--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,4 +1,2 @@
-export type { PruneOptions, PruneResult } from "./prune.js";
-export { prune } from "./prune.js";
 export { MemoryStore } from "./store.js";
 export type { MemoryConfig } from "./types.js";


### PR DESCRIPTION
## Summary

\`src/memory/index.ts\` re-exported \`prune\`, \`PruneOptions\`, and \`PruneResult\` alongside \`MemoryStore\`. None of those exports are reachable by an external caller:

- \`prune(db, sourceRoot, options)\` needs a \`Db\` handle. Neither \`Db\` nor \`openDatabase\` is re-exported through \`memory/index.ts\` or \`src/index.ts\`.
- \`package.json#exports\` only publishes \`.\` and \`./core\` — \`./memory\` isn't a public path.
- The only internal caller (\`store.ts:20\`) imports from \`./prune.js\` directly, not the barrel.

\`MemoryStore.prune\` is the supported public surface; its own rationale comment (\`store.ts:122-127\`) argues against exposing the escape hatches the standalone export would need to be useful. Match the export surface to what's actually reachable: drop the two lines.

\`PruneOptions\`/\`PruneResult\` types remain imported by \`store.ts:20\` from the direct path for the wrapper method's signature — that import is unchanged.

Closes #166.

## Test plan

- [x] \`npm test\` — 820 tests pass.
- [x] \`tsc --noEmit\` clean (proves no consumer relied on the barrel for these exports).
- [x] Grep confirms only \`MemoryStore\` and \`MemoryConfig\` are imported from \`memory/index.ts\` across \`src/\` and \`test/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)