### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 + add types: ["node"] to tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@vitest/coverage-v8": "^4.1.0",
         "simple-git-hooks": "2.13.1",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.0"
       },
       "engines": {
@@ -3099,10 +3099,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@vitest/coverage-v8": "^4.1.0",
     "simple-git-hooks": "2.13.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]


### PR DESCRIPTION
Supersedes #175 — that PR carries the dep bump alone, which fails CI on this codebase precisely because of the auto-types change below.

## Root cause

TypeScript 6.0 no longer auto-includes `@types/*` packages in the implicit types scope when `compilerOptions.types` is unset. Without `"types": ["node"]`, every `node:fs`/`node:path`/`process`/`Buffer`/`NodeJS.*` reference fails with `TS2591: Cannot find name` (~110 errors across `src/`). Zero are real diagnostics — purely a tsconfig surface change.

## Fix

- Bump `typescript` 5.9.3 → 6.0.3 in `package.json` + `package-lock.json` (same as #175)
- Add `"types": ["node"]` to `compilerOptions` in `tsconfig.json`

Listing `node` explicitly is forward- and backward-compatible: it's a no-op under TS 5.x (where it was implicitly included), and it's the required form under TS 6.x.

## Local verification

- `npm run build` — clean
- `npm test` — 42 files, 819 passed | 2 todo
- `npx biome check` — clean (pre-existing schema-version info notice unrelated)

## Plan

Once CI is green, merge and close #175 (dependabot's own branch can't be cleanly fixed in place since the dep bump and tsconfig change must land together).


---
_Generated by [Claude Code](https://claude.ai/code/session_014bmAkFQa11DLaf86Gy56CT)_