### PR TITLE
refactor(setup): split memory setup, make resolveMemoryConfig pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`freelance memory reset --confirm` no longer leaves an empty
+  `memory/` directory behind (#197).** `resolveMemoryConfig` in
+  `src/cli/setup.ts` was a path resolver that performed `mkdirSync`
+  as a side effect on every config branch. The `memory reset` handler
+  deliberately bypasses `composeRuntime` (the recovery path for "old
+  memory.db schema is incompatible with the current build"), but
+  still went through `resolveMemoryConfig` — so reset-on-clean-repo
+  *created* the directory it had just unlinked. `resolveMemoryConfig`
+  is now pure; the parent-directory mkdir lives inside
+  `buildMemoryStore`'s lazy thunk in `src/compose.ts`, where opening
+  the SQLite handle happens anyway. Codified in `docs/decisions.md` §
+  "Memory directory creation lives in `buildMemoryStore`".
+
+### Changed
+
+- **Memory CLI verbs no longer parse every workflow yaml on startup
+  (#198).** `createMemoryStore` (`src/cli/setup.ts`) ran through
+  `loadGraphSetup` → `loadGraphsGraceful`, which walks every
+  `.workflow.yaml` under the resolved graphs directories and parses +
+  Zod-validates each one. Memory commands operate on a flat namespace
+  with no graph-id coupling, so they only need `graphsDirs +
+  sourceRoot + config`. New `loadMemorySetup` provides exactly that;
+  every `freelance memory <verb>` skips graph parsing. Cost reduction
+  scales with `graphsDirs × graphs per dir`. `loadGraphSetup` is now
+  a thin wrapper that adds graph parsing + `sourceOpts` on top of
+  `loadMemorySetup`, so config also threads through `CliSetup`,
+  killing a duplicate `loadConfigFromDirs` call in
+  `createTraversalStore`.
+
 - **Plugin SessionStart nudge no longer false-positives on Windows.**
   `plugins/freelance/hooks/nudge.mjs` probed the CLI with
   `execFileSync("freelance", ["--version"])`. On Windows npm installs

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -86,6 +86,16 @@ Two adjacent mitigations travel with the lazy open: (a) `PRAGMA busy_timeout = 5
 
 See issue [#138](https://github.com/duct-tape-and-markdown/freelance/issues/138).
 
+### Memory directory creation lives in `buildMemoryStore`, never in `resolveMemoryConfig`
+
+`resolveMemoryConfig` (in `src/cli/setup.ts`) is pure: it returns the resolved db path without touching the filesystem. The `mkdirSync` for the parent directory lives inside `buildMemoryStore`'s thunk in `src/compose.ts`, so the dir is created exactly when (and only when) the SQLite handle is about to open.
+
+Any CLI verb that needs to *resolve* a path without *opening* the db must be free to do so without leaving artifacts behind. The motivating case is `freelance memory reset`: the recovery path for "old memory.db schema is incompatible with the current build" deliberately bypasses `composeRuntime` and unlinks the files directly. Pre-fix, `resolveMemoryConfig` performed an `mkdirSync` as a side effect of every config branch, so `memory reset --confirm` on a clean repo *created* the very `memory/` directory it had just unlinked.
+
+**What would break if reversed:** any future helper added to `setup.ts` that calls `mkdirSync` to "make sure the path is ready" re-introduces the same bug class. The invariant is not "memory reset is special" — it's "path resolution is pure; I/O is `composeRuntime`'s budget."
+
+See issue [#197](https://github.com/duct-tape-and-markdown/freelance/issues/197).
+
 ### Sealed memory workflows are runtime-injected freelance primitives
 
 `memory:compile` and `memory:recall` live in code (`src/memory/sealed.ts` + `src/memory/recollection.ts` + `src/memory/workflow.ts`) and are merged into the loaded graphs map at runtime via `mergeSealedGraphs`. Validate / visualize / sources_validate special-case their ids via `extraAvailableIds` so user workflows can reference them as subgraphs without seeing "unknown graph" errors at load time.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -7,9 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Command, Option } from "commander";
-import { loadConfigFromDirs } from "../config.js";
 import { EC, EngineError } from "../errors.js";
-import { resolveGraphsDirs } from "../graph-resolution.js";
 import { INSPECT_FIELDS } from "../types.js";
 import { VERSION } from "../version.js";
 import { catalog } from "./catalog.js";
@@ -30,6 +28,7 @@ import {
   createMemoryStore,
   createTraversalStore,
   loadGraphSetup,
+  loadMemorySetup,
   resolveMemoryConfig,
 } from "./setup.js";
 import { distillRun, guideShow, sourcesCheck, sourcesHash, sourcesValidate } from "./stateless.js";
@@ -407,11 +406,9 @@ addWorkflowsOpt(
     .option("--dry-run", "Show what would be pruned without deleting")
     .option("--confirm", "Execute the prune (required unless --dry-run)"),
 ).action((opts) => {
-  const dirs = resolveGraphsDirs(opts.workflows);
-  const fileConfig = loadConfigFromDirs(dirs);
+  const { store, setup } = createMemoryStore({ workflows: opts.workflows });
   // CLI --keep concatenates on top of memory.prune.keep in config.
-  const mergedKeep = [...(fileConfig.memory.prune?.keep ?? []), ...(opts.keep ?? [])];
-  const { store } = createMemoryStore({ workflows: opts.workflows });
+  const mergedKeep = [...(setup.config.memory.prune?.keep ?? []), ...(opts.keep ?? [])];
   runCliHandler(store, () =>
     memoryPrune(store, { keep: mergedKeep, dryRun: opts.dryRun, confirm: opts.confirm }),
   );
@@ -430,9 +427,8 @@ addWorkflowsOpt(
   // resource to dispose, but the wrapper still carries its weight:
   // `CliExit` from the `--confirm` refusal and any `EngineError` from
   // the unlink loop both route through the standard exit plumbing.
-  const dirs = resolveGraphsDirs(opts.workflows);
-  const fileConfig = loadConfigFromDirs(dirs);
-  const memConfig = resolveMemoryConfig(dirs, {}, fileConfig);
+  const setup = loadMemorySetup({ workflows: opts.workflows });
+  const memConfig = resolveMemoryConfig(setup.graphsDirs, {}, setup.config);
   if (!memConfig) {
     outputJson({ status: "noop", reason: "memory disabled in config" });
     return;

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -94,18 +94,13 @@ export function resolveTraversalsDir(graphsDirs: string[]): string {
 
 // --- Memory config resolution ---
 
-function ensureMemoryDir(dir: string): string {
-  const resolved = path.resolve(dir);
-  if (!fs.existsSync(resolved)) {
-    fs.mkdirSync(resolved, { recursive: true });
-  }
-  return path.join(resolved, "memory.db");
-}
-
 /**
  * Resolve the effective memory configuration from (a) CLI flags, (b)
  * a pre-loaded or freshly-loaded FreelanceConfig, and (c) the default
  * location under the first graphs directory.
+ *
+ * Pure — no filesystem writes. See `docs/decisions.md` § "Memory
+ * directory creation lives in `buildMemoryStore`".
  *
  * Precedence:
  *   - `opts.memory === false` (CLI `--no-memory`) → memory off
@@ -113,7 +108,7 @@ function ensureMemoryDir(dir: string): string {
  *   - otherwise on, with db path from (CLI `--memory-dir` > config `memory.dir` > default)
  *
  * The default is `<graphsDir>/memory/memory.db`, under the first
- * existing graphs directory. The `memory/` subdir is created lazily.
+ * graphs directory.
  */
 export function resolveMemoryConfig(
   graphsDirs: string[],
@@ -126,19 +121,11 @@ export function resolveMemoryConfig(
 
   if (cfg.memory.enabled === false && opts.memory !== true) return null;
 
-  let dbPath: string;
-  if (opts.memoryDir) {
-    dbPath = ensureMemoryDir(opts.memoryDir);
-  } else if (cfg.memory.dir) {
-    dbPath = ensureMemoryDir(cfg.memory.dir);
-  } else {
-    const graphsDir = graphsDirs[0] ?? ".freelance";
-    dbPath = ensureMemoryDir(memoryDirFor(graphsDir));
-  }
+  const dir = opts.memoryDir ?? cfg.memory.dir ?? memoryDirFor(graphsDirs[0] ?? ".freelance");
 
   return {
     enabled: true,
-    db: dbPath,
+    db: path.join(path.resolve(dir), "memory.db"),
   };
 }
 
@@ -150,26 +137,41 @@ interface CliSetupOptions {
   sourceRoot?: string;
 }
 
-interface CliSetup {
-  graphs: Map<string, ValidatedGraph>;
+/**
+ * Memory verbs operate on a flat namespace with no graph-id coupling,
+ * so workflow yaml parsing is unnecessary work for every `freelance
+ * memory <verb>` invocation. `MemorySetup` is the lean half of
+ * `CliSetup` — same path resolution + config, minus the graph parse.
+ */
+export interface MemorySetup {
   graphsDirs: string[];
   sourceRoot: string | undefined;
+  config: FreelanceConfig;
+}
+
+interface CliSetup extends MemorySetup {
+  graphs: Map<string, ValidatedGraph>;
   sourceOpts: SourceOptions;
   /** Non-fatal per-file load failures from graphsDirs; empty when all files parsed + validated. */
   loadErrors: readonly LoadError[];
 }
 
+/** Resolve dirs, sourceRoot, and config without parsing any workflow yaml. */
+export function loadMemorySetup(opts: CliSetupOptions): MemorySetup {
+  const graphsDirs = resolveGraphsDirs(opts.workflows);
+  const sourceRoot = resolveSourceRoot(graphsDirs, opts.sourceRoot);
+  const config = loadConfigFromDirs(graphsDirs);
+  return { graphsDirs, sourceRoot, config };
+}
+
 /** Load graphs and resolve directories for CLI commands. */
 export function loadGraphSetup(opts: CliSetupOptions): CliSetup {
-  const graphsDirs = resolveGraphsDirs(opts.workflows);
-  const { graphs, errors: loadErrors } = loadGraphsGraceful(graphsDirs);
-  const sourceRoot = resolveSourceRoot(graphsDirs, opts.sourceRoot);
-  const sectionResolver = (filePath: string, section: string) => extractSection(filePath, section);
+  const base = loadMemorySetup(opts);
+  const { graphs, errors: loadErrors } = loadGraphsGraceful(base.graphsDirs);
   return {
+    ...base,
     graphs,
-    graphsDirs,
-    sourceRoot,
-    sourceOpts: { resolver: sectionResolver, basePath: sourceRoot },
+    sourceOpts: { resolver: extractSection, basePath: base.sourceRoot },
     loadErrors,
   };
 }
@@ -188,19 +190,18 @@ export function createTraversalStore(opts: CliSetupOptions): {
   const graphsDir = setup.graphsDirs[0] ?? ".freelance";
   ensureFreelanceDir(graphsDir);
   const traversalsDir = resolveTraversalsDir(setup.graphsDirs);
-  const fileConfig = loadConfigFromDirs(setup.graphsDirs);
-  const memConfig = resolveMemoryConfig(setup.graphsDirs, {}, fileConfig);
+  const memConfig = resolveMemoryConfig(setup.graphsDirs, {}, setup.config);
 
   const runtime = composeRuntime({
     graphsDir,
     graphs: setup.graphs,
     stateDir: traversalsDir,
     sourceRoot: setup.sourceRoot,
-    sectionResolver: (filePath, section) => extractSection(filePath, section),
+    sectionResolver: extractSection,
     memory: memConfig,
-    maxDepth: opts.maxDepth ?? fileConfig.maxDepth ?? 5,
-    hookTimeoutMs: fileConfig.hooks.timeoutMs,
-    contextCaps: resolveContextCaps(fileConfig.context),
+    maxDepth: opts.maxDepth ?? setup.config.maxDepth ?? 5,
+    hookTimeoutMs: setup.config.hooks.timeoutMs,
+    contextCaps: resolveContextCaps(setup.config.context),
     loadErrors: setup.loadErrors,
   });
 
@@ -208,10 +209,12 @@ export function createTraversalStore(opts: CliSetupOptions): {
 }
 
 /** Create a MemoryStore for CLI memory commands. */
-export function createMemoryStore(opts: CliSetupOptions): { store: MemoryStore; setup: CliSetup } {
-  const setup = loadGraphSetup(opts);
-  const config = loadConfigFromDirs(setup.graphsDirs);
-  const memConfig = resolveMemoryConfig(setup.graphsDirs, {}, config);
+export function createMemoryStore(opts: CliSetupOptions): {
+  store: MemoryStore;
+  setup: MemorySetup;
+} {
+  const setup = loadMemorySetup(opts);
+  const memConfig = resolveMemoryConfig(setup.graphsDirs, {}, setup.config);
   if (!memConfig) {
     throw new EngineError(
       "Memory is disabled. Enable it in config.yml or remove --no-memory.",

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -26,9 +26,13 @@ import { openStateStore, TraversalStore } from "./state/index.js";
 import type { LoadError, ValidatedGraph } from "./types.js";
 
 // Thunk form: defers the SQLite open until first memory access. See
-// `docs/decisions.md` § "Memory database opens lazily on first access".
+// `docs/decisions.md` § "Memory database opens lazily on first access"
+// and § "Memory directory creation lives in buildMemoryStore".
 export function buildMemoryStore(memConfig: MemoryConfig, sourceRoot: string): MemoryStore {
-  return new MemoryStore(() => openDatabase(memConfig.db), sourceRoot);
+  return new MemoryStore(() => {
+    fs.mkdirSync(path.dirname(memConfig.db), { recursive: true });
+    return openDatabase(memConfig.db);
+  }, sourceRoot);
 }
 
 export interface ComposeConfig {

--- a/test/cli-index.test.ts
+++ b/test/cli-index.test.ts
@@ -1,4 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FreelanceConfig } from "../src/config.js";
+
+// Typed against the real interface so a schema change breaks the
+// mock instead of letting it rot under structural-typing optionality.
+const STUB_CONFIG: FreelanceConfig = {
+  workflows: [],
+  memory: {},
+  hooks: {},
+  context: {},
+  sources: [],
+};
 
 // Mock heavy dependencies
 vi.mock("../src/cli/validate.js", () => ({ validate: vi.fn() }));
@@ -40,13 +51,20 @@ vi.mock("../src/cli/setup.js", () => ({
   })),
   createMemoryStore: vi.fn(() => ({
     store: { close: vi.fn() },
-    setup: { graphsDirs: [], sourceOpts: {} },
+    setup: { graphsDirs: [], sourceRoot: undefined, config: STUB_CONFIG },
   })),
   loadGraphSetup: vi.fn(() => ({
     graphs: new Map(),
     graphsDirs: [],
     sourceRoot: undefined,
     sourceOpts: {},
+    config: STUB_CONFIG,
+    loadErrors: [],
+  })),
+  loadMemorySetup: vi.fn(() => ({
+    graphsDirs: [],
+    sourceRoot: undefined,
+    config: STUB_CONFIG,
   })),
   ensureFreelanceDir: vi.fn((dir: string) => dir),
   resolveTraversalsDir: vi.fn(() => ":memory:"),

--- a/test/compose.test.ts
+++ b/test/compose.test.ts
@@ -161,10 +161,6 @@ describe("composeRuntime", () => {
   });
 
   it("builds a MemoryStore when memory is enabled", () => {
-    // openDatabase can create the .db file but not its parent dir —
-    // that's resolveMemoryConfig's job in the CLI path. Test mkdirs
-    // the parent directly to isolate composeRuntime.
-    fs.mkdirSync(path.join(tmpDir, "memory"), { recursive: true });
     const runtime = composeRuntime({
       graphs: emptyGraphs(),
       stateDir: ":memory:",
@@ -238,6 +234,19 @@ describe("buildMemoryStore", () => {
     const status = store.status();
     expect(status.total_propositions).toBe(0);
     expect(status.total_entities).toBe(0);
+    store.close();
+  });
+
+  it("creates the parent directory lazily on first db access", () => {
+    // Pins the invariant from decisions.md § "Memory directory creation
+    // lives in buildMemoryStore" — without this, a pure resolveMemoryConfig
+    // would have nowhere to mkdir, and openDatabase would fail.
+    const memDir = path.join(tmpDir, "nested", "memory");
+    expect(fs.existsSync(memDir)).toBe(false);
+    const store = buildMemoryStore({ enabled: true, db: path.join(memDir, "memory.db") }, tmpDir);
+    expect(fs.existsSync(memDir)).toBe(false);
+    store.status();
+    expect(fs.existsSync(memDir)).toBe(true);
     store.close();
   });
 });

--- a/test/config-integration.test.ts
+++ b/test/config-integration.test.ts
@@ -60,11 +60,6 @@ describe("plugin hook flow", () => {
     const memConfig = resolveMemoryConfig([freelanceDir], {});
     expect(memConfig).not.toBeNull();
     expect(memConfig!.db).toBe(path.join(persistentDir, "memory.db"));
-
-    // Cleanup created dir
-    if (fs.existsSync(persistentDir)) {
-      fs.rmSync(persistentDir, { recursive: true, force: true });
-    }
   });
 
   it("set-local workflows is idempotent across multiple hook runs", () => {
@@ -109,11 +104,18 @@ describe("config + memory resolution", () => {
     const memConfig = resolveMemoryConfig([freelanceDir], { memoryDir: cliDir });
     expect(memConfig).not.toBeNull();
     expect(memConfig!.db).toBe(path.join(cliDir, "memory.db"));
+  });
 
-    // Cleanup created dirs
-    for (const d of [configDir, cliDir]) {
-      if (fs.existsSync(d)) fs.rmSync(d, { recursive: true, force: true });
-    }
+  it("resolveMemoryConfig does not create the memory directory", () => {
+    // decisions.md § "Memory directory creation lives in buildMemoryStore"
+    const freelanceDir = makeDir("mem-pure-");
+    const memDir = path.join(freelanceDir, "memory");
+
+    expect(fs.existsSync(memDir)).toBe(false);
+    const memConfig = resolveMemoryConfig([freelanceDir], {});
+    expect(memConfig).not.toBeNull();
+    expect(memConfig!.db).toBe(path.join(memDir, "memory.db"));
+    expect(fs.existsSync(memDir)).toBe(false);
   });
 
   it("CLI --memory overrides config.yml memory.enabled=false", () => {


### PR DESCRIPTION
## Summary

Splits `src/cli/setup.ts` into pure path resolution + a lean memory setup, moves directory creation into `buildMemoryStore`'s thunk, and rewires the CLI memory verbs to share resolution + config. Closes #197, #198, #200.

- **#197** `resolveMemoryConfig` performed `mkdirSync` as a side effect of every config branch, so `freelance memory reset --confirm` on a clean repo *created* the `.freelance/memory/` directory it had just unlinked. The function is now pure; the parent-directory mkdir lives inside `buildMemoryStore`'s lazy thunk in `src/compose.ts`. New `docs/decisions.md` § "Memory directory creation lives in `buildMemoryStore`" codifies the invariant so the next refactor in this neighborhood doesn't re-introduce the bug class.
- **#198** Every `freelance memory <verb>` ran `loadGraphSetup` → `loadGraphsGraceful`, which parses + Zod-validates every `.workflow.yaml` under the resolved graph directories. Memory commands operate on a flat namespace with no graph-id coupling, so they only need `graphsDirs + sourceRoot + config`. New `loadMemorySetup` provides exactly that. `loadGraphSetup` is now a thin wrapper that adds graph parsing on top, so config also threads through `CliSetup` — killing a duplicate `loadConfigFromDirs` call in `createTraversalStore` and another pair in `program.ts`'s memory prune/reset handlers.
- **#200** Two identity-arrow wrappers around `extractSection` (`loadGraphSetup` and `createTraversalStore`) replaced with the function reference directly, matching the pattern already in `validate.ts`.

The `MemoryStore` thunk ($src/memory/store.ts$) memoizes the opened db, so the mkdir runs at most once per store instance. `mkdirSync(... { recursive: true })` is itself idempotent — no `existsSync` pre-check.

## Test plan

- [x] `npm run build` passes.
- [x] `npm test` — 828 tests pass (added 2: positive coverage for the no-mkdir contract on `resolveMemoryConfig` + lazy-mkdir on `buildMemoryStore`).
- [ ] Manual: in a clean repo, `freelance memory reset --confirm` reports `deleted: []` and leaves no `memory/` directory behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)