### PR TITLE
docs(security): drop stale MCP/stdio scope, document CLI-only posture

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,11 +8,14 @@ Use GitHub's [private security advisory](https://github.com/duct-tape-and-markdo
 
 ## Scope
 
+`freelance-mcp` is a CLI-only package. There is no long-running server and no MCP/stdio transport — that surface was removed in #121 (see `docs/decisions.md` § "MCP server and tool surface deleted"). The npm package name is historical; the binary is `freelance`.
+
 In scope:
 
 - The `freelance-mcp` npm package and its published binaries
-- The MCP server (stdio transport) and its tool surface
+- The `freelance` CLI verbs and their JSON wire format
 - Graph loading, expression evaluation, and source-binding validation
+- `onEnter` hook resolution and execution (path restrictions, the `FREELANCE_HOOKS_ALLOW_SCRIPTS` trust gate)
 - The SQLite memory store and its FTS5 query surface
 - Claude Code plugin artifacts under `plugins/freelance/`
 
@@ -20,6 +23,7 @@ Out of scope:
 
 - Issues in dependencies — please report those upstream
 - Abuse of features working as designed (e.g., an agent choosing to emit harmful propositions into memory — that's a workflow-design question, not a vulnerability in this package)
+- Author-controlled hook scripts running with full Node privileges — this is the documented trust model (see README "Trust model for hook scripts"); deployments that can't vet workflow authors set `FREELANCE_HOOKS_ALLOW_SCRIPTS=0`
 - Social engineering of maintainers
 
 ## Supported versions


### PR DESCRIPTION
Reporters chasing the OX Security MCP-stdio vulnerability class
(VentureBeat 2026-04 / OX Security advisory) hit a dead link: the
SECURITY.md scope listed "The MCP server (stdio transport) and its tool
surface" as in-scope, but that surface was deleted in #121. Replace with
the actual surfaces (CLI verbs, onEnter hook resolution + trust gate)
and add a one-line note up front explaining the missing transport so the
package's name doesn't mislead.

https://claude.ai/code/session_01Q8iXpG5XLQFMuwfpWjbqCf