### PR TITLE
fix(state): AMBIGUOUS_TRAVERSAL carries structured candidates (#188)

### DIFF
--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -399,16 +399,16 @@ export class TraversalStore {
     if (ids.length === 1) return ids[0];
 
     // Ambiguous: only now do we need the full records to build a useful error.
-    const records = this.state.list();
-    const summary = records
-      .map((t) => {
-        const base = `${t.id} (${t.graphId} @ ${t.currentNode})`;
-        return t.meta ? `${base} ${JSON.stringify(t.meta)}` : base;
-      })
-      .join(", ");
+    // `state.list()` is sorted updatedAt-desc, so records[0] is the natural
+    // representative for the `{traversalId}` slot in RECOVERY[AMBIGUOUS_TRAVERSAL].verb.
+    // The skill picks differently using the structured `candidates` array.
+    // `candidates` mirrors `freelance status`'s activeTraversals shape so a
+    // skill that parses one parses the other.
+    const candidates = this.state.list().map(recordToInfo);
     throw new EngineError(
-      `Multiple active traversals. Specify traversalId. Active: ${summary}`,
+      `Multiple active traversals (${candidates.length}). Specify --traversal <id>.`,
       EC.AMBIGUOUS_TRAVERSAL,
+      { envelopeSlots: { traversalId: candidates[0].traversalId, candidates } },
     );
   }
 

--- a/test/envelope-contract.test.ts
+++ b/test/envelope-contract.test.ts
@@ -162,11 +162,32 @@ describe("CLI error envelope — wire-level contract", () => {
     assertEnvelope(result, "INVALID_FLAG_VALUE");
   });
 
-  // AMBIGUOUS_TRAVERSAL is reachable today (when multiple traversals
-  // are active), but the task contract (#5) requires `candidates`
-  // on the envelope — that field arrives with PR C's recovery
-  // catalog work.
-  it.todo("AMBIGUOUS_TRAVERSAL carries candidates: Array<{traversalId, meta}> (PR C)");
+  it("AMBIGUOUS_TRAVERSAL carries candidates and a traversalId slot", () => {
+    // Two starts → two active traversals → resolveTraversalId throws ambiguous.
+    runCli(["start", "valid-simple"], tmpDir);
+    runCli(["start", "valid-simple"], tmpDir);
+    const result = runCli(["advance", "work-done"], tmpDir);
+    const envelope = assertEnvelope(result, "AMBIGUOUS_TRAVERSAL");
+    // `candidates` is the structured projection the skill picks from;
+    // `traversalId` is the most-recent record's id, supplied so
+    // RECOVERY[AMBIGUOUS_TRAVERSAL].verb's `{traversalId}` slot
+    // resolves to a runnable command rather than an unsubstituted
+    // template.
+    const root = envelope as Record<string, unknown>;
+    expect(Array.isArray(root.candidates)).toBe(true);
+    const candidates = root.candidates as Array<Record<string, unknown>>;
+    expect(candidates).toHaveLength(2);
+    for (const c of candidates) {
+      expect(typeof c.traversalId).toBe("string");
+      expect(c.graphId).toBe("valid-simple");
+      expect(typeof c.currentNode).toBe("string");
+    }
+    expect(typeof root.traversalId).toBe("string");
+    expect(candidates.some((c) => c.traversalId === root.traversalId)).toBe(true);
+    // `recoveryVerb` stays the literal catalog template — the skill
+    // interpolates `{traversalId}` against the root-level slot.
+    expect(envelope.error.recoveryVerb).toBe("advance --traversal {traversalId}");
+  });
 
   it("CONFIRM_REQUIRED — freelance reset without --confirm carries commandName", () => {
     // Also scaffold a traversal-of-one so `reset` reaches the


### PR DESCRIPTION
## Summary

- `resolveTraversalId` now populates `envelopeSlots.candidates` (Array<TraversalInfo>) and `envelopeSlots.traversalId` (most-recent record). The catalog template `advance --traversal {traversalId}` resolves cleanly; the skill picks from `candidates` instead of regex-parsing the message.
- `candidates` reuses `recordToInfo`, so it matches `freelance status`'s `activeTraversals` shape.
- Lights up `test/envelope-contract.test.ts:169`'s `it.todo` with a real assertion.

Closes #188.

## Test plan

- [x] `npm run build` — tsc clean
- [x] `npm test` — 823 pass, 2 todo (was 3)
- [x] `npx biome check` — clean
- [x] Envelope-contract test asserts `candidates`, `traversalId` slot, and the literal `recoveryVerb` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)