### PR TITLE
fix(state): assertSafeId throws EngineError(INVALID_FLAG_VALUE) (#189)

### DIFF
--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -81,12 +81,15 @@ class InMemoryStateStore implements StateStore {
     return sortByUpdatedDesc([...this.records.values()]);
   }
   get(id: string): TraversalRecord | undefined {
+    assertSafeId(id);
     return this.records.get(id);
   }
   put(record: TraversalRecord): void {
+    assertSafeId(record.id);
     this.records.set(record.id, { ...record, version: (record.version ?? 0) + 1 });
   }
   putIfVersion(record: TraversalRecord, expectedVersion: number): TraversalRecord {
+    assertSafeId(record.id);
     const current = this.records.get(record.id);
     if (!current) {
       throw new TraversalConflictError(record.id, expectedVersion, 0);
@@ -100,14 +103,21 @@ class InMemoryStateStore implements StateStore {
     return next;
   }
   delete(id: string): void {
+    assertSafeId(id);
     this.records.delete(id);
   }
   close(): void {}
 }
 
+// Caller-supplied id boundary check. `--traversal "../foo"` short-circuits
+// `resolveTraversalId` and reaches the store directly; without this the
+// path-traversal attempt either escapes the traversals dir (json backend
+// without the guard) or silently succeeds (in-memory). Routing through
+// `INVALID_FLAG_VALUE` keeps the failure on the catalog's fix-context
+// branch instead of collapsing to INTERNAL via outputError's fallback.
 function assertSafeId(id: string): void {
   if (!id || id.includes("/") || id.includes("\\") || id.includes("..") || id.includes("\0")) {
-    throw new Error(`Invalid traversal id: ${JSON.stringify(id)}`);
+    throw new EngineError(`Invalid traversal id: ${JSON.stringify(id)}`, EC.INVALID_FLAG_VALUE);
   }
 }
 

--- a/test/envelope-contract.test.ts
+++ b/test/envelope-contract.test.ts
@@ -162,6 +162,15 @@ describe("CLI error envelope — wire-level contract", () => {
     assertEnvelope(result, "INVALID_FLAG_VALUE");
   });
 
+  it("INVALID_FLAG_VALUE — assertSafeId rejects --traversal with path traversal", () => {
+    // `resolveTraversalId` short-circuits on caller-supplied ids;
+    // the storage backend's `assertSafeId` is the boundary that
+    // catches `../foo`. Without an EngineError throw the failure
+    // collapses to INTERNAL.
+    const result = runCli(["advance", "--traversal", "../foo", "anything"], tmpDir);
+    assertEnvelope(result, "INVALID_FLAG_VALUE");
+  });
+
   // AMBIGUOUS_TRAVERSAL is reachable today (when multiple traversals
   // are active), but the task contract (#5) requires `candidates`
   // on the envelope — that field arrives with PR C's recovery


### PR DESCRIPTION
## Summary

- `assertSafeId` now throws `EngineError(INVALID_FLAG_VALUE)` instead of a raw `Error`. `--traversal "../foo"` previously collapsed to `INTERNAL` (exit 1, `recoveryKind: "report"`) via `outputError`'s fallback; it now routes through the catalog's `fix-context` branch (exit 5).
- `InMemoryStateStore.get/put/putIfVersion/delete` now invoke the same guard. The json backend has always checked; the two backends now agree on rejection semantics so test fixtures don't silently accept ids prod would reject.
- Adds an envelope-contract case for `--traversal "../foo"` so a future guard re-route doesn't silently regress.

Closes #189.

## Test plan

- [x] `npm run build` — tsc clean
- [x] `npm test` — 823 pass, 3 todo
- [x] `npx biome check` — clean
- [x] New case: `freelance advance --traversal "../foo" anything` → `INVALID_FLAG_VALUE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)