### PR TITLE
perf(memory): conditional FTS rebuild on openDatabase, not unconditional

### DIFF
--- a/src/memory/db.ts
+++ b/src/memory/db.ts
@@ -173,6 +173,24 @@ function migrateDropMtimeColumn(db: Db): void {
 }
 
 /**
+ * FTS5 external-content shadow tables persist on disk; the
+ * `propositions_ai` / `propositions_ad` triggers keep them in sync.
+ * The one exception is a database that had `propositions` rows before
+ * the FTS table existed (or whose FTS was dropped) — `CREATE VIRTUAL
+ * TABLE IF NOT EXISTS` made an empty FTS table and the triggers will
+ * only fire on future inserts, not the existing rows. Detect that one
+ * case via an empty `propositions_fts_idx` against a non-empty
+ * `propositions` and rebuild once. Replaces the prior unconditional
+ * rebuild on every open, which paid O(rows × content-length)
+ * tokenization for nothing on the steady-state path.
+ */
+function migrateRebuildFtsIfEmpty(db: Db): void {
+  if (countQuery(db, "SELECT COUNT(*) FROM propositions_fts_idx") > 0) return;
+  if (countQuery(db, "SELECT COUNT(*) FROM propositions") === 0) return;
+  db.exec("INSERT INTO propositions_fts(propositions_fts) VALUES ('rebuild')");
+}
+
+/**
  * SQLITE_BUSY detection across node:sqlite's error shape. Matches both
  * "database is locked" (short timeout / immediate) and "database is
  * busy" (long-held writer) variants.
@@ -299,10 +317,7 @@ function openDatabaseOnce(dbPath: string): Db {
   // dormant — this drop just makes the schema deterministic across
   // freshly-opened databases.
   inner.exec("DROP TRIGGER IF EXISTS propositions_au");
-
-  // Rebuild FTS index on every open — external content tables don't persist
-  // their index across connections, so we rebuild to ensure search works.
-  db.exec("INSERT INTO propositions_fts(propositions_fts) VALUES ('rebuild')");
+  migrateRebuildFtsIfEmpty(db);
 
   return db;
 }

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -470,6 +470,24 @@ describe("MemoryStore", () => {
       expect(result.propositions).toHaveLength(1);
       expect(result.propositions[0].content).toContain("JWT");
     });
+
+    it("finds propositions after process restart (cross-connection FTS persistence)", () => {
+      // FTS5 external-content shadow tables persist on disk and the
+      // triggers keep them in sync — if a future change reintroduces a
+      // load-bearing rebuild dependency on every open, this test catches
+      // it.
+      writeFile(tmpDir, "a.ts", "x");
+      store.emit([
+        { content: "Auth validates JWT tokens.", entities: ["Auth"], sources: ["a.ts"] },
+      ]);
+      store.close();
+
+      const dbPath = path.join(tmpDir, "memory.db");
+      store = makeMemoryStore(dbPath, tmpDir);
+      const result = store.search("JWT");
+      expect(result.propositions).toHaveLength(1);
+      expect(result.propositions[0].content).toContain("JWT");
+    });
   });
 
   describe("status", () => {
@@ -1110,6 +1128,33 @@ describe("MemoryStore schema migration", () => {
       expect(cols.map((c) => c.name)).not.toContain("collection");
     } finally {
       second.close();
+    }
+  });
+
+  it("rebuilds FTS when propositions exist but the FTS index is empty", () => {
+    // A database created before FTS was populated by triggers (or with
+    // FTS dropped manually) — openDatabase detects the mismatch via
+    // empty propositions_fts_idx + non-empty propositions and rebuilds.
+    const dbPath = path.join(tmpDir, "memory.db");
+    const raw = new DatabaseSync(dbPath);
+    raw.exec(
+      "CREATE TABLE propositions (id TEXT PRIMARY KEY, content TEXT NOT NULL, content_hash TEXT NOT NULL, created_at TEXT NOT NULL)",
+    );
+    raw
+      .prepare("INSERT INTO propositions VALUES (?, ?, ?, ?)")
+      .run("p1", "Auth validates JWT tokens.", "h1", "2026-01-01T00:00:00Z");
+    raw.close();
+
+    const db = openDatabase(dbPath);
+    try {
+      const hits = db
+        .prepare(
+          "SELECT p.id FROM propositions p JOIN propositions_fts fts ON p.rowid = fts.rowid WHERE propositions_fts MATCH ?",
+        )
+        .all("JWT") as Array<{ id: string }>;
+      expect(hits.map((h) => h.id)).toEqual(["p1"]);
+    } finally {
+      db.close();
     }
   });
 


### PR DESCRIPTION
## Summary

The prior \`INSERT INTO propositions_fts(propositions_fts) VALUES ('rebuild')\` ran on every \`openDatabase\` call. The comment claimed FTS5 external-content shadow tables don't persist across connections — but they do. \`propositions_fts_data\`, \`propositions_fts_idx\`, etc. are real on-disk tables, and the \`propositions_ai\` / \`propositions_ad\` triggers keep them in sync with \`propositions\`. The rebuild was cargo, not correctness — paying \`O(rows × content-length)\` tokenization on every CLI invocation for nothing on the steady-state path.

## What changed

\`migrateRebuildFtsIfEmpty(db)\` matches the existing \`migrateDropCollectionColumn\` / \`migrateDropMtimeColumn\` shape — slots into \`openDatabaseOnce\` next to its siblings. Detects the one case where rebuild is genuinely needed: a database with \`propositions\` rows but an empty \`propositions_fts_idx\` (database created before FTS was populated by triggers, or whose FTS was dropped manually). On the common warm-start path: two sub-millisecond \`COUNT\` scans, no rebuild.

## Verification

Probed FTS5 external-content persistence experimentally before changing anything:

\`\`\`
Phase 1 (insert via triggers): search hits: [ 'p1' ]
Phase 2 (close + reopen, no rebuild): search hits: [ 'p1' ]
Phase 3 (insert into reopened db, trigger fires): search hits: [ 'p3' ]
\`\`\`

And \`propositions_fts_idx\` row count is the right sentinel — 0 when the index is empty (just-created FTS table), >0 once segments are written. Bounded by segment count (single to low-double digits), not corpus size.

## Test plan

Two new tests:

- **Cross-connection FTS persistence** (under \`describe("search")\`) — emit, close store, reopen, search still finds the row. If a future change reintroduces a load-bearing rebuild dependency, this test catches it.
- **Legacy rebuild path** (under \`describe("MemoryStore schema migration")\`, alongside the \`collection\` / \`mtime_ms\` drop tests) — seed \`propositions\` directly without FTS, then \`openDatabase\` should detect empty \`propositions_fts_idx\` and rebuild once.

\`npm test\` — 822 tests pass. \`tsc --noEmit\` clean. \`biome check\` clean.

## /simplify pass

- Extracted the inline conditional to a named \`migrateRebuildFtsIfEmpty\` function so it follows the established migration-function pattern (\`openDatabaseOnce\` stays at one level of abstraction).
- Trimmed test docstring narration.

## Context

Sixth in a velocity arc on the memory cluster. After this lands, the natural next step is **MemoryStore class extraction** (the largest item in the queue) — many \`private\` methods only touch \`this.db\` / \`this.sourceRoot\` and would mirror the \`enrichment.ts\` / \`staleness.ts\` free-function precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)