### PR TITLE
refactor(engine): bundle dedup + drop reason field (#209 #210 #211 #212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **`reason` field dropped from gate-block envelopes (#211).**
+  `AdvanceErrorResult` and `AdvanceErrorMinimalResult` no longer carry
+  `reason: string`. The field was a pre-#95 back-compat duplicate of
+  `error.message`, kept while the unified envelope shape stabilized.
+  The decisions log § "Error envelope is the wire contract" commits to
+  the post-#95 shape, so `reason` was dead wire weight on every blocked
+  advance. Read `error.message` instead.
+
 ### Fixed
 
 - **`freelance memory reset --confirm` no longer leaves an empty

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -33,7 +33,13 @@ import {
   checkWaitBlocking,
   type GateOptions,
 } from "./gates.js";
-import { buildAdvanceSuccessResult, cloneContext, keysSince, toNodeInfo } from "./helpers.js";
+import {
+  type AdvanceResponseMode,
+  buildAdvanceSuccessResult,
+  cloneContext,
+  keysSince,
+  toNodeInfo,
+} from "./helpers.js";
 import type { HookRunner, MetaCollector } from "./hooks.js";
 import { maybePushSubgraph, popSubgraph } from "./subgraph.js";
 import { evaluateTransitions } from "./transitions.js";
@@ -359,8 +365,10 @@ export class GraphEngine {
     await this.runHooksOnArrival(session, graph, options?.metaCollector);
 
     const { previousNode, edge, writesBefore, minimal, newNodeDef, isTerminal, isWait } = commit;
-    const contextDelta = minimal ? keysSince(session.contextHistory, writesBefore) : [];
     const validTransitions = evaluateTransitions(newNodeDef, session.context);
+    const mode: AdvanceResponseMode = minimal
+      ? { contextDelta: keysSince(session.contextHistory, writesBefore) }
+      : { node: newNodeDef, context: session.context, graphSources: def.sources };
 
     // Wait node arrival
     if (isWait && newNodeDef.waitOn) {
@@ -379,13 +387,7 @@ export class GraphEngine {
           ...(newNodeDef.timeout ? { timeout: newNodeDef.timeout } : {}),
           ...(timeoutAt ? { timeoutAt } : {}),
         },
-        minimal
-          ? { contextDelta }
-          : {
-              node: newNodeDef,
-              context: session.context,
-              graphSources: def.sources,
-            },
+        mode,
       );
     }
 
@@ -403,13 +405,7 @@ export class GraphEngine {
         validTransitions,
         ...(terminalHistory ? { traversalHistory: terminalHistory } : {}),
       },
-      minimal
-        ? { contextDelta }
-        : {
-            node: newNodeDef,
-            context: session.context,
-            graphSources: def.sources,
-          },
+      mode,
     );
 
     // Root terminal GC: clear the stack so TraversalStore.saveEngine
@@ -498,21 +494,15 @@ export class GraphEngine {
     };
     this.stack = [];
 
-    if (clearedStack.length > 1) {
-      return {
-        status: "reset",
-        previousGraph: prev.graphId,
-        previousNode: prev.node,
-        message: `Traversal stack cleared (${clearedStack.length} graphs). Call freelance_start to begin a new workflow.`,
-        clearedStack,
-      } satisfies ResetResult;
-    }
-
+    const isMulti = clearedStack.length > 1;
     return {
       status: "reset",
       previousGraph: prev.graphId,
       previousNode: prev.node,
-      message: "Traversal cleared. Call freelance_start to begin a new workflow.",
+      message: isMulti
+        ? `Traversal stack cleared (${clearedStack.length} graphs). Call freelance_start to begin a new workflow.`
+        : "Traversal cleared. Call freelance_start to begin a new workflow.",
+      ...(isMulti ? { clearedStack } : {}),
     } satisfies ResetResult;
   }
 

--- a/src/engine/gates.ts
+++ b/src/engine/gates.ts
@@ -1,5 +1,5 @@
 import type { GateBlockCode } from "../error-codes.js";
-import { evaluate } from "../evaluator.js";
+import { evaluatePredicate } from "../evaluator.js";
 import type {
   AdvanceErrorMinimalResult,
   AdvanceErrorResult,
@@ -100,13 +100,7 @@ export function checkValidations(
   if (!nodeDef.validations || nodeDef.validations.length === 0) return null;
 
   for (const v of nodeDef.validations) {
-    let result: boolean;
-    try {
-      result = evaluate(v.expr, session.context);
-    } catch {
-      result = false;
-    }
-    if (!result) {
+    if (!evaluatePredicate(v.expr, session.context)) {
       return makeAdvanceError(
         session,
         "VALIDATION_FAILED",
@@ -127,13 +121,7 @@ export function checkEdgeCondition(
   edgeLabel: string,
   opts: GateOptions,
 ): GateBlockResult | null {
-  let condMet: boolean;
-  try {
-    condMet = evaluate(edgeCondition, session.context);
-  } catch {
-    condMet = false;
-  }
-  if (condMet) return null;
+  if (evaluatePredicate(edgeCondition, session.context)) return null;
 
   return makeAdvanceError(
     session,

--- a/src/engine/helpers.ts
+++ b/src/engine/helpers.ts
@@ -113,10 +113,8 @@ export function buildAdvanceSuccessResult(
 }
 
 /**
- * Base fields every gate-block error response shares. `reason`
- * duplicates `error.message` for pre-#95 readers — see
- * `AdvanceErrorResult`'s docstring. Mirrors `BaseAdvanceFields` for
- * the success path.
+ * Base fields every gate-block error response shares. Mirrors
+ * `BaseAdvanceFields` for the success path.
  */
 export interface BaseAdvanceErrorFields {
   readonly code: GateBlockCode;
@@ -153,7 +151,6 @@ export function buildAdvanceErrorResult(
     isError: true as const,
     error: { code: base.code, message: base.message, kind: "blocked" as const },
     currentNode: base.currentNode,
-    reason: base.message,
     validTransitions: base.validTransitions,
   };
   if ("contextDelta" in mode) {

--- a/src/engine/subgraph.ts
+++ b/src/engine/subgraph.ts
@@ -1,5 +1,5 @@
 import { EC, EngineError } from "../errors.js";
-import { evaluate } from "../evaluator.js";
+import { evaluatePredicate } from "../evaluator.js";
 import { resolveContextDefaults } from "../loader.js";
 import type { NodeDefinition, SessionState, ValidatedGraph } from "../types.js";
 import { buildAdvanceSuccessResult, keysSince, mergeDelta } from "./helpers.js";
@@ -51,13 +51,7 @@ export async function maybePushSubgraph(args: PushSubgraphArgs): Promise<Subgrap
   const subgraph = newNodeDef.subgraph!;
 
   if (subgraph.condition) {
-    let condMet: boolean;
-    try {
-      condMet = evaluate(subgraph.condition, parentSession.context);
-    } catch {
-      condMet = false;
-    }
-    if (!condMet) {
+    if (!evaluatePredicate(subgraph.condition, parentSession.context)) {
       const parentGraph = graphs.get(parentSession.graphId);
       if (!parentGraph) {
         throw new EngineError(`Graph "${parentSession.graphId}" not found`, EC.GRAPH_NOT_FOUND);

--- a/src/engine/transitions.ts
+++ b/src/engine/transitions.ts
@@ -1,4 +1,4 @@
-import { evaluate } from "../evaluator.js";
+import { evaluatePredicate } from "../evaluator.js";
 import type { NodeDefinition, TransitionInfo } from "../types.js";
 
 export function evaluateTransitions(
@@ -22,11 +22,7 @@ export function evaluateTransitions(
     if (e.default) {
       conditionMet = false;
     } else if (e.condition) {
-      try {
-        conditionMet = evaluate(e.condition, context);
-      } catch {
-        conditionMet = false;
-      }
+      conditionMet = evaluatePredicate(e.condition, context);
     } else {
       conditionMet = true;
     }

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -506,3 +506,18 @@ export function evaluate(expr: string, context: Record<string, unknown>): boolea
   const parser = new Parser(tokens, context, expr);
   return parser.parse();
 }
+
+/**
+ * Predicate-site wrapper: any throw resolves to `false` so a malformed
+ * expression at runtime can't abort the advance. Use at gate checks,
+ * edge conditions, validation rules, and subgraph conditions — every
+ * site whose semantic contract is "no-pass on error". Validate-time
+ * enumeration that needs to surface a throw keeps using `evaluate`.
+ */
+export function evaluatePredicate(expr: string, context: Record<string, unknown>): boolean {
+  try {
+    return evaluate(expr, context);
+  } catch {
+    return false;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,10 +145,9 @@ export interface AdvanceSuccessMinimalResult {
  * so a skill sees one unified error format: `{ isError: true, error: {
  * code, message, kind } }`. Blocked responses add `status: "error"`,
  * `currentNode`, `validTransitions`, and `context` so the caller can
- * pick a different edge or fix context and retry. `reason` duplicates
- * `error.message` for back-compat with pre-#95 readers; new code should
- * read `error.message`. See `error-codes.ts` for the `kind`
- * discriminator and issue #95 for the unification rationale.
+ * pick a different edge or fix context and retry. See `error-codes.ts`
+ * for the `kind` discriminator and issue #95 for the unification
+ * rationale.
  */
 export interface AdvanceErrorResult {
   readonly status: "error";
@@ -159,7 +158,6 @@ export interface AdvanceErrorResult {
     readonly kind: "blocked";
   };
   readonly currentNode: string;
-  readonly reason: string;
   readonly validTransitions: readonly TransitionInfo[];
   readonly context: Readonly<Record<string, unknown>>;
   readonly graphSources?: readonly SourceBinding[];
@@ -167,12 +165,12 @@ export interface AdvanceErrorResult {
 
 /**
  * Lean gate-blocked shape — `responseMode: "minimal"` counterpart to
- * `AdvanceErrorResult`. Keeps `reason` and `validTransitions` (the
- * caller needs both to fix and retry) but drops the full `context`
- * echo. `contextDelta` is included for symmetry with the success shape
- * — empty on pure gate blocks (wait/validation/return-schema/edge
- * condition don't write), populated only when the caller's
- * contextUpdates applied before a gate failed.
+ * `AdvanceErrorResult`. Keeps `validTransitions` (the caller needs it
+ * to fix and retry) but drops the full `context` echo. `contextDelta`
+ * is included for symmetry with the success shape — empty on pure gate
+ * blocks (wait/validation/return-schema/edge condition don't write),
+ * populated only when the caller's contextUpdates applied before a
+ * gate failed.
  */
 export interface AdvanceErrorMinimalResult {
   readonly status: "error";
@@ -183,7 +181,6 @@ export interface AdvanceErrorMinimalResult {
     readonly kind: "blocked";
   };
   readonly currentNode: string;
-  readonly reason: string;
   readonly validTransitions: readonly TransitionInfo[];
   readonly contextDelta: readonly string[];
 }

--- a/test/cli-traversals.test.ts
+++ b/test/cli-traversals.test.ts
@@ -125,14 +125,12 @@ describe("traversalAdvance — unified error envelope on gate-block", () => {
         isError: true;
         status: string;
         error: { code: string; kind: string; message: string };
-        reason: string;
         validTransitions: unknown[];
       };
       expect(parsed.isError).toBe(true);
       expect(parsed.status).toBe("error");
       expect(parsed.error.code).toBe("EDGE_CONDITION_NOT_MET");
       expect(parsed.error.kind).toBe("blocked");
-      expect(parsed.error.message).toBe(parsed.reason);
       expect(parsed.validTransitions).toBeDefined();
       expect(exitSpy).toHaveBeenCalledWith(2); // EXIT.BLOCKED
     } finally {
@@ -601,7 +599,7 @@ describe("--minimal response projection (issue #81)", () => {
     }
   });
 
-  it("--minimal on a blocked advance keeps reason + validTransitions, drops context", async () => {
+  it("--minimal on a blocked advance keeps error + validTransitions, drops context", async () => {
     // valid-branching's choose-path decision has conditional-only edges;
     // without context.path set, every edge's condition evaluates false
     // and `advance go-left` fires checkEdgeCondition as a gate block.
@@ -621,7 +619,7 @@ describe("--minimal response projection (issue #81)", () => {
       ).rejects.toThrow("process.exit");
       const parsed = stdoutJson() as Record<string, unknown>;
       expect(parsed.isError).toBe(true);
-      expect(parsed).toHaveProperty("reason");
+      expect(parsed).toHaveProperty("error");
       expect(parsed).toHaveProperty("validTransitions");
       expect(parsed).toHaveProperty("contextDelta");
       expect(parsed).not.toHaveProperty("context");

--- a/test/engine-minimal-response.test.ts
+++ b/test/engine-minimal-response.test.ts
@@ -103,7 +103,7 @@ describe("advance({ responseMode: 'minimal' }) — success shape", () => {
 });
 
 describe("advance({ responseMode: 'minimal' }) — gate-blocked shape", () => {
-  it("omits context, keeps reason + validTransitions + contextDelta", async () => {
+  it("omits context, keeps error.message + validTransitions + contextDelta", async () => {
     const engine = makeEngine("valid-simple.workflow.yaml");
     await engine.start("valid-simple");
     await engine.advance("work-done"); // at gate; taskStarted still false
@@ -113,7 +113,7 @@ describe("advance({ responseMode: 'minimal' }) — gate-blocked shape", () => {
     if (!r.isError) return;
 
     expect(r.status).toBe("error");
-    expect(r.reason).toContain("Task must be started");
+    expect(r.error.message).toContain("Task must be started");
     expect(r.currentNode).toBe("review");
     expect(r.validTransitions).toBeDefined();
     // Caller-side write landed before the gate tripped — surface it.
@@ -140,8 +140,6 @@ describe("advance({ responseMode: 'minimal' }) — gate-blocked shape", () => {
       message: expect.stringContaining("Task must be started"),
       kind: "blocked",
     });
-    // reason is retained as a back-compat mirror of error.message.
-    expect(r.reason).toBe(r.error.message);
   });
 
   it("blocked minimal with no caller writes has empty contextDelta", async () => {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -137,7 +137,7 @@ describe("advance() — context updates persist on failure", () => {
     const result = await engine.advance("approved", { someKey: "persisted" });
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("Task must be started");
+      expect(result.error.message).toContain("Task must be started");
       expect(result.context.someKey).toBe("persisted");
     }
   });
@@ -172,7 +172,7 @@ describe("advance() — gate enforcement", () => {
     const result = await engine.advance("approved");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("Task must be started");
+      expect(result.error.message).toContain("Task must be started");
       expect(result.currentNode).toBe("review");
     }
   });
@@ -216,7 +216,7 @@ describe("advance() — conditional edges", () => {
     const result = await engine.advance("go-right");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("condition not met");
+      expect(result.error.message).toContain("condition not met");
     }
   });
 });
@@ -232,7 +232,6 @@ describe("advance() — unified error envelope", () => {
     if (result.isError) {
       expect(result.error.code).toBe("VALIDATION_FAILED");
       expect(result.error.kind).toBe("blocked");
-      expect(result.error.message).toBe(result.reason);
     }
   });
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -142,14 +142,14 @@ describe("Data pipeline — gate enforcement", () => {
     const fail1 = await engine.advance("verified");
     expect(fail1.isError).toBe(true);
     if (fail1.isError) {
-      expect(fail1.reason).toContain("verification failed");
+      expect(fail1.error.message).toContain("verification failed");
     }
 
     engine.contextSet({ verificationPassed: true });
     const fail2 = await engine.advance("verified");
     expect(fail2.isError).toBe(true);
     if (fail2.isError) {
-      expect(fail2.reason).toContain("Quality score");
+      expect(fail2.error.message).toContain("Quality score");
     }
 
     engine.contextSet({ qualityScore: 85 });
@@ -318,7 +318,7 @@ describe("Change request — gate failure and recovery loop", () => {
     const fail = await engine.advance("pass");
     expect(fail.isError).toBe(true);
     if (fail.isError) {
-      expect(fail.reason).toContain("Tests must pass");
+      expect(fail.error.message).toContain("Tests must pass");
     }
 
     // Fix the issue and pass the gate.
@@ -373,7 +373,7 @@ describe("Change request — validation blocks missing target branch", () => {
     const fail = await engine.advance("ready");
     expect(fail.isError).toBe(true);
     if (fail.isError) {
-      expect(fail.reason).toContain("Target branch must be set");
+      expect(fail.error.message).toContain("Target branch must be set");
     }
   });
 });

--- a/test/returns.test.ts
+++ b/test/returns.test.ts
@@ -23,8 +23,8 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("done");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("Return schema violation");
-      expect(result.reason).toContain("filesChanged");
+      expect(result.error.message).toContain("Return schema violation");
+      expect(result.error.message).toContain("filesChanged");
       expect(result.error.code).toBe("RETURN_SCHEMA_VIOLATION");
       expect(result.error.kind).toBe("blocked");
     }
@@ -41,9 +41,9 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("done");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("filesChanged");
-      expect(result.reason).toContain("array");
-      expect(result.reason).toContain("string");
+      expect(result.error.message).toContain("filesChanged");
+      expect(result.error.message).toContain("array");
+      expect(result.error.message).toContain("string");
     }
   });
 
@@ -58,9 +58,9 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("done");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("filesChanged");
-      expect(result.reason).toContain("item [1]");
-      expect(result.reason).toContain("string");
+      expect(result.error.message).toContain("filesChanged");
+      expect(result.error.message).toContain("item [1]");
+      expect(result.error.message).toContain("string");
     }
   });
 
@@ -76,8 +76,8 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("done");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("scopeNotes");
-      expect(result.reason).toContain("string");
+      expect(result.error.message).toContain("scopeNotes");
+      expect(result.error.message).toContain("string");
     }
   });
 
@@ -138,10 +138,10 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("approved");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("Return schema violation");
-      expect(result.reason).toContain("reviewPassed");
+      expect(result.error.message).toContain("Return schema violation");
+      expect(result.error.message).toContain("reviewPassed");
       // Should NOT mention the expression validation
-      expect(result.reason).not.toContain("Tests must be written");
+      expect(result.error.message).not.toContain("Tests must be written");
     }
   });
 
@@ -168,8 +168,8 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("done");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("metrics");
-      expect(result.reason).toContain("object");
+      expect(result.error.message).toContain("metrics");
+      expect(result.error.message).toContain("object");
     }
   });
 
@@ -184,7 +184,7 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("done");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("filesChanged");
+      expect(result.error.message).toContain("filesChanged");
     }
   });
 
@@ -205,8 +205,8 @@ describe("return schema — engine validation", () => {
     const result = await engine.advance("approved");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("reviewComments");
-      expect(result.reason).toContain("item [1]");
+      expect(result.error.message).toContain("reviewComments");
+      expect(result.error.message).toContain("item [1]");
     }
   });
 });

--- a/test/wait.test.ts
+++ b/test/wait.test.ts
@@ -65,8 +65,8 @@ describe("wait nodes — blocking advance", () => {
     const result = await engine.advance("proceed");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("Waiting for external signals");
-      expect(result.reason).toContain("approved");
+      expect(result.error.message).toContain("Waiting for external signals");
+      expect(result.error.message).toContain("approved");
       expect(result.error.code).toBe("WAIT_BLOCKING");
       expect(result.error.kind).toBe("blocked");
     }
@@ -83,7 +83,7 @@ describe("wait nodes — blocking advance", () => {
     const result = await engine.advance("ready");
     expect(result.isError).toBe(true);
     if (result.isError) {
-      expect(result.reason).toContain("coverageReport");
+      expect(result.error.message).toContain("coverageReport");
     }
   });
 


### PR DESCRIPTION
## Summary

Bundle of four engine-slice dedup refactors. All called out by `/simplify` over the last two days; bundling because they touch overlapping files (`engine.ts`, `helpers.ts`, `types.ts`) and three of them are mechanical.

- **#209** — `evaluatePredicate(expr, ctx)` helper in `src/evaluator.ts`. Collapses the `try { evaluate } catch { false }` swallow pattern at four sites: `transitions.ts:23-29`, `gates.ts:102-108`, `gates.ts:130-135`, `subgraph.ts:53-59`. One audit point for the "malformed-expression-resolves-to-false" policy.
- **#210** — Hoist the wait-vs-standard response-mode discriminator in `runArrivalHooks` (`engine.ts`). Reuses `AdvanceResponseMode` already exported from `helpers.ts`. Drift class shared with #195.
- **#211** — Drop `reason` from `AdvanceErrorResult` / `AdvanceErrorMinimalResult` (`types.ts`) and from `buildAdvanceErrorResult` (`helpers.ts`). Pre-#95 back-compat duplicate of `error.message` per the field's existing docstring; the wire contract is committed (decisions.md § "Error envelope is the wire contract"). **Breaking change** for any external consumer reading `result.reason` — user declined back-compat scaffolding. ~14 test files migrated to `result.error.message`; the equivalence assertions (`expect(result.error.message).toBe(result.reason)`) were deleted as no longer meaningful.
- **#212** — Collapse the single-graph and multi-graph return branches in `GraphEngine.reset()` (`engine.ts`) into one with conditional spread on `clearedStack` and ternary on message. Empty-stack branch stays separate.

CHANGELOG entry added under `Removed` for #211.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 828 passed, 2 todo, 43 files
- [x] `/simplify` (3 reviewers in parallel) returned clean — single false-positive efficiency flag on #210 dismissed (only one branch executes per call, no extra allocation)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)