### PR TITLE
fix(engine): close two invariant-bypass holes (#182, #183)

### DIFF
--- a/src/engine/builtin-hooks.ts
+++ b/src/engine/builtin-hooks.ts
@@ -6,19 +6,22 @@
  * missing name fails the graph load, same as a missing script file.
  */
 
+import { EC, EngineError } from "../errors.js";
 import type { PropositionShape } from "../memory/types.js";
 import type { HookContext, HookFn, HookMemoryAccess } from "./hooks.js";
 
 /**
  * Guard: every built-in memory hook needs live memory access. If the
  * host wired a HookRunner without memory (memory off), fail at first
- * invocation with a message that points the user at the config switch.
+ * invocation with the catalogued `MEMORY_DISABLED` code so the skill's
+ * structured recovery fires (point operator at config.yml).
  */
 function requireMemory(ctx: HookContext, opName: string): HookMemoryAccess {
   if (!ctx.memory) {
-    throw new Error(
+    throw new EngineError(
       `Built-in hook "${opName}" on node "${ctx.nodeId}" requires memory to be enabled. ` +
         `Set memory.enabled: true in config.yml, or replace this hook with a local script.`,
+      EC.MEMORY_DISABLED,
     );
   }
   return ctx.memory;
@@ -205,9 +208,10 @@ const memoryBySource: HookFn = async (ctx) => {
 // collector which the store applies before persisting the record.
 const metaSet: HookFn = async (ctx) => {
   if (!ctx.setMeta) {
-    throw new Error(
+    throw new EngineError(
       `Built-in hook "meta_set" on node "${ctx.nodeId}" needs a meta collector — ` +
         `the host did not thread one. Internal bug; please report.`,
+      EC.INTERNAL,
     );
   }
   const updates: Record<string, string> = {};

--- a/src/engine/hooks.ts
+++ b/src/engine/hooks.ts
@@ -188,6 +188,14 @@ export class HookRunner {
       try {
         result = await withTimeout(fn(hookCtx), this.hookTimeoutMs, resolved.call, nodeId);
       } catch (e) {
+        // Pass EngineError codes through (MEMORY_DISABLED, INTERNAL,
+        // etc.); wrapping as HOOK_FAILED would collapse the catalogued
+        // recovery. See docs/decisions.md § "Error envelope is the
+        // wire contract".
+        if (e instanceof EngineError) {
+          e.context = { ...e.context, hook: { name: resolved.call, nodeId, index: i } };
+          throw e;
+        }
         const message = e instanceof Error ? e.message : String(e);
         throw new EngineError(
           `onEnter hook "${resolved.call}" on node "${nodeId}" failed: ${message}`,

--- a/src/engine/wait.ts
+++ b/src/engine/wait.ts
@@ -33,7 +33,7 @@ export function evaluateWaitConditions(
 
 export function checkWaitTimeout(session: SessionState, nodeDef: NodeDefinition): boolean {
   if (!nodeDef.timeout || !session.waitArrivedAt) return false;
-  if (session.context._waitTimedOut === true) return true;
+  if (session.waitTimedOutAt) return true;
 
   const timeoutMs = parseDuration(nodeDef.timeout);
   if (timeoutMs === null) return false;
@@ -41,7 +41,7 @@ export function checkWaitTimeout(session: SessionState, nodeDef: NodeDefinition)
   const arrivedAt = new Date(session.waitArrivedAt).getTime();
   const now = Date.now();
   if (now >= arrivedAt + timeoutMs) {
-    session.context._waitTimedOut = true;
+    session.waitTimedOutAt = new Date(now).toISOString();
     return true;
   }
   return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,6 +350,15 @@ export interface SessionState {
   turnCount: number;
   startedAt: string;
   waitArrivedAt?: string;
+  /**
+   * ISO timestamp of when `checkWaitTimeout` first observed that
+   * `waitArrivedAt + timeout` was in the past. Engine-internal —
+   * lives on SessionState rather than `context` so it doesn't ride
+   * the context wire (full-mode echoes) or slip past `strictContext`,
+   * byte caps, or the `contextHistory` audit trail. `waitStatus:
+   * "timed_out"` is the public signal.
+   */
+  waitTimedOutAt?: string;
 }
 
 // --- Traversal management types ---

--- a/test/builtin-hooks.test.ts
+++ b/test/builtin-hooks.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BUILTIN_HOOK_NAMES, BUILTIN_HOOKS, isBuiltinHook } from "../src/engine/builtin-hooks.js";
 import type { HookContext } from "../src/engine/hooks.js";
+import { EngineError } from "../src/errors.js";
 import { openDatabase } from "../src/memory/db.js";
 import { MemoryStore } from "../src/memory/store.js";
 
@@ -112,11 +113,16 @@ describe("memory_status built-in hook", () => {
     expect(result.total_propositions).toBe(0);
   });
 
-  it("throws a clear error when ctx.memory is undefined", async () => {
+  it("throws EngineError(MEMORY_DISABLED) when ctx.memory is undefined", async () => {
     const memoryStatus = BUILTIN_HOOKS.get("memory_status")!;
-    await expect(memoryStatus(makeCtx())).rejects.toThrow(
-      /memory_status.*requires memory to be enabled/,
-    );
+    try {
+      await memoryStatus(makeCtx());
+      expect.fail("expected EngineError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(EngineError);
+      expect((e as EngineError).code).toBe("MEMORY_DISABLED");
+      expect((e as EngineError).message).toMatch(/requires memory to be enabled/);
+    }
   });
 });
 

--- a/test/hooks.test.ts
+++ b/test/hooks.test.ts
@@ -6,6 +6,7 @@ import { BUILTIN_HOOKS } from "../src/engine/builtin-hooks.js";
 import type { HookFn } from "../src/engine/hooks.js";
 import { HookRunner, resolveHookArgs } from "../src/engine/hooks.js";
 import { GraphEngine } from "../src/engine/index.js";
+import { EngineError } from "../src/errors.js";
 import type { HookResolutionMap } from "../src/hook-resolution.js";
 import { resolveGraphHooks, validateHookImports } from "../src/hook-resolution.js";
 import { loadGraphs, loadSingleGraph } from "../src/loader.js";
@@ -322,7 +323,25 @@ describe("hook runner — end-to-end via engine", () => {
     // Default runner (no overrides) → uses real BUILTIN_HOOKS, no memoryStore.
     const runner = new HookRunner({});
     const engine = new GraphEngine(graphs, { hookRunner: runner });
-    await expect(engine.start("builtin-no-store")).rejects.toThrow(/requires memory to be enabled/);
+    try {
+      await engine.start("builtin-no-store");
+      expect.fail("expected EngineError");
+    } catch (e) {
+      // HookRunner preserves EngineError codes thrown by built-ins
+      // instead of wrapping as HOOK_FAILED — lets the skill branch
+      // on the catalogued MEMORY_DISABLED recovery (point operator
+      // at config.yml) rather than the generic script-hook-blew-up
+      // fallback.
+      expect(e).toBeInstanceOf(EngineError);
+      expect((e as EngineError).code).toBe("MEMORY_DISABLED");
+      expect((e as EngineError).message).toMatch(/requires memory to be enabled/);
+      // Hook attribution still attaches on the pass-through path.
+      expect((e as EngineError).context?.hook).toEqual({
+        name: "memory_status",
+        nodeId: "start",
+        index: 0,
+      });
+    }
   });
 
   it("throws a clear error when script returns non-object", async () => {

--- a/test/wait.test.ts
+++ b/test/wait.test.ts
@@ -237,7 +237,9 @@ describe("wait nodes — timeout", () => {
     // Inspect should show timed_out
     const inspect = engine.inspect("position") as InspectPositionResult;
     expect(inspect.waitStatus).toBe("timed_out");
-    expect(inspect.context._waitTimedOut).toBe(true);
+    // The timeout flag lives on SessionState (waitTimedOutAt), not in
+    // context — waitStatus is the public wire signal.
+    expect(inspect.context._waitTimedOut).toBeUndefined();
   });
 
   it("advance is unblocked after timeout", async () => {
@@ -260,7 +262,7 @@ describe("wait nodes — timeout", () => {
     }
   });
 
-  it("sets _waitTimedOut in context on timeout", async () => {
+  it("stamps waitTimedOutAt on SessionState when the timeout fires", async () => {
     const engine = makeEngine("valid-wait.workflow.yaml");
     await engine.start("valid-wait");
     await engine.advance("submitted");
@@ -270,10 +272,13 @@ describe("wait nodes — timeout", () => {
     stack[0].waitArrivedAt = new Date(Date.now() - 25 * 3600 * 1000).toISOString();
     engine.restoreStack(stack);
 
-    // Trigger timeout check via advance
-    engine.contextSet({ ciPassed: false, coverageReport: "n/a" });
-    await engine.advance("failed");
-    // _waitTimedOut should have been set — we advanced to fix-ci
+    // Inspect triggers checkWaitTimeout via computeWaitInfo
+    engine.inspect("position");
+    const after = engine.getStack();
+    expect(after[0].waitTimedOutAt).toBeDefined();
+    // Flag lives on SessionState, not context — confirms no bleed
+    // into the wire shape or past strictContext / caps / contextHistory.
+    expect(after[0].context._waitTimedOut).toBeUndefined();
   });
 
   it("does not timeout before duration elapses", async () => {


### PR DESCRIPTION
## Summary

Two correctness fixes bundled under the shared theme "engine silently bypasses its own contracts."

### #182 — \`_waitTimedOut\` moves off \`session.context\` onto \`SessionState.waitTimedOutAt\`

\`checkWaitTimeout\` (wait.ts) was stamping \`_waitTimedOut = true\` directly into \`session.context\`, bypassing \`applyContextUpdates\` (the \`contextHistory\` append path), \`enforceContextCaps\`, and \`enforceStrictContext\`. Consequences:

- **contextHistory gap** — flag transition missing from the audit trail (\`inspect --detail history\` shows the arrival step but no timeout entry; \`contextDelta\` on post-timeout minimal responses omits it).
- **Leak into full-mode echoes** — agents see \`_waitTimedOut: true\` in context even though it's implementation-private.
- **strictContext bypass** — a closed context schema accumulates \`_waitTimedOut\` while equivalent agent/hook writes are rejected with STRICT_CONTEXT_VIOLATION.
- **Cap bypass** — benign today (one boolean) but wrong shape for future engine-internal flags.

**Fix**: \`waitTimedOutAt\` is an ISO timestamp on \`SessionState\`, sibling of \`waitArrivedAt\`. \`waitStatus: "timed_out"\` remains the public wire signal — what tests should have been asserting on all along.

**Migration**: no schema bump. Old session records with \`context._waitTimedOut\` keep working — the field is ignored; the next \`checkWaitTimeout\` re-derives from \`waitArrivedAt + timeout\` and stamps \`waitTimedOutAt\` fresh.

### #183 — \`HookRunner\` preserves \`EngineError\` codes instead of wrapping as HOOK_FAILED

\`HookRunner.runHooksFor\`'s catch wrapped every throw as \`HOOK_FAILED\` — including \`EngineError\`s with catalogued codes like \`MEMORY_DISABLED\`. The skill's structured recovery (per \`error-codes.ts\` + \`docs/decisions.md\` § "Error envelope is the wire contract") collapsed to the generic script-hook-blew-up fallback. A hidden re-opening of the pre-#118 string-typed-recovery debt.

**Fix**: two-line change to the catch — pass \`EngineError\` through (enrich with hook attribution via \`e.context = { ...e.context, hook: {...} }\`), wrap only plain \`Error\` as \`HOOK_FAILED\`. Built-ins that want a catalogued code opt in by throwing \`EngineError\` directly.

- \`requireMemory\` throws \`EngineError(MEMORY_DISABLED)\`.
- \`meta_set\` host-bug guard throws \`EngineError(INTERNAL)\` (low-stakes, same shape of collapse).

User-script throws (the common case) still get the \`HOOK_FAILED\` wrapper — trust model unchanged.

## Test plan

- **\`test/wait.test.ts\`** — three sites that read \`context._waitTimedOut\` migrate to the public \`waitStatus === "timed_out"\` + negative guards on \`context._waitTimedOut\` (confirming no bleed into the wire). New test stamps \`waitTimedOutAt\` via \`inspect\` and confirms the flag lives on SessionState, not context.
- **\`test/builtin-hooks.test.ts\`** — \`requireMemory\` test now asserts \`EngineError\` + \`code === "MEMORY_DISABLED"\` instead of just matching the message string.
- **\`test/hooks.test.ts\`** — new end-to-end assertion: built-in memory hook fired through \`engine.start\` without memory surfaces \`MEMORY_DISABLED\` (not \`HOOK_FAILED\`), with hook attribution (\`{ name, nodeId, index }\`) attached via \`EngineError.context.hook\`. Catches any future regression that reintroduces the catch-all wrap.

\`npm test\` — 822 tests pass. \`tsc --noEmit\` clean, \`biome check\` clean.

## /simplify pass

Trimmed narrative comments in \`hooks.ts\`, \`builtin-hooks.ts\`, and \`test/builtin-hooks.test.ts\` to keep only the non-obvious WHY. Reuse and efficiency passes both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)