### PR TITLE
refactor(memory): extract MemoryStore helpers to entities.ts + enrichment.ts + ids.ts

### DIFF
--- a/src/memory/enrichment.ts
+++ b/src/memory/enrichment.ts
@@ -1,15 +1,14 @@
 /**
- * Query helpers for MemoryStore's read-side operations.
- *
- * Pure functions that take a database handle plus whatever pre-computed
- * staleness info the caller has, and return enriched query results.
- * Kept stateless so MemoryStore's public methods can orchestrate without
- * these helpers holding any state of their own.
+ * Read-side helpers for MemoryStore: scalar/aggregate queries, bulk
+ * fetches over a db handle, and pure projections from row + pre-fetched
+ * joins to the wire shape. Stateless — every input flows through
+ * parameters, including the staleness cache and source root that the
+ * projection helpers need.
  */
 
-import { countQuery, type Db } from "./db.js";
-import { notStaleExists } from "./staleness.js";
-import type { NeighborEntity, StatusResult } from "./types.js";
+import { countQuery, type Db, sqlPlaceholders } from "./db.js";
+import { isFileChanged, notStaleExists, type StalenessCache } from "./staleness.js";
+import type { NeighborEntity, PropositionInfo, PropositionRow, StatusResult } from "./types.js";
 
 // Every query below joins against `STALE_PROP_IDS_TABLE` via
 // `notStaleExists`. Callers MUST invoke `materializeStalePropIds(db,
@@ -108,4 +107,103 @@ export function computeStatus(db: Db, stalePropIds: Set<string>): StatusResult {
     stale_propositions: totalProps - validCount,
     total_entities: totalEntities,
   };
+}
+
+/**
+ * Bulk-fetch `proposition_sources` for a list of proposition ids and
+ * group by id. Replaces the per-row SELECT pattern (one query per
+ * returned proposition; up to MAX_PAGE_LIMIT round-trips per read).
+ * Caller-supplied `propIds` is bounded by pagination well below
+ * SQLite's `SQLITE_MAX_VARIABLE_NUMBER` ceiling.
+ */
+export function fetchSourcesByProp(
+  db: Db,
+  propIds: readonly string[],
+): Map<string, Array<{ file_path: string; content_hash: string }>> {
+  if (propIds.length === 0) return new Map();
+  const rows = db
+    .prepare(
+      `SELECT proposition_id, file_path, content_hash
+       FROM proposition_sources
+       WHERE proposition_id IN (${sqlPlaceholders(propIds.length)})`,
+    )
+    .all(...propIds) as Array<{
+    proposition_id: string;
+    file_path: string;
+    content_hash: string;
+  }>;
+  return groupByProp(rows, (r) => ({ file_path: r.file_path, content_hash: r.content_hash }));
+}
+
+/** Search-side companion to `fetchSourcesByProp`. */
+export function fetchEntitiesByProp(
+  db: Db,
+  propIds: readonly string[],
+): Map<string, Array<{ id: string; name: string; kind: string | null }>> {
+  if (propIds.length === 0) return new Map();
+  const rows = db
+    .prepare(
+      `SELECT a.proposition_id, e.id, e.name, e.kind
+       FROM entities e
+       JOIN about a ON e.id = a.entity_id
+       WHERE a.proposition_id IN (${sqlPlaceholders(propIds.length)})`,
+    )
+    .all(...propIds) as Array<{
+    proposition_id: string;
+    id: string;
+    name: string;
+    kind: string | null;
+  }>;
+  return groupByProp(rows, (r) => ({ id: r.id, name: r.name, kind: r.kind }));
+}
+
+/**
+ * Project a proposition row + its pre-fetched sources into the
+ * full-shape `PropositionInfo`. The staleness cache amortizes
+ * source-file hashing across propositions sharing the same files in
+ * one read.
+ */
+export function enrichProposition(
+  sourceRoot: string,
+  cache: StalenessCache,
+  row: PropositionRow,
+  propSources: ReadonlyArray<{ file_path: string; content_hash: string }>,
+): PropositionInfo {
+  const sourceFiles = propSources.map((sf) => ({
+    path: sf.file_path,
+    hash: sf.content_hash,
+    current_match: !isFileChanged(sourceRoot, cache, sf.file_path, sf.content_hash),
+  }));
+
+  const valid = sourceFiles.length === 0 || sourceFiles.every((sf) => sf.current_match);
+
+  return {
+    id: row.id,
+    content: row.content,
+    created_at: row.created_at,
+    valid,
+    source_files: sourceFiles,
+  };
+}
+
+/**
+ * Group bulk-fetched rows by `proposition_id` into a `Map<id, T[]>`,
+ * projecting each row to the value shape via `pick`. Local helper for
+ * `fetchSourcesByProp` / `fetchEntitiesByProp` — both run a single
+ * `IN (?, ?, …)` query and need the same per-prop bucketing.
+ */
+function groupByProp<R extends { proposition_id: string }, T>(
+  rows: readonly R[],
+  pick: (row: R) => T,
+): Map<string, T[]> {
+  const out = new Map<string, T[]>();
+  for (const r of rows) {
+    let arr = out.get(r.proposition_id);
+    if (!arr) {
+      arr = [];
+      out.set(r.proposition_id, arr);
+    }
+    arr.push(pick(r));
+  }
+  return out;
 }

--- a/src/memory/entities.ts
+++ b/src/memory/entities.ts
@@ -1,0 +1,108 @@
+/** Entity domain queries: lookup, resolution, kind reconciliation. */
+
+import { EC, EngineError } from "../errors.js";
+import type { Db } from "./db.js";
+import { generateId, now } from "./ids.js";
+import type { EmitWarning, EntityRow } from "./types.js";
+
+/**
+ * Look up an entity by id (PK), exact name (`idx_entity_name`), or
+ * case-insensitive name (`idx_entity_name_lower`). All three OR arms
+ * are indexable so SQLite's OR-decomposition unions indexed lookups
+ * instead of scanning; the CASE in ORDER BY picks the winner when
+ * more than one matches. Throws `ENTITY_NOT_FOUND` if no row matches.
+ */
+export function findEntity(db: Db, idOrName: string): EntityRow {
+  const entity = db
+    .prepare(
+      `SELECT id, name, kind, created_at FROM entities
+       WHERE id = ?1 OR name = ?1 OR LOWER(name) = LOWER(?1)
+       ORDER BY CASE
+         WHEN id = ?1 THEN 0
+         WHEN name = ?1 THEN 1
+         ELSE 2
+       END
+       LIMIT 1`,
+    )
+    .get(idOrName) as EntityRow | undefined;
+  if (!entity) {
+    throw new EngineError(`Entity not found: ${idOrName}`, EC.ENTITY_NOT_FOUND);
+  }
+  return entity;
+}
+
+/**
+ * Resolve an entity by name with a provided kind, creating it if
+ * missing.
+ *
+ * Kind semantics:
+ * - If the entity doesn't exist: create it with the given kind.
+ * - If the entity exists with a null kind and a kind is provided:
+ *   backfill the kind.
+ * - If the entity exists with a non-null kind that differs from the
+ *   provided kind: keep the existing kind (first-wins) and push an
+ *   `entity_kind_conflict` warning for the caller. The store does not
+ *   reconcile — surfacing the conflict is the feature.
+ */
+export function resolveEntity(
+  db: Db,
+  name: string,
+  kind: string | undefined,
+  warnings: EmitWarning[],
+): { id: string; name: string; resolution: "exact" | "normalized" | "created" } {
+  // One OR-decomposed lookup: idx_entity_name covers the exact arm,
+  // idx_entity_name_lower covers the normalized arm. CASE rank in
+  // ORDER BY picks the winner when both match (exact wins). Same
+  // pattern as findEntity.
+  const match = db
+    .prepare(
+      `SELECT id, name, kind,
+              CASE WHEN name = ?1 THEN 'exact' ELSE 'normalized' END AS resolution
+       FROM entities
+       WHERE name = ?1 OR LOWER(TRIM(name)) = LOWER(TRIM(?1))
+       ORDER BY CASE WHEN name = ?1 THEN 0 ELSE 1 END
+       LIMIT 1`,
+    )
+    .get(name) as (EntityRow & { resolution: "exact" | "normalized" }) | undefined;
+  if (match) {
+    reconcileKind(db, match, kind, warnings);
+    return { id: match.id, name: match.name, resolution: match.resolution };
+  }
+
+  const id = generateId();
+  db.prepare("INSERT INTO entities (id, name, kind, created_at) VALUES (?, ?, ?, ?)").run(
+    id,
+    name,
+    kind ?? null,
+    now(),
+  );
+
+  return { id, name, resolution: "created" };
+}
+
+/**
+ * First-wins kind policy: if the existing entity has a kind that
+ * disagrees with the provided one, surface a warning but keep the
+ * stored kind. If the existing entity has no kind and one is provided,
+ * backfill. No-op when the caller didn't specify `kind`.
+ */
+function reconcileKind(
+  db: Db,
+  existing: EntityRow,
+  kind: string | undefined,
+  warnings: EmitWarning[],
+): void {
+  if (!kind) return;
+  if (existing.kind && existing.kind !== kind) {
+    warnings.push({
+      type: "entity_kind_conflict",
+      entity: existing.name,
+      existingKind: existing.kind,
+      providedKind: kind,
+    });
+    return;
+  }
+  if (!existing.kind) {
+    db.prepare("UPDATE entities SET kind = ? WHERE id = ?").run(kind, existing.id);
+  }
+}

--- a/src/memory/ids.ts
+++ b/src/memory/ids.ts
@@ -1,0 +1,11 @@
+/** UUID + ISO timestamp primitives shared across memory write paths. */
+
+import crypto from "node:crypto";
+
+export function generateId(): string {
+  return crypto.randomUUID();
+}
+
+export function now(): string {
+  return new Date().toISOString();
+}

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -5,26 +5,37 @@
  * session state. Sources are attached per-proposition at emit time, so
  * staleness is computed per-proposition against the current filesystem.
  *
- * Read-side query helpers live in ./enrichment.ts (pure functions over a
- * db handle), and provenance staleness checking lives in ./staleness.ts
- * (per-call cache threaded through each public read so cache growth is
- * bounded to a single operation).
+ * Per-domain helpers are pure free functions over a db handle:
+ *  - ./entities.ts — entity lookup, resolution, kind reconciliation
+ *  - ./enrichment.ts — read-side query + projection helpers
+ *  - ./staleness.ts — provenance staleness checking
+ *
+ * MemoryStore is the orchestrator: holds the (lazy) db handle + source
+ * root, exposes the public API, and threads the helpers together.
  */
 
 import crypto from "node:crypto";
 import path from "node:path";
 import { EC, EngineError } from "../errors.js";
 import { hashSourceFile } from "../sources.js";
-import { countQuery, type Db, sqlPlaceholders, withTransaction } from "./db.js";
-import { computeStatus, countNeighbors, countValidForEntity, getNeighbors } from "./enrichment.js";
+import { countQuery, type Db, withTransaction } from "./db.js";
+import {
+  computeStatus,
+  countNeighbors,
+  countValidForEntity,
+  enrichProposition,
+  fetchEntitiesByProp,
+  fetchSourcesByProp,
+  getNeighbors,
+} from "./enrichment.js";
+import { findEntity, resolveEntity } from "./entities.js";
+import { generateId, now } from "./ids.js";
 import { type PruneOptions, type PruneResult, prune as pruneExternal } from "./prune.js";
 import {
   createStalenessCache,
   getStalePropositionIds,
-  isFileChanged,
   notStaleExists,
   primeStaleFilter,
-  type StalenessCache,
 } from "./staleness.js";
 import type {
   BrowseResult,
@@ -64,36 +75,6 @@ function clampLimit(requested: number | undefined): number {
 function clampOffset(requested: number | undefined): number {
   if (requested === undefined || requested < 0) return 0;
   return Math.trunc(requested);
-}
-
-function generateId(): string {
-  return crypto.randomUUID();
-}
-
-function now(): string {
-  return new Date().toISOString();
-}
-
-/**
- * Group bulk-fetched rows by `proposition_id` into a `Map<id, T[]>`,
- * projecting each row to the value shape via `pick`. Local helper for
- * `fetchSourcesByProp` / `fetchEntitiesByProp` — both run a single
- * `IN (?, ?, …)` query and need the same per-prop bucketing.
- */
-function groupByProp<R extends { proposition_id: string }, T>(
-  rows: readonly R[],
-  pick: (row: R) => T,
-): Map<string, T[]> {
-  const out = new Map<string, T[]>();
-  for (const r of rows) {
-    let arr = out.get(r.proposition_id);
-    if (!arr) {
-      arr = [];
-      out.set(r.proposition_id, arr);
-    }
-    arr.push(pick(r));
-  }
-  return out;
 }
 
 /**
@@ -178,8 +159,6 @@ export class MemoryStore {
     return { deleted_propositions: propCount, deleted_entities: entCount };
   }
 
-  // --- Source path resolution ---
-
   /**
    * Validate a source file path against the source root. Returns the stored
    * (relative) path and the resolved absolute path. Throws
@@ -216,8 +195,6 @@ export class MemoryStore {
 
     return { storedPath, resolvedPath };
   }
-
-  // --- Proposition emission ---
 
   emit(propositions: EmitProposition[]): EmitResult {
     const result: EmitResult = {
@@ -297,7 +274,7 @@ export class MemoryStore {
 
         for (const entityName of prop.entities) {
           const kind = prop.entityKinds?.[entityName];
-          const resolved = this.resolveEntity(entityName, kind, warnings);
+          const resolved = resolveEntity(this.db, entityName, kind, warnings);
           propResult.entities.push(resolved);
           insertAbout.run(propId, resolved.id);
           if (resolved.resolution === "created") {
@@ -316,105 +293,6 @@ export class MemoryStore {
     }
     return result;
   }
-
-  // --- Entity resolution ---
-
-  /**
-   * Resolve an entity by name with a provided kind, creating it if missing.
-   *
-   * Kind semantics:
-   * - If the entity doesn't exist: create it with the given kind.
-   * - If the entity exists with a null kind and a kind is provided:
-   *   backfill the kind.
-   * - If the entity exists with a non-null kind that differs from the
-   *   provided kind: keep the existing kind (first-wins) and push an
-   *   `entity_kind_conflict` warning for the caller. The store does not
-   *   reconcile — surfacing the conflict is the feature.
-   */
-  private resolveEntity(
-    name: string,
-    kind: string | undefined,
-    warnings: EmitWarning[],
-  ): { id: string; name: string; resolution: "exact" | "normalized" | "created" } {
-    const exact = this.db.prepare("SELECT id, name, kind FROM entities WHERE name = ?").get(name) as
-      | EntityRow
-      | undefined;
-    if (exact) {
-      this.reconcileKind(exact, kind, warnings);
-      return { id: exact.id, name: exact.name, resolution: "exact" };
-    }
-
-    const normalized = name.toLowerCase().trim();
-    const normMatch = this.db
-      .prepare("SELECT id, name, kind FROM entities WHERE LOWER(TRIM(name)) = ?")
-      .get(normalized) as EntityRow | undefined;
-    if (normMatch) {
-      this.reconcileKind(normMatch, kind, warnings);
-      return { id: normMatch.id, name: normMatch.name, resolution: "normalized" };
-    }
-
-    const id = generateId();
-    this.db
-      .prepare("INSERT INTO entities (id, name, kind, created_at) VALUES (?, ?, ?, ?)")
-      .run(id, name, kind ?? null, now());
-
-    return { id, name, resolution: "created" };
-  }
-
-  /**
-   * First-wins kind policy: if the existing entity has a kind that
-   * disagrees with the provided one, surface a warning but keep the
-   * stored kind. If the existing entity has no kind and one is
-   * provided, backfill. Either branch is a no-op when the caller
-   * didn't specify `kind`.
-   */
-  private reconcileKind(
-    existing: EntityRow,
-    kind: string | undefined,
-    warnings: EmitWarning[],
-  ): void {
-    if (!kind) return;
-    if (existing.kind && existing.kind !== kind) {
-      warnings.push({
-        type: "entity_kind_conflict",
-        entity: existing.name,
-        existingKind: existing.kind,
-        providedKind: kind,
-      });
-      return;
-    }
-    if (!existing.kind) {
-      this.db.prepare("UPDATE entities SET kind = ? WHERE id = ?").run(kind, existing.id);
-    }
-  }
-
-  // --- Entity lookup ---
-
-  private findEntity(idOrName: string): EntityRow {
-    // Precedence: id (PK) > exact name (`idx_entity_name`) >
-    // case-insensitive name (`idx_entity_name_lower`). All three OR
-    // arms are indexable so SQLite's OR-decomposition unions indexed
-    // lookups instead of scanning; the CASE in ORDER BY picks the
-    // winner when more than one matches.
-    const entity = this.db
-      .prepare(
-        `SELECT id, name, kind, created_at FROM entities
-         WHERE id = ?1 OR name = ?1 OR LOWER(name) = LOWER(?1)
-         ORDER BY CASE
-           WHEN id = ?1 THEN 0
-           WHEN name = ?1 THEN 1
-           ELSE 2
-         END
-         LIMIT 1`,
-      )
-      .get(idOrName) as EntityRow | undefined;
-    if (!entity) {
-      throw new EngineError(`Entity not found: ${idOrName}`, EC.ENTITY_NOT_FOUND);
-    }
-    return entity;
-  }
-
-  // --- Query operations ---
 
   browse(options?: {
     name?: string;
@@ -477,7 +355,7 @@ export class MemoryStore {
     options?: { limit?: number; offset?: number; shape?: PropositionShape },
   ): InspectResult {
     const cache = createStalenessCache();
-    const entity = this.findEntity(entityIdOrName);
+    const entity = findEntity(this.db, entityIdOrName);
     const limit = clampLimit(options?.limit);
     const offset = clampOffset(options?.offset);
     const shape: PropositionShape = options?.shape ?? "full";
@@ -522,9 +400,12 @@ export class MemoryStore {
       };
     }
 
-    const sourcesByProp = this.fetchSourcesByProp(propRows.map((p) => p.id));
+    const sourcesByProp = fetchSourcesByProp(
+      this.db,
+      propRows.map((p) => p.id),
+    );
     const propositions = propRows.map((p) =>
-      this.enrichProposition(p, cache, sourcesByProp.get(p.id) ?? []),
+      enrichProposition(this.sourceRoot, cache, p, sourcesByProp.get(p.id) ?? []),
     );
 
     // Deduped source files across the entity's *full* proposition set
@@ -601,9 +482,12 @@ export class MemoryStore {
     if (shape === "minimal") {
       propositions = propRows.map((p) => ({ id: p.id, content: p.content }) as MinimalProposition);
     } else {
-      const sourcesByProp = this.fetchSourcesByProp(propRows.map((p) => p.id));
+      const sourcesByProp = fetchSourcesByProp(
+        this.db,
+        propRows.map((p) => p.id),
+      );
       propositions = propRows.map((p) =>
-        this.enrichProposition(p, cache, sourcesByProp.get(p.id) ?? []),
+        enrichProposition(this.sourceRoot, cache, p, sourcesByProp.get(p.id) ?? []),
       );
     }
 
@@ -630,10 +514,10 @@ export class MemoryStore {
       .all(sanitized, limit) as PropositionRow[];
 
     const propIds = rows.map((p) => p.id);
-    const sourcesByProp = this.fetchSourcesByProp(propIds);
-    const entitiesByProp = this.fetchEntitiesByProp(propIds);
+    const sourcesByProp = fetchSourcesByProp(this.db, propIds);
+    const entitiesByProp = fetchEntitiesByProp(this.db, propIds);
     const propositions = rows.map((p) => ({
-      ...this.enrichProposition(p, cache, sourcesByProp.get(p.id) ?? []),
+      ...enrichProposition(this.sourceRoot, cache, p, sourcesByProp.get(p.id) ?? []),
       entities: entitiesByProp.get(p.id) ?? [],
     }));
 
@@ -650,7 +534,7 @@ export class MemoryStore {
 
   related(entityIdOrName: string, options?: { limit?: number; offset?: number }): RelatedResult {
     const cache = createStalenessCache();
-    const entity = this.findEntity(entityIdOrName);
+    const entity = findEntity(this.db, entityIdOrName);
     const limit = clampLimit(options?.limit);
     const offset = clampOffset(options?.offset);
 
@@ -680,77 +564,6 @@ export class MemoryStore {
       },
       neighbors,
       total,
-    };
-  }
-
-  // --- Proposition enrichment (stays on the class — called by every read) ---
-
-  /**
-   * Bulk-fetch `proposition_sources` rows for a list of proposition
-   * ids in one round-trip and group them by id. Replaces the per-row
-   * SELECT pattern that issued one query per returned proposition;
-   * with `MAX_PAGE_LIMIT = 200` the worst case was 200 round-trips
-   * per read. `propIds.length` is bounded by pagination well below
-   * SQLite's `SQLITE_MAX_VARIABLE_NUMBER` ceiling.
-   */
-  private fetchSourcesByProp(
-    propIds: readonly string[],
-  ): Map<string, Array<{ file_path: string; content_hash: string }>> {
-    if (propIds.length === 0) return new Map();
-    const rows = this.db
-      .prepare(
-        `SELECT proposition_id, file_path, content_hash
-         FROM proposition_sources
-         WHERE proposition_id IN (${sqlPlaceholders(propIds.length)})`,
-      )
-      .all(...propIds) as Array<{
-      proposition_id: string;
-      file_path: string;
-      content_hash: string;
-    }>;
-    return groupByProp(rows, (r) => ({ file_path: r.file_path, content_hash: r.content_hash }));
-  }
-
-  /** Search-side companion to `fetchSourcesByProp`. */
-  private fetchEntitiesByProp(
-    propIds: readonly string[],
-  ): Map<string, Array<{ id: string; name: string; kind: string | null }>> {
-    if (propIds.length === 0) return new Map();
-    const rows = this.db
-      .prepare(
-        `SELECT a.proposition_id, e.id, e.name, e.kind
-         FROM entities e
-         JOIN about a ON e.id = a.entity_id
-         WHERE a.proposition_id IN (${sqlPlaceholders(propIds.length)})`,
-      )
-      .all(...propIds) as Array<{
-      proposition_id: string;
-      id: string;
-      name: string;
-      kind: string | null;
-    }>;
-    return groupByProp(rows, (r) => ({ id: r.id, name: r.name, kind: r.kind }));
-  }
-
-  private enrichProposition(
-    row: PropositionRow,
-    cache: StalenessCache,
-    propSources: ReadonlyArray<{ file_path: string; content_hash: string }>,
-  ): PropositionInfo {
-    const sourceFiles = propSources.map((sf) => ({
-      path: sf.file_path,
-      hash: sf.content_hash,
-      current_match: !isFileChanged(this.sourceRoot, cache, sf.file_path, sf.content_hash),
-    }));
-
-    const valid = sourceFiles.length === 0 || sourceFiles.every((sf) => sf.current_match);
-
-    return {
-      id: row.id,
-      content: row.content,
-      created_at: row.created_at,
-      valid,
-      source_files: sourceFiles,
     };
   }
 }


### PR DESCRIPTION
## Summary

\`MemoryStore\` had been accumulating private methods that only depended on \`db\` + \`sourceRoot\` — free functions wearing \`private\` as costume. Mirror the existing \`enrichment.ts\` / \`staleness.ts\` free-function precedent so the class stays a thin orchestrator.

### New modules

- **\`src/memory/entities.ts\`** — \`findEntity\`, \`resolveEntity\`, \`reconcileKind\`. Entity-domain queries.
- **\`src/memory/ids.ts\`** — \`generateId\`, \`now\`. Shared id/timestamp primitives, used by both \`store.ts\` (emit) and \`entities.ts\` (resolveEntity); previously duplicated across the two.

### Extended

- **\`src/memory/enrichment.ts\`** — adds \`enrichProposition\`, \`fetchSourcesByProp\`, \`fetchEntitiesByProp\`, plus a private \`groupByProp\` helper. Module docstring updated to match the broader scope (was "pure functions over a db handle"; now also covers projections that need \`sourceRoot\` + staleness cache).

### Slimmed

- **\`src/memory/store.ts\`** — class loses 6 private methods (~200 lines). Call sites switch from \`this.findEntity(x)\` to \`findEntity(this.db, x)\` etc. Only one private method remains: \`prepareSourcePath\` (one-off; tightly coupled to MemoryStore's emit/bySource; no clean home until a third caller appears). Top docstring enumerates the new sibling modules. Stale section dividers (\`// --- X ---\`) removed.

### /simplify pass — adjacent wins absorbed

- **\`generateId\` / \`now\` promoted to \`ids.ts\`** so entities.ts and store.ts share one source instead of duplicating \`crypto.randomUUID()\` / \`new Date().toISOString()\`.
- **\`resolveEntity\` SELECT collapse** — the two sequential SELECTs (exact name, then \`LOWER(TRIM(name))\`) became one OR-decomposed query mirroring \`findEntity\`'s shape. Both indexes (\`idx_entity_name\`, \`idx_entity_name_lower\`) cover their respective arms; SQLite's OR-decomposition unions the indexed lookups. Halves round-trips on the emit hot path.
- Trimmed \`entities.ts\` module docstring (refactor narration).
- Updated \`enrichment.ts\` module docstring (was stale — claimed "pure functions over a db handle" before \`enrichProposition\` was added).

## No public API change

Every behavioral test still passes; the diff is purely structural. The 822 existing tests cover entity resolution end-to-end via emit + read methods, so the resolveEntity SQL collapse is exercised.

## Test plan

- [x] \`npm test\` — 822 tests pass.
- [x] \`tsc --noEmit\` clean, \`biome check\` clean.

## Velocity arc tally

This is the seventh PR in a sustained cleanup arc on the memory cluster (#172, #173, #174, #177, #178, #179, this). Each PR has surfaced the next: \`/simplify\` findings on one PR became the scope of the next; debt entries got logged on one PR and absorbed by a later one. After this lands, **no open issues remain** for the memory module — the queue is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)