### PR TITLE
refactor(engine): dedup round 2 — snapshot, predicates, validators (#193 #194 #195 #196)

### DIFF
--- a/src/engine/builtin-hooks.ts
+++ b/src/engine/builtin-hooks.ts
@@ -27,68 +27,60 @@ function requireMemory(ctx: HookContext, opName: string): HookMemoryAccess {
   return ctx.memory;
 }
 
-function optionalString(args: Record<string, unknown>, key: string): string | undefined {
+type Guard<T> = (v: unknown) => v is T;
+
+const isString: Guard<string> = (v): v is string => typeof v === "string";
+const isNonEmptyString: Guard<string> = (v): v is string => typeof v === "string" && v.length > 0;
+const isInt: Guard<number> = (v): v is number =>
+  typeof v === "number" && Number.isFinite(v) && Number.isInteger(v);
+const isBool: Guard<boolean> = (v): v is boolean => typeof v === "boolean";
+const isShape: Guard<PropositionShape> = (v): v is PropositionShape =>
+  v === "minimal" || v === "full";
+
+/**
+ * Reads `args[key]`. `null`/`undefined` returns undefined; anything
+ * else must satisfy `guard` or throws with a uniform message. `desc`
+ * fills the "must be ${desc}" slot — caller chooses the wording.
+ *
+ * Note: the optional-shape's "or null" wording lives at the call site
+ * because nullability is per-helper convention, not part of the guard.
+ */
+function optional<T>(
+  args: Record<string, unknown>,
+  key: string,
+  guard: Guard<T>,
+  desc: string,
+): T | undefined {
   const v = args[key];
   if (v === undefined || v === null) return undefined;
-  if (typeof v !== "string") {
+  if (!guard(v)) {
     throw new TypeError(
-      `Hook arg "${key}" must be a string or null; got ${typeof v} (${JSON.stringify(v)})`,
-    );
-  }
-  return v;
-}
-
-function optionalInt(args: Record<string, unknown>, key: string): number | undefined {
-  const v = args[key];
-  if (v === undefined || v === null) return undefined;
-  if (typeof v !== "number" || !Number.isFinite(v) || !Number.isInteger(v)) {
-    throw new TypeError(
-      `Hook arg "${key}" must be an integer; got ${typeof v} (${JSON.stringify(v)})`,
-    );
-  }
-  return v;
-}
-
-function optionalBool(args: Record<string, unknown>, key: string): boolean | undefined {
-  const v = args[key];
-  if (v === undefined || v === null) return undefined;
-  if (typeof v !== "boolean") {
-    throw new TypeError(
-      `Hook arg "${key}" must be a boolean; got ${typeof v} (${JSON.stringify(v)})`,
-    );
-  }
-  return v;
-}
-
-function requireString(args: Record<string, unknown>, key: string): string {
-  const v = args[key];
-  if (typeof v !== "string" || v.length === 0) {
-    throw new TypeError(
-      `Hook arg "${key}" is required and must be a non-empty string; got ${typeof v} (${JSON.stringify(v)})`,
+      `Hook arg "${key}" must be ${desc}; got ${typeof v} (${JSON.stringify(v)})`,
     );
   }
   return v;
 }
 
 /**
- * Parse `shape` hook arg to the store's `PropositionShape` union.
- *
- * Hooks default to `"minimal"` — the warm-path delta-check use case only
- * needs claim text, and the full PropositionInfo payload (per-file
- * hashes, mtimes, validity flags, source arrays, `created_at`) was
- * blowing `freelance advance` responses past 50 KB on multi-file
- * on-enter hooks (see issue #87). Callers that genuinely need
- * provenance can pass `shape: "full"` explicitly.
+ * Reads `args[key]` and asserts it satisfies `guard` (covering
+ * missing/null/wrong-type in one branch). `desc` fills the "must be
+ * ${desc}" slot.
  */
-function optionalShape(args: Record<string, unknown>, key: string): PropositionShape | undefined {
+function required<T>(args: Record<string, unknown>, key: string, guard: Guard<T>, desc: string): T {
   const v = args[key];
-  if (v === undefined || v === null) return undefined;
-  if (v === "minimal" || v === "full") return v;
-  throw new TypeError(
-    `Hook arg "${key}" must be "minimal" or "full"; got ${typeof v} (${JSON.stringify(v)})`,
-  );
+  if (!guard(v)) {
+    throw new TypeError(
+      `Hook arg "${key}" is required and must be ${desc}; got ${typeof v} (${JSON.stringify(v)})`,
+    );
+  }
+  return v;
 }
 
+/**
+ * `paths: string[]` — bespoke because element-level validation isn't
+ * captured by a single guard; building an `arrayOf(guard)` factory for
+ * one call site would be more scaffold than the inline check.
+ */
 function requireStringArray(args: Record<string, unknown>, key: string): string[] {
   const v = args[key];
   if (!Array.isArray(v)) {
@@ -115,45 +107,49 @@ const memoryBrowse: HookFn = async (ctx) => {
   const memory = requireMemory(ctx, "memory_browse");
   return {
     ...memory.browse({
-      name: optionalString(ctx.args, "name"),
-      kind: optionalString(ctx.args, "kind"),
-      limit: optionalInt(ctx.args, "limit"),
-      offset: optionalInt(ctx.args, "offset"),
-      includeOrphans: optionalBool(ctx.args, "includeOrphans"),
+      name: optional(ctx.args, "name", isString, "a string or null"),
+      kind: optional(ctx.args, "kind", isString, "a string or null"),
+      limit: optional(ctx.args, "limit", isInt, "an integer"),
+      offset: optional(ctx.args, "offset", isInt, "an integer"),
+      includeOrphans: optional(ctx.args, "includeOrphans", isBool, "a boolean"),
     }),
   };
 };
 
 const memorySearch: HookFn = async (ctx) => {
   const memory = requireMemory(ctx, "memory_search");
-  const query = requireString(ctx.args, "query");
+  const query = required(ctx.args, "query", isNonEmptyString, "a non-empty string");
   return {
     ...memory.search(query, {
-      limit: optionalInt(ctx.args, "limit"),
+      limit: optional(ctx.args, "limit", isInt, "an integer"),
     }),
   };
 };
 
 const memoryRelated: HookFn = async (ctx) => {
   const memory = requireMemory(ctx, "memory_related");
-  const entity = requireString(ctx.args, "entity");
+  const entity = required(ctx.args, "entity", isNonEmptyString, "a non-empty string");
   return {
     ...memory.related(entity, {
-      limit: optionalInt(ctx.args, "limit"),
-      offset: optionalInt(ctx.args, "offset"),
+      limit: optional(ctx.args, "limit", isInt, "an integer"),
+      offset: optional(ctx.args, "offset", isInt, "an integer"),
     }),
   };
 };
 
+// `shape` defaults to `"minimal"` in hooks: the warm-path delta-check
+// only needs claim text, and the full PropositionInfo payload (per-file
+// hashes, validity flags, source arrays, `created_at`) blew `freelance
+// advance` responses past 50 KB on multi-file on-enter hooks (see #87).
+// Callers that genuinely need provenance pass `shape: "full"` explicitly.
 const memoryInspect: HookFn = async (ctx) => {
   const memory = requireMemory(ctx, "memory_inspect");
-  const entity = requireString(ctx.args, "entity");
-  // `shape` defaults to `"minimal"` in hooks — see optionalShape for why.
+  const entity = required(ctx.args, "entity", isNonEmptyString, "a non-empty string");
   return {
     ...memory.inspect(entity, {
-      limit: optionalInt(ctx.args, "limit"),
-      offset: optionalInt(ctx.args, "offset"),
-      shape: optionalShape(ctx.args, "shape") ?? "minimal",
+      limit: optional(ctx.args, "limit", isInt, "an integer"),
+      offset: optional(ctx.args, "offset", isInt, "an integer"),
+      shape: optional(ctx.args, "shape", isShape, '"minimal" or "full"') ?? "minimal",
     }),
   };
 };
@@ -181,7 +177,7 @@ const memoryBySource: HookFn = async (ctx) => {
   const memory = requireMemory(ctx, "memory_by_source");
   const paths = requireStringArray(ctx.args, "paths");
   const capped = paths.slice(0, MAX_BY_SOURCE_PATHS);
-  const perPathLimit = optionalInt(ctx.args, "limit");
+  const perPathLimit = optional(ctx.args, "limit", isInt, "an integer");
   const priorKnowledgeByPath: Record<string, PriorKnowledgeEntry[]> = {};
   for (const p of capped) {
     // Always ask the store for the minimal shape — the wire contract

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -35,6 +35,9 @@ import {
 } from "./gates.js";
 import {
   type AdvanceResponseMode,
+  type AdvanceSnapshot,
+  type AdvanceSnapshotMode,
+  buildAdvanceSnapshot,
   buildAdvanceSuccessResult,
   cloneContext,
   keysSince,
@@ -507,44 +510,34 @@ export class GraphEngine {
   }
 
   /**
-   * Build the envelope-sibling snapshot (`currentNode`,
-   * `validTransitions`, `context` / `contextDelta`) that the CLI
-   * attaches to a post-transition hook-throw. Mirrors the gate-block
-   * shape so HOOK_FAILED surfaces the same recover-or-stop fields
-   * the caller sees on any other advance error. Returns `null` when
-   * no session is active (the throw happened before any transition
-   * committed — unusual; the CLI falls back to the bare envelope).
+   * Build the envelope-sibling snapshot the CLI attaches to a
+   * post-transition hook-throw. Delegates shape to `buildAdvanceSnapshot`
+   * so HOOK_FAILED surfaces the same recover-or-stop fields any
+   * gate-block response carries. Returns `null` when no session is
+   * active (the throw happened before any transition committed —
+   * unusual; the CLI falls back to the bare envelope).
    *
    * `writesBefore` narrows `contextDelta` on `--minimal` responses;
    * when omitted, `contextDelta` is empty and `context` is the full
    * snapshot.
    */
-  captureHookFailureEnvelope(opts?: { minimal?: boolean; writesBefore?: number }): {
-    currentNode: string;
-    validTransitions: readonly import("../types.js").TransitionInfo[];
-    context?: Readonly<Record<string, unknown>>;
-    contextDelta?: readonly string[];
-  } | null {
+  captureHookFailureEnvelope(opts?: {
+    minimal?: boolean;
+    writesBefore?: number;
+  }): AdvanceSnapshot | null {
     if (this.stack.length === 0) return null;
     const session = this.activeSession();
     const def = this.currentGraphDef();
     const nodeDef = def.nodes[session.currentNode];
-    const validTransitions = evaluateTransitions(nodeDef, session.context);
-    if (opts?.minimal) {
-      return {
-        currentNode: session.currentNode,
-        validTransitions,
-        contextDelta:
-          opts.writesBefore !== undefined
-            ? keysSince(session.contextHistory, opts.writesBefore)
-            : [],
-      };
-    }
-    return {
-      currentNode: session.currentNode,
-      validTransitions,
-      context: cloneContext(session.context),
-    };
+    const mode: AdvanceSnapshotMode = opts?.minimal
+      ? {
+          contextDelta:
+            opts.writesBefore !== undefined
+              ? keysSince(session.contextHistory, opts.writesBefore)
+              : [],
+        }
+      : { full: true };
+    return buildAdvanceSnapshot(session, nodeDef, mode);
   }
 
   // --- Serialization (for persistence) ---

--- a/src/engine/gates.ts
+++ b/src/engine/gates.ts
@@ -7,9 +7,8 @@ import type {
   SessionState,
   SourceBinding,
 } from "../types.js";
-import { buildAdvanceErrorResult } from "./helpers.js";
+import { buildAdvanceSnapshot } from "./helpers.js";
 import { validateReturnSchema } from "./returns.js";
-import { evaluateTransitions } from "./transitions.js";
 import { checkWaitTimeout, evaluateWaitConditions } from "./wait.js";
 
 export type GateBlockResult = AdvanceErrorResult | AdvanceErrorMinimalResult;
@@ -22,9 +21,11 @@ export interface GateOptions {
 }
 
 /**
- * Build the unified in-band gate-block envelope. Computes
- * `validTransitions` once (every gate checker would otherwise duplicate
- * it) and delegates shape assembly to `buildAdvanceErrorResult`.
+ * Build the unified in-band gate-block envelope. The shared
+ * `{currentNode, validTransitions, context | contextDelta}` snapshot
+ * comes from `buildAdvanceSnapshot` so the same shape ships on
+ * post-transition hook throws (see `captureHookFailureEnvelope`); only
+ * the error envelope and optional `graphSources` are layered here.
  */
 function makeAdvanceError(
   session: SessionState,
@@ -33,17 +34,21 @@ function makeAdvanceError(
   nodeDef: NodeDefinition,
   opts: GateOptions,
 ): GateBlockResult {
-  return buildAdvanceErrorResult(
-    {
-      code,
-      message,
-      currentNode: session.currentNode,
-      validTransitions: evaluateTransitions(nodeDef, session.context),
-    },
-    opts.minimal
-      ? { contextDelta: opts.contextDelta }
-      : { context: session.context, graphSources: opts.graphSources },
+  const snapshot = buildAdvanceSnapshot(
+    session,
+    nodeDef,
+    opts.minimal ? { contextDelta: opts.contextDelta } : { full: true },
   );
+  const envelope = {
+    status: "error" as const,
+    isError: true as const,
+    error: { code, message, kind: "blocked" as const },
+    ...snapshot,
+  };
+  if ("context" in snapshot && opts.graphSources?.length) {
+    return { ...envelope, graphSources: opts.graphSources };
+  }
+  return envelope;
 }
 
 /** Returns a gate-block result if wait conditions block advancement, null otherwise. */

--- a/src/engine/helpers.ts
+++ b/src/engine/helpers.ts
@@ -1,16 +1,15 @@
-import type { GateBlockCode } from "../error-codes.js";
 import type {
-  AdvanceErrorMinimalResult,
-  AdvanceErrorResult,
   AdvanceSuccessMinimalResult,
   AdvanceSuccessResult,
   NodeDefinition,
   NodeInfo,
+  SessionState,
   SourceBinding,
   SubgraphPushedInfo,
   TransitionInfo,
   WaitCondition,
 } from "../types.js";
+import { evaluateTransitions } from "./transitions.js";
 
 export function cloneContext(ctx: Record<string, unknown>): Record<string, unknown> {
   return structuredClone(ctx);
@@ -113,52 +112,56 @@ export function buildAdvanceSuccessResult(
 }
 
 /**
- * Base fields every gate-block error response shares. Mirrors
- * `BaseAdvanceFields` for the success path.
+ * Mode discriminator for `buildAdvanceSnapshot`. Mirrors the
+ * success-side `AdvanceResponseMode`: minimal passes a pre-computed
+ * `contextDelta`, full requests a fresh clone of `session.context`.
  */
-export interface BaseAdvanceErrorFields {
-  readonly code: GateBlockCode;
-  readonly message: string;
-  readonly currentNode: string;
-  readonly validTransitions: readonly TransitionInfo[];
-}
+export type AdvanceSnapshotMode =
+  | { readonly contextDelta: readonly string[] }
+  | { readonly full: true };
 
 /**
- * Shape-discriminated: minimal passes `contextDelta`; full passes
- * `context` (+ optional `graphSources`). Same discriminator pattern
- * as `AdvanceResponseMode` for the success path.
+ * Shared advance-failure snapshot fields — `currentNode`,
+ * `validTransitions`, and `context | contextDelta`. The bundle a
+ * skill needs to recover from any advance failure (gate-block or
+ * post-transition hook throw).
  */
-export type AdvanceErrorResponseMode =
-  | { readonly contextDelta: readonly string[] }
+export type AdvanceSnapshot =
   | {
-      readonly context: Record<string, unknown>;
-      readonly graphSources?: readonly SourceBinding[];
+      readonly currentNode: string;
+      readonly validTransitions: readonly TransitionInfo[];
+      readonly contextDelta: readonly string[];
+    }
+  | {
+      readonly currentNode: string;
+      readonly validTransitions: readonly TransitionInfo[];
+      readonly context: Readonly<Record<string, unknown>>;
     };
 
 /**
- * Error-side twin of `buildAdvanceSuccessResult`. Gate-block
- * responses match the thrown-error envelope (`isError: true` + `error:
- * { code, message, kind }`) so the CLI writes one wire format for
- * every advance failure — see issue #95 + `AdvanceErrorResult`'s
- * docstring.
+ * Single source for the advance-failure snapshot. Owned here so
+ * gate-block builders (`makeAdvanceError`) and hook-throw envelope
+ * attachment (`captureHookFailureEnvelope`) emit the same shape — a
+ * future field on the recover-or-stop bundle lands on both paths.
+ * Computes `validTransitions` once against the post-transition node;
+ * skills read it on every advance failure to pick the next move.
  */
-export function buildAdvanceErrorResult(
-  base: BaseAdvanceErrorFields,
-  mode: AdvanceErrorResponseMode,
-): AdvanceErrorResult | AdvanceErrorMinimalResult {
-  const envelope = {
-    status: "error" as const,
-    isError: true as const,
-    error: { code: base.code, message: base.message, kind: "blocked" as const },
-    currentNode: base.currentNode,
-    validTransitions: base.validTransitions,
-  };
+export function buildAdvanceSnapshot(
+  session: SessionState,
+  nodeDef: NodeDefinition,
+  mode: AdvanceSnapshotMode,
+): AdvanceSnapshot {
+  const validTransitions = evaluateTransitions(nodeDef, session.context);
   if ("contextDelta" in mode) {
-    return { ...envelope, contextDelta: mode.contextDelta };
+    return {
+      currentNode: session.currentNode,
+      validTransitions,
+      contextDelta: mode.contextDelta,
+    };
   }
   return {
-    ...envelope,
-    context: cloneContext(mode.context),
-    ...(mode.graphSources?.length ? { graphSources: mode.graphSources } : {}),
+    currentNode: session.currentNode,
+    validTransitions,
+    context: cloneContext(session.context),
   };
 }

--- a/src/engine/returns.ts
+++ b/src/engine/returns.ts
@@ -22,6 +22,20 @@ function actualType(value: unknown): string {
   return typeof value;
 }
 
+function validateField(key: string, field: ReturnField, value: unknown): string | null {
+  if (!checkType(value, field.type)) {
+    return `key "${key}" expected type "${field.type}" but got "${actualType(value)}"`;
+  }
+  if (field.type === "array" && field.items && Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (!checkType(value[i], field.items)) {
+        return `key "${key}" array item [${i}] expected type "${field.items}" but got "${actualType(value[i])}"`;
+      }
+    }
+  }
+  return null;
+}
+
 export function validateReturnSchema(
   returns: NonNullable<NodeDefinition["returns"]>,
   context: Record<string, unknown>,
@@ -31,34 +45,16 @@ export function validateReturnSchema(
       if (!(key in context) || context[key] === undefined) {
         return `required key "${key}" (type: ${field.type}) is missing from context`;
       }
-      const value = context[key];
-      if (!checkType(value, field.type)) {
-        return `key "${key}" expected type "${field.type}" but got "${actualType(value)}"`;
-      }
-      if (field.type === "array" && field.items && Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          if (!checkType(value[i], field.items)) {
-            return `key "${key}" array item [${i}] expected type "${field.items}" but got "${actualType(value[i])}"`;
-          }
-        }
-      }
+      const violation = validateField(key, field, context[key]);
+      if (violation) return violation;
     }
   }
 
   if (returns.optional) {
     for (const [key, field] of Object.entries(returns.optional)) {
       if (!(key in context) || context[key] === undefined) continue;
-      const value = context[key];
-      if (!checkType(value, field.type)) {
-        return `key "${key}" expected type "${field.type}" but got "${actualType(value)}"`;
-      }
-      if (field.type === "array" && field.items && Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
-          if (!checkType(value[i], field.items)) {
-            return `key "${key}" array item [${i}] expected type "${field.items}" but got "${actualType(value[i])}"`;
-          }
-        }
-      }
+      const violation = validateField(key, field, context[key]);
+      if (violation) return violation;
     }
   }
 

--- a/src/engine/transitions.ts
+++ b/src/engine/transitions.ts
@@ -38,10 +38,7 @@ export function evaluateTransitions(
     };
   });
 
-  const anyConditionalMet = results.some(
-    (r) =>
-      !r.isDefault && r.conditionMet && node.edges!.find((e) => e.label === r.label)?.condition,
-  );
+  const anyConditionalMet = results.some((r) => !r.isDefault && r.conditionMet && r.condition);
 
   for (const r of results) {
     if (r.isDefault) {


### PR DESCRIPTION
## Summary

Round 2 of the engine dedup pass. Four small refactors, one bundle.

- **#194** — `evaluateTransitions` drops the O(n²) `Array.find` re-lookup of `node.edges` to recheck `condition`. The value is already projected on each result row by the `map` immediately above. One-token change. Per-`advance`/`inspect` win.
- **#193** — `returns.ts` extracts `validateField(key, field, value)` for the per-key type + array-items walk that was byte-identical across `required` and `optional` branches. ~14 → 4 lines of duplication.
- **#195** — `helpers.ts` gains `buildAdvanceSnapshot` — the single source for the `{currentNode, validTransitions, context | contextDelta}` bundle skills read on every advance failure. `makeAdvanceError` (gates.ts) and `captureHookFailureEnvelope` (engine.ts) both route through it so a future field on the recover-or-stop bundle lands on both gate-block and hook-throw paths. The thin `buildAdvanceErrorResult` indirection was the only consumer of `BaseAdvanceErrorFields` / `AdvanceErrorResponseMode`; all three deleted, gates.ts builds the error envelope inline.
- **#196** — `builtin-hooks.ts` collapses `optionalString` / `optionalInt` / `optionalBool` / `optionalShape` / `requireString` into `optional<T>` / `required<T>` factories parameterized on a type guard + description string. Five inline guards form a small lookup table. `requireStringArray` stays bespoke — element-level walks aren't captured by a single guard.

Net: -10 lines across 6 files, but the real point is collapsing the drift surfaces.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 828 passed, 2 todo, 43 files
- [x] `/simplify` (3 reviewers in parallel) — clean. Quality reviewer flagged the `{ full: true }` discriminator tag on `AdvanceSnapshotMode` as marginally redundant; kept for symmetry with the existing `AdvanceResponseMode` shape and explicit type-level intent.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)