### PR TITLE
refactor(cli): drop CliExit refusals, share enumArg, fix N+1 inspect (#199 #201 #202)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -13,7 +13,9 @@ import { EC, EngineError } from "../errors.js";
 import { EmitBatchSchema } from "../memory/emit-schema.js";
 import type { MemoryStore } from "../memory/index.js";
 import type { PropositionShape } from "../memory/types.js";
-import { CliExit, EXIT, errorEnvelope, outputJson, parseIntArg } from "./output.js";
+import { CliExit, EXIT, enumArg, errorEnvelope, outputJson, parseIntArg } from "./output.js";
+
+const SHAPES = ["minimal", "full"] as const satisfies readonly PropositionShape[];
 
 export function memoryStatus(store: MemoryStore): void {
   outputJson(store.status());
@@ -48,7 +50,7 @@ export function memoryInspect(
     store.inspect(entity, {
       limit: parseIntArg(opts?.limit, "--limit"),
       offset: parseIntArg(opts?.offset, "--offset"),
-      shape: parseShape(opts?.shape),
+      shape: enumArg(opts?.shape, SHAPES, "--shape"),
     }),
   );
 }
@@ -83,18 +85,10 @@ export function memoryBySource(
     store.bySource(filePath, {
       limit: parseIntArg(opts?.limit, "--limit"),
       offset: parseIntArg(opts?.offset, "--offset"),
-      shape: parseShape(opts?.shape),
+      shape: enumArg(opts?.shape, SHAPES, "--shape"),
       includeOrphans: opts?.includeOrphans,
     }),
   );
-}
-
-// Unknown --shape values throw a caller-fixable error rather than
-// silently falling back to default — catches typos at the CLI boundary.
-function parseShape(raw: string | undefined): PropositionShape | undefined {
-  if (raw === undefined) return undefined;
-  if (raw === "minimal" || raw === "full") return raw;
-  throw new EngineError(`--shape must be "minimal" or "full"; got "${raw}".`, EC.INVALID_SHAPE);
 }
 
 export function memoryEmit(store: MemoryStore, file: string): void {
@@ -167,15 +161,10 @@ export function memoryPrune(
  */
 export function memoryReset(dbPath: string, opts: { confirm?: boolean }): void {
   if (!opts.confirm) {
-    throw new CliExit(
-      {
-        ...errorEnvelope(
-          EC.CONFIRM_REQUIRED,
-          "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
-        ),
-        commandName: "memory reset",
-      },
-      EXIT.INVALID_INPUT,
+    throw new EngineError(
+      "memory reset requires --confirm (destructive: deletes memory.db + sidecars).",
+      EC.CONFIRM_REQUIRED,
+      { envelopeSlots: { commandName: "memory reset" } },
     );
   }
   const targets = [dbPath, `${dbPath}-shm`, `${dbPath}-wal`];

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -28,6 +28,28 @@ export function parseIntArg(raw: string | undefined, flag: string): number | und
 }
 
 /**
+ * Shared primitive for CLI enum flags. Validates `raw` against `choices`
+ * and throws `INVALID_FLAG_VALUE` on miss so a typo fails loudly at the
+ * CLI boundary instead of silently falling back to a default. Used at
+ * sites where commander's built-in `.choices()` doesn't apply — flags
+ * with a custom `argParser` (e.g. accumulators) or values plumbed
+ * through helper code before the option is constructed. Same exit code
+ * and undefined-on-empty handling as `parseIntArg`.
+ */
+export function enumArg<T extends string>(
+  raw: string | undefined,
+  choices: readonly T[],
+  flag: string,
+): T | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  if ((choices as readonly string[]).includes(raw)) return raw as T;
+  throw new EngineError(
+    `${flag} must be one of ${choices.join(", ")}; got "${raw}".`,
+    EC.INVALID_FLAG_VALUE,
+  );
+}
+
+/**
  * Shared primitive for CLI flags that accept `key=value` pairs. Splits on
  * the first `=`, validates a non-empty key, and throws with a consistent
  * error message across `--meta`, `--filter`, and `context set`. Callers

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -7,7 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { Command, Option } from "commander";
-import { EC, EngineError } from "../errors.js";
+import { EC } from "../errors.js";
 import { INSPECT_FIELDS } from "../types.js";
 import { VERSION } from "../version.js";
 import { catalog } from "./catalog.js";
@@ -23,7 +23,15 @@ import {
   memorySearch,
   memoryStatus,
 } from "./memory.js";
-import { EXIT, fatal, outputJson, runCliHandler, runCliHandlerAsync, setCli } from "./output.js";
+import {
+  EXIT,
+  enumArg,
+  fatal,
+  outputJson,
+  runCliHandler,
+  runCliHandlerAsync,
+  setCli,
+} from "./output.js";
 import {
   createMemoryStore,
   createTraversalStore,
@@ -260,16 +268,11 @@ addWorkflowsOpt(
       "--fields <name>",
       `Additive projections (repeatable; choices: ${INSPECT_FIELDS.join(", ")}). Works with --detail position or history.`,
       (value: string, previous?: string[]) => {
-        // Validate here — commander's .choices() is bypassed by a custom
-        // argParser, so enum validation has to live alongside the
-        // accumulator. INVALID_FLAG_VALUE keeps this on the same exit
-        // path as --limit/--offset typos.
-        if (!(INSPECT_FIELDS as readonly string[]).includes(value)) {
-          throw new EngineError(
-            `--fields must be one of ${INSPECT_FIELDS.join(", ")}; got "${value}".`,
-            EC.INVALID_FLAG_VALUE,
-          );
-        }
+        // commander's `.choices()` is bypassed by a custom argParser;
+        // call enumArg for the throw-on-invalid side effect (the
+        // coerced return is unused — the accumulator stores the raw
+        // string).
+        enumArg(value, INSPECT_FIELDS, "--fields");
         return previous ? [...previous, value] : [value];
       },
     )

--- a/src/cli/traversals.ts
+++ b/src/cli/traversals.ts
@@ -14,7 +14,7 @@ import type { InspectHistoryOptions } from "../engine/context.js";
 import { EC, EngineError } from "../errors.js";
 import type { TraversalStore } from "../state/index.js";
 import type { InspectField, InspectPositionResult } from "../types.js";
-import { CliExit, EXIT, errorEnvelope, outputJson, parseIntArg, splitKeyValue } from "./output.js";
+import { CliExit, EXIT, outputJson, parseIntArg, splitKeyValue } from "./output.js";
 
 // Shared by `start` and `advance` for their `--context` JSON payload.
 function parseContextJson(raw: string): Record<string, unknown> {
@@ -197,27 +197,7 @@ export function traversalInspectActive(
   store: TraversalStore,
   opts?: { waitsOnly?: boolean },
 ): void {
-  const infos = store.listTraversals();
-  const entries: Array<Record<string, unknown>> = [];
-  for (const t of infos) {
-    const raw = store.inspect(t.traversalId, "position");
-    const pos = raw as { traversalId: string } & InspectPositionResult;
-    if (opts?.waitsOnly && pos.node.type !== "wait") continue;
-    entries.push({
-      traversalId: t.traversalId,
-      graphId: t.graphId,
-      currentNode: t.currentNode,
-      nodeType: pos.node.type,
-      description: pos.node.description ?? "",
-      lastUpdated: t.lastUpdated,
-      stackDepth: t.stackDepth,
-      ...(pos.waitStatus ? { waitStatus: pos.waitStatus } : {}),
-      ...(pos.waitingOn ? { waitingOn: pos.waitingOn } : {}),
-      ...(pos.timeout ? { timeout: pos.timeout } : {}),
-      ...(pos.timeoutAt ? { timeoutAt: pos.timeoutAt } : {}),
-    });
-  }
-  outputJson({ traversals: entries });
+  outputJson({ traversals: store.inspectActive(opts) });
 }
 
 export function traversalReset(
@@ -226,18 +206,9 @@ export function traversalReset(
   opts?: { confirm?: boolean },
 ): void {
   if (!opts?.confirm) {
-    // Main's envelope carries `commandName: "reset"` so the `{commandName}`
-    // slot in RECOVERY[CONFIRM_REQUIRED].verb renders correctly. Throw a
-    // CliExit instead of `outputJson + process.exit` so the wrapper
-    // closes the runtime before exit (#153 bug fixed the same way for
-    // memory-prune refusal).
-    throw new CliExit(
-      {
-        ...errorEnvelope(EC.CONFIRM_REQUIRED, "must pass --confirm to reset a traversal."),
-        commandName: "reset",
-      },
-      EXIT.INVALID_INPUT,
-    );
+    throw new EngineError("must pass --confirm to reset a traversal.", EC.CONFIRM_REQUIRED, {
+      envelopeSlots: { commandName: "reset" },
+    });
   }
   const id = store.resolveTraversalId(traversalId);
   const result = store.resetTraversal(id);

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -63,7 +63,6 @@ export const ENGINE_ERROR_CODES = {
     "INVALID_EMIT_JSON",
     "INVALID_EMIT_SHAPE",
     "INVALID_META",
-    "INVALID_SHAPE",
     "INVALID_FLAG_VALUE",
   ],
   BLOCKED: ["NO_EDGES", "STACK_DEPTH_EXCEEDED", "DATABASE_BUSY", ...GATE_BLOCK_CODES],
@@ -184,7 +183,6 @@ export const EC = {
   INVALID_EMIT_JSON: "INVALID_EMIT_JSON",
   INVALID_EMIT_SHAPE: "INVALID_EMIT_SHAPE",
   INVALID_META: "INVALID_META",
-  INVALID_SHAPE: "INVALID_SHAPE",
   INVALID_FLAG_VALUE: "INVALID_FLAG_VALUE",
   NO_EDGES: "NO_EDGES",
   STACK_DEPTH_EXCEEDED: "STACK_DEPTH_EXCEEDED",
@@ -322,7 +320,6 @@ export const RECOVERY = {
   INVALID_EMIT_JSON: { verb: "memory emit", kind: "fix-context" },
   INVALID_EMIT_SHAPE: { verb: "memory emit", kind: "fix-context" },
   INVALID_META: { verb: "advance", kind: "fix-context" },
-  INVALID_SHAPE: { verb: "advance", kind: "fix-context" },
   INVALID_FLAG_VALUE: { verb: null, kind: "fix-context" },
 
   // BLOCKED — traversal state fine, fix context and re-advance

--- a/src/state/traversal-store.ts
+++ b/src/state/traversal-store.ts
@@ -10,12 +10,14 @@ import type { HookRunner } from "../engine/hooks.js";
 import { GraphEngine } from "../engine/index.js";
 import { EC, EngineError } from "../errors.js";
 import type {
+  ActiveTraversalEntry,
   AdvanceMinimalResult,
   AdvanceResult,
   ContextSetMinimalResult,
   ContextSetResult,
   InspectField,
   InspectMinimalResult,
+  InspectPositionResult,
   InspectResult,
   LoadError,
   ResetResult,
@@ -348,6 +350,47 @@ export class TraversalStore {
       options?.responseMode ? { responseMode: options.responseMode } : undefined,
     );
     return { traversalId, meta: record.meta ?? EMPTY_META, ...result };
+  }
+
+  /**
+   * Walk records once, hydrate each engine in place, and project the
+   * fields the `--active` listing surfaces. Avoids the N+1 disk read of
+   * `listTraversals()` followed by per-id `inspect()` (each `inspect`
+   * re-hits `state.get(id)` for a record `state.list()` already
+   * returned). Throws `TRAVERSAL_ORPHANED` on the first record whose
+   * graph isn't loaded — same shape as `loadEngine`.
+   */
+  inspectActive(opts?: { waitsOnly?: boolean }): readonly ActiveTraversalEntry[] {
+    const records = this.state.list();
+    const entries: ActiveTraversalEntry[] = [];
+    for (const record of records) {
+      if (!this.graphs.has(record.graphId)) {
+        throw new EngineError(
+          `Graph "${record.graphId}" not found. Traversal "${record.id}" is orphaned — ` +
+            `its workflow yaml is missing, renamed, or failed to parse.`,
+          EC.TRAVERSAL_ORPHANED,
+          { envelopeSlots: { traversalId: record.id } },
+        );
+      }
+      const engine = this.newEngine();
+      engine.restoreStack(record.stack);
+      const pos = engine.inspect("position") as InspectPositionResult;
+      if (opts?.waitsOnly && pos.node.type !== "wait") continue;
+      entries.push({
+        traversalId: record.id,
+        graphId: record.graphId,
+        currentNode: record.currentNode,
+        nodeType: pos.node.type,
+        description: pos.node.description ?? "",
+        lastUpdated: record.updatedAt,
+        stackDepth: record.stackDepth,
+        ...(pos.waitStatus !== undefined && { waitStatus: pos.waitStatus }),
+        ...(pos.waitingOn !== undefined && { waitingOn: pos.waitingOn }),
+        ...(pos.timeout !== undefined && { timeout: pos.timeout }),
+        ...(pos.timeoutAt !== undefined && { timeoutAt: pos.timeoutAt }),
+      });
+    }
+    return entries;
   }
 
   resetTraversal(traversalId: string): { traversalId: string } & ResetResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -398,3 +398,23 @@ export interface TraversalListResult {
    */
   readonly orphanedTraversals?: readonly TraversalInfo[];
 }
+
+/**
+ * One entry returned by `TraversalStore.inspectActive` — a `TraversalInfo`
+ * augmented with the current node's `type` + `description` and any live
+ * wait state. Plugin hooks consume this to nudge the agent at wait
+ * nodes; surfaces `waitStatus` for "should I poll again?".
+ */
+export interface ActiveTraversalEntry {
+  readonly traversalId: string;
+  readonly graphId: string;
+  readonly currentNode: string;
+  readonly nodeType: NodeDefinition["type"];
+  readonly description: string;
+  readonly lastUpdated: string;
+  readonly stackDepth: number;
+  readonly waitStatus?: "waiting" | "ready" | "timed_out";
+  readonly waitingOn?: readonly WaitCondition[];
+  readonly timeout?: string;
+  readonly timeoutAt?: string;
+}


### PR DESCRIPTION
## Summary

Three CLI-side cleanups bundled. All from 2026-04-27.

- **#201** — `traversalReset` and `memoryReset` switch from `CliExit` to `EngineError` + `envelopeSlots`. `CliExit` is documented as the dual-payload escape hatch (a structured payload *plus* an error envelope); single-envelope refusals route through `outputError`, which already spreads `envelopeSlots` at the envelope root. Same wire shape, narrower `CliExit` surface — only `memoryPrune`'s plan-plus-refusal still needs it.
- **#199** — `enumArg<T>(raw, choices, flag)` joins `splitKeyValue` and `parseIntArg` in `cli/output.ts` as a shared CLI primitive. Replaces bespoke `parseShape` in `memory.ts` and the inline `--fields` argParser validator in `program.ts`. `INVALID_SHAPE` folded into `INVALID_FLAG_VALUE` — the catalog doesn't need per-enum codes when one helper covers every enum-flag typo. Catalog drop is the only externally-visible change; no tests pin `INVALID_SHAPE`.
- **#202** — `TraversalStore.inspectActive` walks `state.list()` once and hydrates each engine in place. The CLI handler previously did N+1 disk reads: `listTraversals` (→ `state.list`) followed by per-id `inspect` (→ `state.get` re-reading the same record). Halves the I/O on `freelance inspect --active`. New `ActiveTraversalEntry` type pins the projection shape. CLI handler shrinks to one line.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 828 passed, 2 todo, 43 files
- [x] `/simplify` (3 reviewers) — clean. Applied two minor follow-ups: `enumArg` matches `parseIntArg`'s undefined-on-empty handling, and the `--fields` argParser comment now explains why the `enumArg` return value is discarded.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)