### PR TITLE
fix(state): putIfVersion missing-record → TRAVERSAL_NOT_FOUND (#192)

### DIFF
--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -40,12 +40,19 @@ export interface StateStore {
   /**
    * Optimistic-concurrency update. Writes `record` iff a record with
    * the same id exists and its on-disk version still matches
-   * `expectedVersion`. Throws `EngineError(TRAVERSAL_CONFLICT)`
-   * otherwise — including when the record was deleted between the
-   * caller's load and this call. Use `put` for first-time creation;
-   * this method assumes the caller loaded a prior record and rejects
-   * the resurrection case where `freelance reset --confirm` races an
-   * in-flight advance.
+   * `expectedVersion`. Two distinct failure shapes:
+   *
+   *   - missing record (deleted between read and write, e.g. via a
+   *     racing `reset --confirm`) → `EngineError(TRAVERSAL_NOT_FOUND)`,
+   *     `recoveryKind: "clear"`. The skill drops the dead handle.
+   *   - version drift (another writer bumped the version) →
+   *     `EngineError(TRAVERSAL_CONFLICT)` (TraversalConflictError),
+   *     `recoveryKind: "retry"`. The skill re-reads and retries.
+   *
+   * Use `put` for first-time creation; this method assumes the caller
+   * loaded a prior record and rejects the resurrection case (per #163)
+   * — the missing-record throw still blocks the write, just under a
+   * code whose recovery shape matches the actual situation.
    *
    * The supplied `record.version` is ignored on input — the store
    * always writes `expectedVersion + 1`. Returns the record actually
@@ -89,7 +96,10 @@ class InMemoryStateStore implements StateStore {
   putIfVersion(record: TraversalRecord, expectedVersion: number): TraversalRecord {
     const current = this.records.get(record.id);
     if (!current) {
-      throw new TraversalConflictError(record.id, expectedVersion, 0);
+      throw new EngineError(
+        `Traversal "${record.id}" not found (deleted between read and write).`,
+        EC.TRAVERSAL_NOT_FOUND,
+      );
     }
     const currentVersion = current.version ?? 0;
     if (currentVersion !== expectedVersion) {
@@ -172,7 +182,10 @@ class JsonDirectoryStateStore implements StateStore {
     // detection via TRAVERSAL_CONFLICT beats silent loss.
     const existing = this.get(record.id);
     if (!existing) {
-      throw new TraversalConflictError(record.id, expectedVersion, 0);
+      throw new EngineError(
+        `Traversal "${record.id}" not found (deleted between read and write).`,
+        EC.TRAVERSAL_NOT_FOUND,
+      );
     }
     const current = existing.version ?? 0;
     if (current !== expectedVersion) {

--- a/test/envelope-contract.test.ts
+++ b/test/envelope-contract.test.ts
@@ -142,6 +142,17 @@ describe("CLI error envelope — wire-level contract", () => {
     assertEnvelope(result, "NO_TRAVERSAL");
   });
 
+  it("TRAVERSAL_NOT_FOUND — advance --traversal <unknown id>", () => {
+    // Distinct from NO_TRAVERSAL (none exist) and AMBIGUOUS_TRAVERSAL
+    // (multiple exist). recoveryKind: "clear" — skill drops the dead
+    // handle. Also covers the putIfVersion deleted-mid-flight path
+    // (#192) at the wire level: both produce the same code.
+    runCli(["start", "valid-simple"], tmpDir);
+    const result = runCli(["advance", "--traversal", "tr_deadbeef", "work-done"], tmpDir);
+    const envelope = assertEnvelope(result, "TRAVERSAL_NOT_FOUND");
+    expect(envelope.error.recoveryKind).toBe("clear");
+  });
+
   it("GRAPH_NOT_FOUND — freelance start <unknown-graph>", () => {
     const result = runCli(["start", "no-such-graph"], tmpDir);
     assertEnvelope(result, "GRAPH_NOT_FOUND");

--- a/test/traversal-store.test.ts
+++ b/test/traversal-store.test.ts
@@ -628,7 +628,7 @@ describe("TraversalStore — stateless JSON", () => {
     it.each([
       ["json", () => path.join(tmpDir, "resurrection-json")],
       [":memory:", () => ":memory:"],
-    ])("putIfVersion rejects resurrection of a deleted record (%s)", (_label, dirOrSentinel) => {
+    ])("putIfVersion rejects resurrection of a deleted record with TRAVERSAL_NOT_FOUND (%s)", (_label, dirOrSentinel) => {
       // Writer A loads, writer B deletes (e.g. `freelance reset
       // --confirm`), writer A's saveEngine fires putIfVersion.
       // Without the guard the write proceeds as a fresh create,
@@ -638,6 +638,11 @@ describe("TraversalStore — stateless JSON", () => {
       // `expectedVersion === 0` can legitimately come from a loaded
       // legacy record, so zero is not a safe "is this a create"
       // signal.
+      //
+      // The wire-level code is TRAVERSAL_NOT_FOUND (kind: clear), not
+      // TRAVERSAL_CONFLICT (kind: retry): the dead handle isn't
+      // recoverable by retrying, so the skill drops it instead of
+      // looping. See #192 for the rationale.
       const backend = openStateStore(dirOrSentinel());
       try {
         for (const expectedVersion of [5, 0]) {
@@ -653,10 +658,10 @@ describe("TraversalStore — stateless JSON", () => {
           };
           try {
             backend.putIfVersion(record, expectedVersion);
-            throw new Error("expected TRAVERSAL_CONFLICT, none thrown");
+            throw new Error("expected TRAVERSAL_NOT_FOUND, none thrown");
           } catch (e) {
             expect(e).toBeInstanceOf(EngineError);
-            expect((e as EngineError).code).toBe("TRAVERSAL_CONFLICT");
+            expect((e as EngineError).code).toBe("TRAVERSAL_NOT_FOUND");
           }
           expect(backend.get(record.id)).toBeUndefined();
         }


### PR DESCRIPTION
## Summary

- `StateStore.putIfVersion` (both backends) now distinguishes the deleted-record race (TRAVERSAL_NOT_FOUND, `kind: "clear"`) from the version-drift race (TRAVERSAL_CONFLICT, `kind: "retry"`). The interface comment documents both failure shapes.
- The #163 resurrection-rejection invariant is preserved — missing-record still rejects the write. Only the wire code changes from `retry` to `clear`, matching the operator's intent when they ran `reset --confirm`.
- `test/traversal-store.test.ts` resurrection-rejection assertion flipped from TRAVERSAL_CONFLICT to TRAVERSAL_NOT_FOUND. Test name updated.
- New wire-level case in `envelope-contract.test.ts` for TRAVERSAL_NOT_FOUND (`advance --traversal <unknown-id>`).

Closes #192.

## Why

Per `docs/decisions.md` § "Error envelope is the wire contract", `recoveryKind` is the classifier the skill branches on. Mis-categorizing a stale-state case (deleted record) as transient-retry made the skill loop one extra hop on a dead handle. Real race: writer A loads → operator runs `freelance reset <id> --confirm` → writer A's `saveEngine` fires `putIfVersion` against the deleted file. Same shape applies to `setMeta`.

## Test plan

- [x] `npm run build` — tsc clean
- [x] `npm test` — 823 pass, 3 todo
- [x] `npx biome check` — clean
- [x] Resurrection-rejection assertion now matches the wire shape (`TRAVERSAL_NOT_FOUND`, not `TRAVERSAL_CONFLICT`)
- [x] Wire-level `TRAVERSAL_NOT_FOUND` test asserts `recoveryKind: "clear"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)